### PR TITLE
Fix datagrid render issue with incomplete data

### DIFF
--- a/src/store/mcode.js
+++ b/src/store/mcode.js
@@ -176,7 +176,7 @@ export const medicationStatementColumns = [
 export const processMCodeMainData = (dataObject) => {
     const row = {};
 
-    row.id = dataObject.id;
+    row.id = dataObject.id || null;
     row.sex = dataObject.subject.sex || 'NA';
     row.ethnicity = dataObject.subject.ethnicity || 'NA';
     row.date_of_birth = dataObject.subject.date_of_birth || 'NA';
@@ -195,7 +195,7 @@ export const processMCodeMainData = (dataObject) => {
  */
 export const processSubjectData = (dataObject) => {
     const row = {};
-    row.id = dataObject.id;
+    row.id = dataObject.id || null;
     row.sex = dataObject.subject.sex || 'NA';
     row.date_of_birth = dataObject.subject.date_of_birth || 'NA';
     row.date_of_death = dataObject.date_of_death || 'NA';
@@ -217,13 +217,15 @@ export const processConditionsData = (dataObject) => {
     // eslint-disable-next-line camelcase
     dataObject.cancer_condition.forEach((cancer_condition) => {
         const row = {};
-        row.id = cancer_condition.id;
-        row.condition_type = cancer_condition.condition_type || 'NA';
-        row.code_id = cancer_condition.code.id || 'NA';
-        row.code_label = cancer_condition.code.label || 'NA';
-        row.date_of_diagnosis = cancer_condition.date_of_diagnosis || 'NA';
+        row.id = cancer_condition.id || null;
+        if (row.id !== null) {
+            row.condition_type = cancer_condition.condition_type || 'NA';
+            row.code_id = cancer_condition.code.id || 'NA';
+            row.code_label = cancer_condition.code.label || 'NA';
+            row.date_of_diagnosis = cancer_condition.date_of_diagnosis || 'NA';
 
-        rows.push(row);
+            rows.push(row);
+        }
     });
 
     return rows;
@@ -240,14 +242,16 @@ export const processProceduresData = (dataObject) => {
     // eslint-disable-next-line camelcase
     dataObject.cancer_related_procedures.forEach((cancer_related_procedure) => {
         const row = {};
-        row.id = cancer_related_procedure.id;
-        row.procedure_type = cancer_related_procedure.procedure_type || 'NA';
-        row.procedure_code_id = cancer_related_procedure.code.id || 'NA';
-        row.procedure_code_label = cancer_related_procedure.code.label || 'NA';
-        row.body_site_id = cancer_related_procedure.body_site.id || 'NA';
-        row.body_site_label = cancer_related_procedure.body_site.label || 'NA';
+        row.id = cancer_related_procedure.id || null;
+        if (row.id !== null) {
+            row.procedure_type = cancer_related_procedure.procedure_type || 'NA';
+            row.procedure_code_id = cancer_related_procedure.code.id || 'NA';
+            row.procedure_code_label = cancer_related_procedure.code.label || 'NA';
+            row.body_site_id = cancer_related_procedure.body_site.id || 'NA';
+            row.body_site_label = cancer_related_procedure.body_site.label || 'NA';
 
-        rows.push(row);
+            rows.push(row);
+        }
     });
 
     return rows;
@@ -264,11 +268,13 @@ export const processMedicationStatementData = (dataObject) => {
     // eslint-disable-next-line camelcase
     dataObject.medication_statement.forEach((medication_statement) => {
         const row = {};
-        row.id = medication_statement.id;
-        row.medication_code_id = medication_statement.medication_code.id || 'NA';
-        row.medication_code_label = medication_statement.medication_code.label || 'NA';
+        row.id = medication_statement.id || null;
+        if (row.id !== null) {
+            row.medication_code_id = medication_statement.medication_code.id || 'NA';
+            row.medication_code_label = medication_statement.medication_code.label || 'NA';
 
-        rows.push(row);
+            rows.push(row);
+        }
     });
 
     return rows;

--- a/src/store/mcode.js
+++ b/src/store/mcode.js
@@ -181,7 +181,6 @@ export const processMCodeMainData = (dataObject) => {
     row.ethnicity = dataObject.subject.ethnicity || 'NA';
     row.date_of_birth = dataObject.subject.date_of_birth || 'NA';
     row.date_of_death = dataObject.date_of_death || 'NA';
-    row.ethnicity = dataObject.subject.ethnicity || 'NA';
     row.race = dataObject.subject.race || 'NA';
     row.communication_language = dataObject.subject.extra_properties.communication_language || 'NA';
 

--- a/src/store/mcode.js
+++ b/src/store/mcode.js
@@ -177,13 +177,13 @@ export const processMCodeMainData = (dataObject) => {
     const row = {};
 
     row.id = dataObject.id;
-    row.sex = dataObject.subject.sex;
-    row.ethnicity = dataObject.subject.ethnicity;
-    row.date_of_birth = dataObject.subject.date_of_birth;
-    row.date_of_death = dataObject.date_of_death;
-    row.ethnicity = dataObject.subject.ethnicity;
-    row.race = dataObject.subject.race;
-    row.communication_language = dataObject.subject.extra_properties.communication_language;
+    row.sex = dataObject.subject.sex || 'NA';
+    row.ethnicity = dataObject.subject.ethnicity || 'NA';
+    row.date_of_birth = dataObject.subject.date_of_birth || 'NA';
+    row.date_of_death = dataObject.date_of_death || 'NA';
+    row.ethnicity = dataObject.subject.ethnicity || 'NA';
+    row.race = dataObject.subject.race || 'NA';
+    row.communication_language = dataObject.subject.extra_properties.communication_language || 'NA';
 
     return row;
 };
@@ -196,12 +196,12 @@ export const processMCodeMainData = (dataObject) => {
 export const processSubjectData = (dataObject) => {
     const row = {};
     row.id = dataObject.id;
-    row.sex = dataObject.subject.sex;
-    row.date_of_birth = dataObject.subject.date_of_birth;
-    row.date_of_death = dataObject.date_of_death;
-    row.ethnicity = dataObject.subject.ethnicity;
-    row.race = dataObject.subject.race;
-    row.communication_language = dataObject.subject.extra_properties.communication_language;
+    row.sex = dataObject.subject.sex || 'NA';
+    row.date_of_birth = dataObject.subject.date_of_birth || 'NA';
+    row.date_of_death = dataObject.date_of_death || 'NA';
+    row.ethnicity = dataObject.subject.ethnicity || 'NA';
+    row.race = dataObject.subject.race || 'NA';
+    row.communication_language = dataObject.subject.extra_properties.communication_language || 'NA';
 
     return [row];
 };
@@ -218,10 +218,10 @@ export const processConditionsData = (dataObject) => {
     dataObject.cancer_condition.forEach((cancer_condition) => {
         const row = {};
         row.id = cancer_condition.id;
-        row.condition_type = cancer_condition.condition_type;
-        row.code_id = cancer_condition.code.id;
-        row.code_label = cancer_condition.code.label;
-        row.date_of_diagnosis = cancer_condition.date_of_diagnosis;
+        row.condition_type = cancer_condition.condition_type || 'NA';
+        row.code_id = cancer_condition.code.id || 'NA';
+        row.code_label = cancer_condition.code.label || 'NA';
+        row.date_of_diagnosis = cancer_condition.date_of_diagnosis || 'NA';
 
         rows.push(row);
     });
@@ -241,11 +241,11 @@ export const processProceduresData = (dataObject) => {
     dataObject.cancer_related_procedures.forEach((cancer_related_procedure) => {
         const row = {};
         row.id = cancer_related_procedure.id;
-        row.procedure_type = cancer_related_procedure.procedure_type;
-        row.procedure_code_id = cancer_related_procedure.code.id;
-        row.procedure_code_label = cancer_related_procedure.code.label;
-        row.body_site_id = cancer_related_procedure.body_site.id;
-        row.body_site_label = cancer_related_procedure.body_site.label;
+        row.procedure_type = cancer_related_procedure.procedure_type || 'NA';
+        row.procedure_code_id = cancer_related_procedure.code.id || 'NA';
+        row.procedure_code_label = cancer_related_procedure.code.label || 'NA';
+        row.body_site_id = cancer_related_procedure.body_site.id || 'NA';
+        row.body_site_label = cancer_related_procedure.body_site.label || 'NA';
 
         rows.push(row);
     });
@@ -265,8 +265,8 @@ export const processMedicationStatementData = (dataObject) => {
     dataObject.medication_statement.forEach((medication_statement) => {
         const row = {};
         row.id = medication_statement.id;
-        row.medication_code_id = medication_statement.medication_code.id;
-        row.medication_code_label = medication_statement.medication_code.label;
+        row.medication_code_id = medication_statement.medication_code.id || 'NA';
+        row.medication_code_label = medication_statement.medication_code.label || 'NA';
 
         rows.push(row);
     });
@@ -323,7 +323,7 @@ export const processProceduresListData = (dataObject) => {
         patient.cancer_related_procedures.forEach((procedure) => {
             const key = procedure.code.id;
             if (!(key in list)) {
-                list[key] = procedure.procedure_type;
+                list[key] = procedure.procedure_typeo;
             }
         });
     });

--- a/src/store/mcode.js
+++ b/src/store/mcode.js
@@ -329,7 +329,7 @@ export const processProceduresListData = (dataObject) => {
         patient.cancer_related_procedures.forEach((procedure) => {
             const key = procedure.code.id;
             if (!(key in list)) {
-                list[key] = procedure.procedure_typeo;
+                list[key] = procedure.procedure_type;
             }
         });
     });

--- a/src/store/phenopackets.js
+++ b/src/store/phenopackets.js
@@ -255,7 +255,7 @@ export const resourcesColumns = [
  */
 export const processPhenopacketMainData = (dataObject) => {
     const row = {};
-    row.id = dataObject.id;
+    row.id = dataObject.id || null;
     row.ethnicity = dataObject.subject.ethnicity || 'NA';
     row.sex = dataObject.subject.sex || 'NA';
     row.height = dataObject.subject.extra_properties.height || 'NA';
@@ -290,13 +290,15 @@ export const processPhenotypicFeaturesData = (dataObject) => {
     dataObject.phenotypic_features.forEach((phenotypic_features) => {
         const row = {};
 
-        row.id = phenotypic_features.type.id;
-        row.label = phenotypic_features.type.label || 'NA';
-        row.description = phenotypic_features.description || 'NA';
-        row.negated = phenotypic_features.negated || 'NA';
-        row.datatype = phenotypic_features.extra_properties.datatype || 'NA';
+        row.id = phenotypic_features.type.id || null;
+        if (row.id !== null) {
+            row.label = phenotypic_features.type.label || 'NA';
+            row.description = phenotypic_features.description || 'NA';
+            row.negated = phenotypic_features.negated || 'NA';
+            row.datatype = phenotypic_features.extra_properties.datatype || 'NA';
 
-        rows.push(row);
+            rows.push(row);
+        }
     });
 
     return rows;
@@ -313,12 +315,14 @@ export const processDiseaseData = (dataObject) => {
     dataObject.diseases.forEach((diseases) => {
         const row = {};
 
-        row.id = diseases.id;
-        row.label = diseases.term.label || 'NA';
-        row.datatype = diseases.extra_properties.datatype || 'NA';
-        row.comorbidities_group = diseases.extra_properties.comorbidities_group || 'NA';
-        row.created = diseases.created || 'NA';
-        row.updated = diseases.updated || 'NA';
+        row.id = diseases.id || null;
+        if (row.id !== null) {
+            row.label = diseases.term.label || 'NA';
+            row.datatype = diseases.extra_properties.datatype || 'NA';
+            row.comorbidities_group = diseases.extra_properties.comorbidities_group || 'NA';
+            row.created = diseases.created || 'NA';
+            row.updated = diseases.updated || 'NA';
+        }
 
         rows.push(row);
     });
@@ -337,14 +341,16 @@ export const processResourcesData = (dataObject) => {
     dataObject.meta_data.resources.forEach((resources) => {
         const row = {};
 
-        row.id = resources.id;
-        row.name = resources.name || 'NA';
-        row.namespace_prefix = resources.namespace_prefix || 'NA';
-        row.url = resources.url || 'NA';
-        row.version = resources.version || 'NA';
-        row.iri_prefix = resources.iri_prefix || 'NA';
-        row.created = resources.created || 'NA';
-        row.updated = resources.updated || 'NA';
+        row.id = resources.id || null;
+        if (row.id !== null) {
+            row.name = resources.name || 'NA';
+            row.namespace_prefix = resources.namespace_prefix || 'NA';
+            row.url = resources.url || 'NA';
+            row.version = resources.version || 'NA';
+            row.iri_prefix = resources.iri_prefix || 'NA';
+            row.created = resources.created || 'NA';
+            row.updated = resources.updated || 'NA';
+        }
 
         rows.push(row);
     });

--- a/src/store/phenopackets.js
+++ b/src/store/phenopackets.js
@@ -256,25 +256,25 @@ export const resourcesColumns = [
 export const processPhenopacketMainData = (dataObject) => {
     const row = {};
     row.id = dataObject.id;
-    row.ethnicity = dataObject.subject.ethnicity;
-    row.sex = dataObject.subject.sex;
-    row.height = dataObject.subject.extra_properties.height;
-    row.weight = dataObject.subject.extra_properties.weight;
-    row.abo_type = dataObject.subject.extra_properties.abo_type;
-    row.education = dataObject.subject.extra_properties.education;
-    row.household = dataObject.subject.extra_properties.household;
-    row.pregnancy = dataObject.subject.extra_properties.pregnancy;
-    row.employment = dataObject.subject.extra_properties.employment;
-    row.asymptomatic = dataObject.subject.extra_properties.asymptomatic;
-    row.covid19_test = dataObject.subject.extra_properties.covid19_test;
-    row.hospitalized = dataObject.subject.extra_properties.hospitalized;
-    row.birth_country = dataObject.subject.extra_properties.birth_country;
-    row.host_hospital = dataObject.subject.extra_properties.host_hospital;
-    row.residence_type = dataObject.subject.extra_properties.residence_type;
-    row.enrollment_date = dataObject.subject.extra_properties.enrollment_date;
-    row.covid19_test_date = dataObject.subject.extra_properties.covid19_test_date;
-    row.covid19_diagnosis_date = dataObject.subject.extra_properties.covid19_diagnosis_date;
-    row.date_of_birth = dataObject.subject.date_of_birth;
+    row.ethnicity = dataObject.subject.ethnicity || 'NA';
+    row.sex = dataObject.subject.sex || 'NA';
+    row.height = dataObject.subject.extra_properties.height || 'NA';
+    row.weight = dataObject.subject.extra_properties.weight || 'NA';
+    row.abo_type = dataObject.subject.extra_properties.abo_type || 'NA';
+    row.education = dataObject.subject.extra_properties.education || 'NA';
+    row.household = dataObject.subject.extra_properties.household || 'NA';
+    row.pregnancy = dataObject.subject.extra_properties.pregnancy || 'NA';
+    row.employment = dataObject.subject.extra_properties.employment || 'NA';
+    row.asymptomatic = dataObject.subject.extra_properties.asymptomatic || 'NA';
+    row.covid19_test = dataObject.subject.extra_properties.covid19_test || 'NA';
+    row.hospitalized = dataObject.subject.extra_properties.hospitalized || 'NA';
+    row.birth_country = dataObject.subject.extra_properties.birth_country || 'NA';
+    row.host_hospital = dataObject.subject.extra_properties.host_hospital || 'NA';
+    row.residence_type = dataObject.subject.extra_properties.residence_type || 'NA';
+    row.enrollment_date = dataObject.subject.extra_properties.enrollment_date || 'NA';
+    row.covid19_test_date = dataObject.subject.extra_properties.covid19_test_date || 'NA';
+    row.covid19_diagnosis_date = dataObject.subject.extra_properties.covid19_diagnosis_date || 'NA';
+    row.date_of_birth = dataObject.subject.date_of_birth || 'NA';
 
     return row;
 };
@@ -291,10 +291,10 @@ export const processPhenotypicFeaturesData = (dataObject) => {
         const row = {};
 
         row.id = phenotypic_features.type.id;
-        row.label = phenotypic_features.type.label;
-        row.description = phenotypic_features.description;
-        row.negated = phenotypic_features.negated;
-        row.datatype = phenotypic_features.extra_properties.datatype;
+        row.label = phenotypic_features.type.label || 'NA';
+        row.description = phenotypic_features.description || 'NA';
+        row.negated = phenotypic_features.negated || 'NA';
+        row.datatype = phenotypic_features.extra_properties.datatype || 'NA';
 
         rows.push(row);
     });
@@ -314,11 +314,11 @@ export const processDiseaseData = (dataObject) => {
         const row = {};
 
         row.id = diseases.id;
-        row.label = diseases.term.label;
-        row.datatype = diseases.extra_properties.datatype;
-        row.comorbidities_group = diseases.extra_properties.comorbidities_group;
-        row.created = diseases.created;
-        row.updated = diseases.updated;
+        row.label = diseases.term.label || 'NA';
+        row.datatype = diseases.extra_properties.datatype || 'NA';
+        row.comorbidities_group = diseases.extra_properties.comorbidities_group || 'NA';
+        row.created = diseases.created || 'NA';
+        row.updated = diseases.updated || 'NA';
 
         rows.push(row);
     });
@@ -338,13 +338,13 @@ export const processResourcesData = (dataObject) => {
         const row = {};
 
         row.id = resources.id;
-        row.name = resources.name;
-        row.namespace_prefix = resources.namespace_prefix;
-        row.url = resources.url;
-        row.version = resources.version;
-        row.iri_prefix = resources.iri_prefix;
-        row.created = resources.created;
-        row.updated = resources.updated;
+        row.name = resources.name || 'NA';
+        row.namespace_prefix = resources.namespace_prefix || 'NA';
+        row.url = resources.url || 'NA';
+        row.version = resources.version || 'NA';
+        row.iri_prefix = resources.iri_prefix || 'NA';
+        row.created = resources.created || 'NA';
+        row.updated = resources.updated || 'NA';
 
         rows.push(row);
     });

--- a/src/views/clinical/mcode.js
+++ b/src/views/clinical/mcode.js
@@ -99,6 +99,7 @@ function MCodeView() {
     // Subtable selection of patient
     const handleRowClick = (row) => {
         const index = mcodeData.results.findIndex((item) => item.id === row.id);
+
         setSelectedPatient(mcodeData.results[index].id);
         setSelectedPatientMobileInfo({
             Ethnicity: mcodeData.results[index].subject.ethnicity,
@@ -138,7 +139,9 @@ function MCodeView() {
                     // Patient table filtering
                     if (selectedConditions === 'All' && selectedProcedures === 'All' && selectedMedications === 'All') {
                         // All patients
-                        tempRows.push(processMCodeMainData(data.results[i]));
+                        if (processMCodeMainData(data.results[i]).id !== null) {
+                            tempRows.push(processMCodeMainData(data.results[i]));
+                        }
                     } else {
                         // Filtered patients
                         let patientCondition = false;
@@ -166,20 +169,27 @@ function MCodeView() {
                             return true;
                         });
 
-                        if (patientCondition && patientProcedure && patientMedication) {
+                        if (
+                            patientCondition &&
+                            patientProcedure &&
+                            patientMedication &&
+                            processMCodeMainData(data.results[i]).id !== null
+                        ) {
                             tempRows.push(processMCodeMainData(data.results[i]));
                         }
                     }
                 }
                 setRows(tempRows);
-                setSelectedPatient(tempRows[0].id);
-                setSelectedPatientMobileInfo({
-                    Ethnicity: tempRows[0].ethnicity,
-                    Sex: tempRows[0].sex,
-                    Birthday: tempRows[0].date_of_birth,
-                    DeathDate: tempRows[0].date_of_death,
-                    Language: tempRows[0].communication_language
-                });
+                if (tempRows[0].id !== null) {
+                    setSelectedPatient(tempRows[0].id);
+                    setSelectedPatientMobileInfo({
+                        Ethnicity: tempRows[0].ethnicity,
+                        Sex: tempRows[0].sex,
+                        Birthday: tempRows[0].date_of_birth,
+                        DeathDate: tempRows[0].date_of_death,
+                        Language: tempRows[0].communication_language
+                    });
+                }
 
                 // Subtables
                 const index = data.results.findIndex((item) => item.id === tempRows[0].id);
@@ -258,7 +268,7 @@ function MCodeView() {
                         </Table>
                     </TableContainer>
                 )}
-                {!desktopResolution && (
+                {!desktopResolution && selectedPatient && (
                     <SingleRowTable
                         dropDownLabel="Patient Id"
                         dropDownSelection={selectedPatient}

--- a/src/views/clinical/phenopackets.js
+++ b/src/views/clinical/phenopackets.js
@@ -99,36 +99,40 @@ function Phenopackets() {
                 setPhenopacketsData(data);
                 const tempRows = [];
                 for (let i = 0; i < data.results.length; i += 1) {
-                    tempRows.push(processPhenopacketMainData(data.results[i]));
+                    if (processPhenopacketMainData(data.results[i]).id !== null) {
+                        tempRows.push(processPhenopacketMainData(data.results[i]));
+                    }
                 }
                 setRows(tempRows);
-                setSelectedPatient(tempRows[0].id);
-                setSelectedPatientMobileInfo({
-                    Ethnicity: tempRows[0].ethnicity,
-                    Sex: tempRows[0].sex,
-                    Birthday: tempRows[0].date_of_birth,
-                    Height: tempRows[0].height,
-                    Weight: tempRows[0].weight,
-                    BloodType: tempRows[0].abo_type,
-                    Education: tempRows[0].education,
-                    Household: tempRows[0].household,
-                    Pregnancy: tempRows[0].pregnancy,
-                    Employment: tempRows[0].employment,
-                    Asymptomatic: tempRows[0].asymptomatic,
-                    Covid19_test: tempRows[0].covid19_test,
-                    Hospitalized: tempRows[0].hospitalized,
-                    Birth_country: tempRows[0].birth_country,
-                    Host_hospital: tempRows[0].host_hospital,
-                    Residence_type: tempRows[0].residence_type,
-                    Enrollment_date: tempRows[0].enrollment_date,
-                    Covid19_test_date: tempRows[0].Covid19_test_date,
-                    Covid19_diagnosis_date: tempRows[0].covid19_diagnosis_date
-                });
+                if (tempRows[0].id !== null) {
+                    setSelectedPatient(tempRows[0].id);
+                    setSelectedPatientMobileInfo({
+                        Ethnicity: tempRows[0].ethnicity,
+                        Sex: tempRows[0].sex,
+                        Birthday: tempRows[0].date_of_birth,
+                        Height: tempRows[0].height,
+                        Weight: tempRows[0].weight,
+                        BloodType: tempRows[0].abo_type,
+                        Education: tempRows[0].education,
+                        Household: tempRows[0].household,
+                        Pregnancy: tempRows[0].pregnancy,
+                        Employment: tempRows[0].employment,
+                        Asymptomatic: tempRows[0].asymptomatic,
+                        Covid19_test: tempRows[0].covid19_test,
+                        Hospitalized: tempRows[0].hospitalized,
+                        Birth_country: tempRows[0].birth_country,
+                        Host_hospital: tempRows[0].host_hospital,
+                        Residence_type: tempRows[0].residence_type,
+                        Enrollment_date: tempRows[0].enrollment_date,
+                        Covid19_test_date: tempRows[0].Covid19_test_date,
+                        Covid19_diagnosis_date: tempRows[0].covid19_diagnosis_date
+                    });
 
-                // Subtables
-                setPhenotypicFeatures(processPhenotypicFeaturesData(data.results[0]));
-                setDiseases(processDiseaseData(data.results[0]));
-                setResources(processResourcesData(data.results[0]));
+                    // Subtables
+                    setPhenotypicFeatures(processPhenotypicFeaturesData(data.results[0]));
+                    setDiseases(processDiseaseData(data.results[0]));
+                    setResources(processResourcesData(data.results[0]));
+                }
             })
         );
 
@@ -191,7 +195,7 @@ function Phenopackets() {
                         <span>{selectedPatient}</span>
                     </Box>
                 )}
-                {!desktopResolution && (
+                {!desktopResolution && selectedPatient && (
                     <SingleRowTable
                         dropDownLabel="Patient Id"
                         dropDownSelection={selectedPatient}


### PR DESCRIPTION
# Description
Fix the data-grid render issue of mcodepackets/phenopackets with missing data. Currently, if part of the mcodepackets/phenopackets data is missing, the data-grid tables do not render. This is because some attributes are not read in a safe way (e.g., the attributes are accessed via key.attr1, which would throw exceptions if the attr1 doesn’t exist. The solution is to have both data-grid tables correctly render even with incomplete data except if missing the ID.