### PR TITLE
Set count with double call

### DIFF
--- a/src/store/api.js
+++ b/src/store/api.js
@@ -8,7 +8,7 @@ export function fetchKatsu(URL) {
     return fetch(`${katsu}${URL}`)
         .then((response) => response.json())
         .then((data) =>
-            fetch(`${katsu}${URL}?${data.count}`) // Page size by default is 25 set page size to count to returns all
+            fetch(`${katsu}${URL}?page_size=${data.count}`) // Page size by default is 25 set page size to count to returns all
                 .then((response) => response.json())
                 .then((data) => data)
         );

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -7,7 +7,11 @@ export const BASE_URL = process.env.REACT_APP_CANDIG_SERVER;
 export function fetchKatsu(URL) {
     return fetch(`${katsu}${URL}`)
         .then((response) => response.json())
-        .then((data) => data);
+        .then((data) =>
+            fetch(`${katsu}${URL}?${data.count}`) // Page size by default is 25 set page size to count to returns all
+                .then((response) => response.json())
+                .then((data) => data)
+        );
 }
 
 /*


### PR DESCRIPTION
## Description
The mcodepacket call was only returning 25 because of unset page_size. The solution is to grab the count and then recall with the exact page_size. Mcodepacket call will become an issue at large sizes, reevaluate the solution if/when that occurs. 