### PR TITLE
Logout redirects to keycloak login

### DIFF
--- a/src/layout/MainLayout/Header/ProfileSection/index.js
+++ b/src/layout/MainLayout/Header/ProfileSection/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 
 import { makeStyles, useTheme } from '@mui/styles';

--- a/src/layout/MainLayout/Header/ProfileSection/index.js
+++ b/src/layout/MainLayout/Header/ProfileSection/index.js
@@ -239,7 +239,6 @@ const ProfileSection = () => {
                                                     className={classes.listItem}
                                                     sx={{ borderRadius: `${customization.borderRadius}px` }}
                                                     selected={selectedIndex === 4}
-                                                    component={Link}
                                                     to="/auth/logout"
                                                 >
                                                     <ListItemIcon>


### PR DESCRIPTION
# Description
Fixes [JIRA Ticket](https://candig.atlassian.net/browse/DIG-870)

Logout was initially redirecting to a 404 page. To fix this redirection when using tyk virtual endpoints I had to remove the component type that was added to our ListItemButton. It was initially set to a [Link](https://reactrouter.com/en/main/components/link) redirecting inside the router dom. With this removed redirection to keycloak login works. 

## Type of Change
- [x] Bug fix -- logout redirects to 404 and only brings to keycloak on refresh

## How Has This Been Tested?
- [x] Local docker stack
- [x] Development server

## Acceptance criteria on JIRA ticket:

- [x] UHN instances successfully log out
- [ ] BC instances successfully log out