### PR TITLE
feature: greyscale completeness data

### DIFF
--- a/src/assets/scss/_themes-vars.module.scss
+++ b/src/assets/scss/_themes-vars.module.scss
@@ -46,11 +46,11 @@ $warningDark: #ffc107;
 // grey
 $grey50: #fafafa;
 $grey100: #f5f5f5;
-$grey200: #eeeeee;
-$grey300: #e0e0e0;
-$grey500: #9e9e9e;
-$grey600: #757575;
-$grey700: #616161;
+$grey200: #bebebe;
+$grey300: #acacac;
+$grey500: #858585;
+$grey600: #505050;
+$grey700: #3b3b3b;
 $grey900: #212121;
 
 // ===========================|| JAVASCRIPT ||=========================== //

--- a/src/store/constant.js
+++ b/src/store/constant.js
@@ -141,12 +141,12 @@ export const DataVisualizationChartInfo = {
         yAxis: 'Number of Patients'
     },
     full_clinical_data: {
-        title: 'Example of Complete Clinical Data',
+        title: 'Mock Data: Complete Clincal',
         xAxis: 'Site',
         yAxis: 'Number of Patients'
     },
     full_genomic_data: {
-        title: 'Example of Complete Genomic Data',
+        title: 'Mock Data: Complete Genomic',
         xAxis: 'Site',
         yAxis: 'Number of Patients'
     }

--- a/src/views/clinicalGenomic/widgets/dataVisualization.js
+++ b/src/views/clinicalGenomic/widgets/dataVisualization.js
@@ -211,7 +211,7 @@ function DataVisualization(props) {
                     dropDown
                     onRemoveChart={() => removeChart(index)}
                     edit={edit}
-                    colours={!completenessData.includes(item)}
+                    grayscale={completenessData.includes(item)}
                 />
             </Grid>
         ));

--- a/src/views/clinicalGenomic/widgets/dataVisualization.js
+++ b/src/views/clinicalGenomic/widgets/dataVisualization.js
@@ -144,7 +144,7 @@ function DataVisualization(props) {
     function AddChart(data, chartType) {
         setOpen(false);
         const newdataVisData = [...dataVisData, data];
-        const newDataVisChartType = [...dataVisChartType, chartType];
+        const newDataVisChartType = [...dataVisChartType, validStackedCharts.includes(data) ? 'bar' : chartType];
         setDataVisChartType(newDataVisChartType);
         setdataVisData(newdataVisData);
         Cookies.set('dataVisData', JSON.stringify(newdataVisData), { expires: 365 });
@@ -197,6 +197,7 @@ function DataVisualization(props) {
         );
     }
 
+    const completenessData = ['full_clinical_data', 'full_genomic_data'];
     function returndataVisData() {
         const data = dataVisData.map((item, index) => (
             <Grid item xs={12} sm={12} md={6} lg={3} key={item + index}>
@@ -210,6 +211,7 @@ function DataVisualization(props) {
                     dropDown
                     onRemoveChart={() => removeChart(index)}
                     edit={edit}
+                    colours={!completenessData.includes(item)}
                 />
             </Grid>
         ));

--- a/src/views/summary/CustomOfflineChart.js
+++ b/src/views/summary/CustomOfflineChart.js
@@ -29,7 +29,7 @@ window.Highcharts = Highcharts;
  * @param {array} dataObject
  */
 
-function CustomOfflineChart({ chartType, data, index, height, dataVis, dataObject, dropDown, onRemoveChart, edit, colours }) {
+function CustomOfflineChart({ chartType, data, index, height, dataVis, dataObject, dropDown, onRemoveChart, edit, grayscale }) {
     const theme = useTheme();
 
     // State management
@@ -82,8 +82,16 @@ function CustomOfflineChart({ chartType, data, index, height, dataVis, dataObjec
                 data.forEach((value, key) => {
                     stackSeries.push({ name: key, data: value });
                 });
-                const stackedTheme = colours
+                const stackedTheme = grayscale
                     ? [
+                          theme.palette.grey[200],
+                          theme.palette.grey[300],
+                          theme.palette.grey[500],
+                          theme.palette.grey[600],
+                          theme.palette.grey[700],
+                          theme.palette.grey[900]
+                      ]
+                    : [
                           theme.palette.secondary[200],
                           theme.palette.tertiary[200],
                           theme.palette.primary[200],
@@ -96,14 +104,6 @@ function CustomOfflineChart({ chartType, data, index, height, dataVis, dataObjec
                           theme.palette.secondary[800],
                           theme.palette.tertiary[800],
                           theme.palette.primary[800]
-                      ]
-                    : [
-                          theme.palette.grey[200],
-                          theme.palette.grey[300],
-                          theme.palette.grey[500],
-                          theme.palette.grey[600],
-                          theme.palette.grey[700],
-                          theme.palette.grey[900]
                       ];
 
                 setChartOptions({
@@ -322,7 +322,7 @@ CustomOfflineChart.propTypes = {
     dataVis: PropTypes.any,
     dataObject: PropTypes.any,
     onRemoveChart: PropTypes.func,
-    colours: PropTypes.bool
+    grayscale: PropTypes.bool
 };
 
 CustomOfflineChart.defaultProps = {

--- a/src/views/summary/CustomOfflineChart.js
+++ b/src/views/summary/CustomOfflineChart.js
@@ -29,7 +29,7 @@ window.Highcharts = Highcharts;
  * @param {array} dataObject
  */
 
-function CustomOfflineChart({ chartType, data, index, height, dataVis, dataObject, dropDown, onRemoveChart, edit }) {
+function CustomOfflineChart({ chartType, data, index, height, dataVis, dataObject, dropDown, onRemoveChart, edit, colours }) {
     const theme = useTheme();
 
     // State management
@@ -82,6 +82,29 @@ function CustomOfflineChart({ chartType, data, index, height, dataVis, dataObjec
                 data.forEach((value, key) => {
                     stackSeries.push({ name: key, data: value });
                 });
+                const stackedTheme = colours
+                    ? [
+                          theme.palette.secondary[200],
+                          theme.palette.tertiary[200],
+                          theme.palette.primary[200],
+                          theme.palette.secondary.main,
+                          theme.palette.tertiary.main,
+                          theme.palette.primary.main,
+                          theme.palette.secondary.dark,
+                          theme.palette.tertiary.dark,
+                          theme.palette.primary.dark,
+                          theme.palette.secondary[800],
+                          theme.palette.tertiary[800],
+                          theme.palette.primary[800]
+                      ]
+                    : [
+                          theme.palette.grey[200],
+                          theme.palette.grey[300],
+                          theme.palette.grey[500],
+                          theme.palette.grey[600],
+                          theme.palette.grey[700],
+                          theme.palette.grey[900]
+                      ];
 
                 setChartOptions({
                     credits: {
@@ -96,20 +119,7 @@ function CustomOfflineChart({ chartType, data, index, height, dataVis, dataObjec
                     },
                     xAxis: { title: { text: DataVisualizationChartInfo[chartData].xAxis }, categories },
                     yAxis: { title: { text: DataVisualizationChartInfo[chartData].yAxis } },
-                    colors: [
-                        theme.palette.secondary[200],
-                        theme.palette.tertiary[200],
-                        theme.palette.primary[200],
-                        theme.palette.secondary.main,
-                        theme.palette.tertiary.main,
-                        theme.palette.primary.main,
-                        theme.palette.secondary.dark,
-                        theme.palette.tertiary.dark,
-                        theme.palette.primary.dark,
-                        theme.palette.secondary[800],
-                        theme.palette.tertiary[800],
-                        theme.palette.primary[800]
-                    ],
+                    colors: stackedTheme,
                     plotOptions: {
                         series: {
                             stacking: 'normal'
@@ -251,7 +261,7 @@ function CustomOfflineChart({ chartType, data, index, height, dataVis, dataObjec
                             <label htmlFor="types">
                                 Chart Types:
                                 <select
-                                    value={chart}
+                                    value="bar"
                                     name="types"
                                     id="types"
                                     onChange={(event) => {
@@ -278,7 +288,6 @@ function CustomOfflineChart({ chartType, data, index, height, dataVis, dataObjec
                                     <option value="line">Line</option>
                                     <option value="column">Column</option>
                                     <option value="scatter">Scatter</option>
-                                    <option value="pie">Pie</option>
                                 </select>
                             </label>
                         )}
@@ -312,7 +321,8 @@ CustomOfflineChart.propTypes = {
     height: PropTypes.string,
     dataVis: PropTypes.any,
     dataObject: PropTypes.any,
-    onRemoveChart: PropTypes.func
+    onRemoveChart: PropTypes.func,
+    colours: PropTypes.bool
 };
 
 CustomOfflineChart.defaultProps = {

--- a/src/views/summary/summary.js
+++ b/src/views/summary/summary.js
@@ -235,6 +235,7 @@ function Summary() {
                         height="400px; auto"
                         chartType="bar"
                         dropDown={false}
+                        colours
                     />
                 </Grid>
             )}
@@ -247,6 +248,7 @@ function Summary() {
                         chartType="bar"
                         height="400px; auto"
                         dropDown={false}
+                        colours
                     />
                 </Grid>
             )}
@@ -259,6 +261,7 @@ function Summary() {
                         chartType="bar"
                         height="400px; auto"
                         dropDown={false}
+                        colours
                     />
                 </Grid>
             )}
@@ -271,6 +274,7 @@ function Summary() {
                         chartType="bar"
                         height="400px; auto"
                         dropDown={false}
+                        colours
                     />
                 </Grid>
             )}
@@ -283,6 +287,7 @@ function Summary() {
                         chartType="bar"
                         height="400px; auto"
                         dropDown={false}
+                        colours={false}
                     />
                 </Grid>
             )}
@@ -295,6 +300,7 @@ function Summary() {
                         chartType="bar"
                         height="400px; auto"
                         dropDown={false}
+                        colours={false}
                     />
                 </Grid>
             )}

--- a/src/views/summary/summary.js
+++ b/src/views/summary/summary.js
@@ -235,7 +235,6 @@ function Summary() {
                         height="400px; auto"
                         chartType="bar"
                         dropDown={false}
-                        colours
                     />
                 </Grid>
             )}
@@ -248,7 +247,6 @@ function Summary() {
                         chartType="bar"
                         height="400px; auto"
                         dropDown={false}
-                        colours
                     />
                 </Grid>
             )}
@@ -261,7 +259,6 @@ function Summary() {
                         chartType="bar"
                         height="400px; auto"
                         dropDown={false}
-                        colours
                     />
                 </Grid>
             )}
@@ -274,7 +271,6 @@ function Summary() {
                         chartType="bar"
                         height="400px; auto"
                         dropDown={false}
-                        colours
                     />
                 </Grid>
             )}
@@ -287,7 +283,7 @@ function Summary() {
                         chartType="bar"
                         height="400px; auto"
                         dropDown={false}
-                        colours={false}
+                        grayscale
                     />
                 </Grid>
             )}
@@ -300,7 +296,7 @@ function Summary() {
                         chartType="bar"
                         height="400px; auto"
                         dropDown={false}
-                        colours={false}
+                        grayscale
                     />
                 </Grid>
             )}


### PR DESCRIPTION
Along with the greyscale feature, there is also a hotfix for the data visualization component

## Ticket(s)
[JIRA DIG-1191](https://candig.atlassian.net/browse/DIG-1191)

## Description
Completeness data greyscaled for demo along with title change for the mock data. This also contains a minor bug fix for data visualization component when selecting stacked charts.

## Expected Behaviour
All Mock charts show up grey with new titles.

## Screenshots
![image](https://github.com/CanDIG/candig-data-portal/assets/37649170/842f5608-834a-4921-8709-1ae1322d4bbd)

## Types of Change(s)
- [x] 🪲 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:
- [x] Prettier linter doesn't return errors
- [x] Locally tested