### PR TITLE
Bugfix: Consume all will fail if one server has much more donors than the other

### DIFF
--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -18,11 +18,11 @@ function ConsumeAllPages(url, resultConsumer, service = 'katsu') {
                 parsedData[loc.location.name] = [];
             }
 
-            if (loc.results.next) {
+            if (loc.results?.next) {
                 nextQuery = `${url}${url.includes('?') ? '&' : '?'}page=${idx + 1}`;
             }
 
-            if (loc.results.results) {
+            if (loc.results?.results) {
                 parsedData[loc.location.name] = parsedData[loc.location.name].concat(loc.results.results.map(resultConsumer));
             }
         });
@@ -102,7 +102,7 @@ function SearchHandler() {
         }
 
         searchParams.append('page_size', 100);
-        const url = `v2/authorized/donors?${searchParams}`;
+        const url = `v2/authorized/donors/?${searchParams}`;
 
         const donorQueryPromise = () =>
             trackPromise(


### PR DESCRIPTION
## Description
The search page's ConsumeAllData function can fail if one server has more pages of donors than the other.

## Screenshots (if appropriate)
### Before PR
![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/fe8e0ade-496e-4b1a-a8af-a905dacbe787)

## Types of Change(s)
- [x] 🪲 Bug fix (non-breaking change that fixes an issue)

## Has it been tested for:
- [x] Prettier linter doesn't return errors
- [x] Locally tested
- [x] Dev server tested