### PR TITLE
Fix a bug where clinical results wouldn't properly filter down genomic results

### DIFF
--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -316,7 +316,7 @@ function SearchHandler() {
                                                     return caseData;
                                                 })
                                                 .filter((caseData) => {
-                                                    if (reader.query && Object.keys(reader.query).length > 0 && caseData.donorID) {
+                                                    if (reader.donorLists && Object.keys(reader.donorLists).length > 0 && caseData.donorID) {
                                                         return finalList.includes(caseData.donorID);
                                                     }
                                                     return true;


### PR DESCRIPTION
## Description
This fixes a bug where selecting a clinical filter would not cut down on the genomic results

## Expected Behaviour
### After PR
![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/e41320a7-79eb-4839-9db0-79180cacee4a)

## Types of Change(s)
- [x] 🪲 Bug fix (non-breaking change that fixes an issue)

## Has it been tested for:
- [x] Dev server tested