### PR TITLE
Fix the positioning of the profile menu

### DIFF
--- a/src/layout/MainLayout/Header/ProfileSection/index.js
+++ b/src/layout/MainLayout/Header/ProfileSection/index.js
@@ -77,6 +77,9 @@ const useStyles = makeStyles((theme) => ({
     cardContent: {
         padding: '16px !important'
     },
+    showOnTop: {
+        zIndex: 11001
+    },
     card: {
         backgroundColor: theme.palette.primary.light,
         marginBottom: '16px',
@@ -118,7 +121,6 @@ const ProfileSection = () => {
     const theme = useTheme();
     const customization = useSelector((state) => state.customization);
 
-    const [value, setValue] = React.useState('');
     const [selectedIndex] = React.useState(1);
 
     const [open, setOpen] = React.useState(false);
@@ -185,7 +187,7 @@ const ProfileSection = () => {
                 anchorEl={anchorRef.current}
                 role={undefined}
                 transition
-                disablePortal
+                className={classes.showOnTop}
                 popperOptions={{
                     modifiers: [
                         {
@@ -214,22 +216,6 @@ const ProfileSection = () => {
                                                 <Typography variant="subtitle2">{SITE}</Typography>
                                             </Grid>
                                         </Grid>
-                                        <OutlinedInput
-                                            className={classes.searchControl}
-                                            id="input-search-profile"
-                                            value={value}
-                                            onChange={(e) => setValue(e.target.value)}
-                                            placeholder="Search profile options"
-                                            startAdornment={
-                                                <InputAdornment position="start">
-                                                    <IconSearch stroke={1.5} size="1.3rem" className={classes.startAdornment} />
-                                                </InputAdornment>
-                                            }
-                                            aria-describedby="search-helper-text"
-                                            inputProps={{
-                                                'aria-label': 'weight'
-                                            }}
-                                        />
                                         <Divider />
                                         <PerfectScrollbar className={classes.ScrollHeight}>
                                             <Divider />

--- a/src/layout/MainLayout/Header/ProfileSection/index.js
+++ b/src/layout/MainLayout/Header/ProfileSection/index.js
@@ -109,6 +109,9 @@ const useStyles = makeStyles((theme) => ({
     badgeWarning: {
         backgroundColor: theme.palette.warning.dark,
         color: '#fff'
+    },
+    usernamePadding: {
+        paddingBottom: '1em'
     }
 }));
 
@@ -210,7 +213,7 @@ const ProfileSection = () => {
                                                     First Name Last Name
                                                 </Typography> */}
                                             </Grid>
-                                            <Grid item>
+                                            <Grid item className={classes.usernamePadding}>
                                                 <Typography variant="subtitle2">{SITE}</Typography>
                                             </Grid>
                                         </Grid>

--- a/src/layout/MainLayout/Header/ProfileSection/index.js
+++ b/src/layout/MainLayout/Header/ProfileSection/index.js
@@ -9,11 +9,9 @@ import {
     ClickAwayListener,
     Divider,
     Grid,
-    InputAdornment,
     List,
     ListItemIcon,
     ListItemText,
-    OutlinedInput,
     Paper,
     Popper,
     Typography
@@ -29,7 +27,7 @@ import Transitions from 'ui-component/extended/Transitions';
 import { SITE } from 'store/constant';
 
 // assets
-import { IconLogout, IconSearch, IconSettings } from '@tabler/icons';
+import { IconLogout, IconSettings } from '@tabler/icons';
 import User1 from 'assets/images/users/user-round.svg';
 import BCGSC from 'assets/images/users/bcgsc.svg';
 import UHN from 'assets/images/users/UHN.svg';


### PR DESCRIPTION
## Expected Behaviour

- The profile popper menu should now display on top of the header for the search page

## Screenshots (if appropriate)

### Before PR
![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/b712f669-7488-4f1c-8b4d-f689d9a7c61b)

### After PR

![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/79206e51-5bfc-4ba2-9a69-b346b0871ac5)

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
