### PR TITLE
Fix for the Katsu UUID change

### DIFF
--- a/src/layout/MainLayout/Sidebar/index.js
+++ b/src/layout/MainLayout/Sidebar/index.js
@@ -65,7 +65,7 @@ const Sidebar = ({ drawerOpen, drawerToggle, window }) => {
                 </PerfectScrollbar>
             </BrowserView>
             <MobileView>
-                <Box sx={{ px: 2 }} />
+                <Box sx={{ px: 2 }}>{sidebarContext || <></>}</Box>
             </MobileView>
         </>
     );

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -76,9 +76,6 @@ function SearchHandler() {
     useEffect(() => {
         // First, we abort any currently-running search promises
         // controller.abort();
-        console.log('Query re-initiated');
-        console.log(reader.query);
-
         const CollateSummary = (data, statName) => {
             const summaryStat = {};
             data.forEach((site) => {
@@ -146,7 +143,7 @@ function SearchHandler() {
                 const clinicalData = {};
                 data.forEach((site) => {
                     discoveryCounts.patients_per_cohort[site.location.name] = site.results?.summary?.patients_per_cohort;
-                    clinicalData[site.location.name] = site?.results?.results;
+                    clinicalData[site.location.name] = site?.results;
                 });
 
                 const genomicData = data

--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -12,6 +12,10 @@ import { useSearchQueryWriterContext, useSearchResultsReaderContext } from '../S
 
 function ClinicalView() {
     const theme = useTheme();
+    const [paginationModel, setPaginationModel] = React.useState({
+        pageSize: 25,
+        page: 0
+    });
 
     // Mobile
     const [desktopResolution, setdesktopResolution] = React.useState(window.innerWidth > 1200);
@@ -24,6 +28,7 @@ function ClinicalView() {
     if (searchResults) {
         rows =
             Object.values(searchResults)
+                ?.map((results) => results.results)
                 ?.flat(1)
                 ?.map((patient, index) => {
                     // Make sure each row has an ID and a deceased status
@@ -52,6 +57,22 @@ function ClinicalView() {
         { field: 'date_of_death', headerName: 'Date of Death', minWidth: 220, sortable: false }
     ];
 
+    const HandlePageChange = (newPage) => {
+        if (newPage !== paginationModel.page) {
+            writerContext((old) => ({ ...old, query: { ...old.query, page: newPage } }));
+        }
+        setPaginationModel({
+            pageSize: 10,
+            page: newPage
+        });
+    };
+
+    const totalRows = searchResults
+        ? Object.values(searchResults)
+              ?.map((site) => site.count)
+              .reduce((partial, a) => partial + a, 0)
+        : 0;
+
     return (
         <Box mr={2} ml={1} p={1} sx={{ border: 1, borderRadius: 2, boxShadow: 2, borderColor: theme.palette.primary[200] + 75 }}>
             <Typography pb={1} variant="h4">
@@ -62,8 +83,12 @@ function ClinicalView() {
                     rows={rows}
                     columns={columns}
                     pageSize={10}
+                    rowCount={totalRows}
                     rowsPerPageOptions={[10]}
                     onRowClick={(rowData) => handleRowClick(rowData.row)}
+                    paginationModel={paginationModel}
+                    onPageChange={HandlePageChange}
+                    paginationMode="server"
                     hideFooterSelectedRowCount
                 />
             </div>

--- a/src/views/clinicalGenomic/widgets/patientCounts.js
+++ b/src/views/clinicalGenomic/widgets/patientCounts.js
@@ -32,10 +32,15 @@ function PatientCounts() {
             if (searchResults && entry.location.name in searchResults) {
                 // Has this node been excluded from the results?
                 if (!(filters && filters?.node?.includes(entry.location.name))) {
-                    console.log(entry);
-                    console.log(searchResults);
                     const match = searchResults[entry.location.name];
-                    // Iterate through each donor in this site
+                    Object.keys(match.summary.patients_per_cohort).forEach((cohort) => {
+                        if (cohort in counts) {
+                            counts[cohort] += match.summary.patients_per_cohort[cohort];
+                        } else {
+                            counts[cohort] = match.summary.patients_per_cohort[cohort];
+                        }
+                    });
+                    /* // Iterate through each donor in this site
                     match.forEach((donor) => {
                         if (filters && filters?.program_id?.includes(donor.program_id)) {
                             // Exclude based on cohort
@@ -47,7 +52,7 @@ function PatientCounts() {
                         } else {
                             counts[donor.program_id] = 1;
                         }
-                    });
+                    }); */
                 }
             }
 

--- a/src/views/clinicalGenomic/widgets/patientCounts.js
+++ b/src/views/clinicalGenomic/widgets/patientCounts.js
@@ -32,6 +32,8 @@ function PatientCounts() {
             if (searchResults && entry.location.name in searchResults) {
                 // Has this node been excluded from the results?
                 if (!(filters && filters?.node?.includes(entry.location.name))) {
+                    console.log(entry);
+                    console.log(searchResults);
                     const match = searchResults[entry.location.name];
                     // Iterate through each donor in this site
                     match.forEach((donor) => {

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -336,7 +336,7 @@ function Sidebar() {
 
     // Parse out what we need:
     const sites = readerContext?.programs?.map((loc) => loc.location.name) || [];
-    const cohorts = readerContext?.programs?.map((loc) => loc.results.results.map((cohort) => cohort.program_id)).flat(1) || [];
+    const cohorts = readerContext?.programs?.map((loc) => loc?.results?.items.map((cohort) => cohort.program_id)).flat(1) || [];
     const treatmentTypes = ExtractSidebarElements('treatment_types');
     const tumourPrimarySites = ExtractSidebarElements('tumour_primary_sites');
     const chemotherapyDrugNames = ExtractSidebarElements('chemotherapy_drug_names');


### PR DESCRIPTION
## Ticket(s)

- [DIG-1399](https://candig.atlassian.net/browse/DIG-1399)

## Description

- Fix issues that cropped up when using the new Katsu. This requires the [query microservice](https://github.com/CanDIG/query/pull/6) changes as well.

## Expected Behaviour

- The search page works as it did before, but with the new Katsu schemas.

## Related Issues (if appropriate)

- [DIG-1355](https://candig.atlassian.net/browse/DIG-1355)
- https://github.com/CanDIG/katsu/pull/158

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch


[DIG-1399]: https://candig.atlassian.net/browse/DIG-1399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DIG-1355]: https://candig.atlassian.net/browse/DIG-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ