### PR TITLE
Fixup

### DIFF
--- a/src/layout/MainLayout/index.js
+++ b/src/layout/MainLayout/index.js
@@ -87,7 +87,7 @@ function MainLayout() {
     const matchDownMd = useMediaQuery(theme.breakpoints.down('lg'));
 
     // Handle left drawer
-    const [sidebarContent, setSidebarContent] = useState(false);
+    const [sidebarContent, setSidebarContent] = useState(null);
     const leftDrawerOpened = useSelector((state) => state.customization.opened) && !!sidebarContent;
     const dispatch = useDispatch();
     const handleLeftDrawerToggle = () => {

--- a/src/ui-component/DataRow.js
+++ b/src/ui-component/DataRow.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Box, Divider, Grid, Typography } from '@mui/material';
-import { useTheme, makeStyles } from '@mui/system';
+import { styled } from '@mui/material/styles';
+import { useTheme } from '@mui/system';
 
 function makeField(lab, val) {
     return {
@@ -11,35 +12,48 @@ function makeField(lab, val) {
     };
 }
 
-const useStyles = makeStyles((theme) => ({
-    rowText: {
-        color: 'black'
-    },
-    container: {
-        minHeight: 40,
-        marginRight: 0
-    },
-    locked: {
-        backgroundColor: theme.palette.action.disabledBackground
-    },
-    button: {
-        // Right-aligned
-        float: 'right',
-        marginLeft: 'auto'
-    },
-    divider: {
-        borderColor: theme.palette.primary.main,
-        marginTop: '0.25em',
-        marginBottom: '0.25em'
-    },
-    dataBox: {
+const PREFIX = 'UIComponentDataRow';
+
+const classes = {
+    dropdownItem: `${PREFIX}-dropdownItem`,
+    rowText: `${PREFIX}-rowText`,
+    container: `${PREFIX}-container`,
+    locked: `${PREFIX}-locked`,
+    button: `${PREFIX}-button`,
+    divider: `${PREFIX}-divider`,
+    dataBox: `${PREFIX}-dataBox`,
+    label: `${PREFIX}-label`
+};
+
+const StyledBox = styled(Box)(({ theme }) => ({
+    [`& .${classes.dataBox}`]: {
         maxHeight: 'none',
         height: 'fit-content',
         paddingTop: '0.75em',
         paddingBottom: '0.75em',
         marginTop: '3em'
     },
-    label: {
+    [`& .${classes.rowText}`]: {
+        color: 'black'
+    },
+    [`& .${classes.container}`]: {
+        minHeight: 40,
+        marginRight: 0
+    },
+    [`& .${classes.locked}`]: {
+        backgroundColor: theme.palette.action.disabledBackground
+    },
+    [`& .${classes.button}`]: {
+        // Right-aligned
+        float: 'right',
+        marginLeft: 'auto'
+    },
+    [`& .${classes.divider}`]: {
+        borderColor: theme.palette.primary.main,
+        marginTop: '0.25em',
+        marginBottom: '0.25em'
+    },
+    [`& .${classes.label}`]: {
         marginTop: '-3.5em',
         paddingBottom: '2em',
         color: 'black'
@@ -49,7 +63,6 @@ const useStyles = makeStyles((theme) => ({
 function DataRow(props) {
     const { fields, itemSize, rowWidth } = props;
     const theme = useTheme();
-    const classes = useStyles();
     const primaryField = fields.shift();
 
     /* const avatarProps = locked
@@ -60,7 +73,7 @@ function DataRow(props) {
         : {}; */
 
     return (
-        <Box
+        <StyledBox
             className={classes.dataBox}
             sx={{
                 // These properties aren't working in useStyles for some reason...
@@ -96,7 +109,7 @@ function DataRow(props) {
                     </React.Fragment>
                 ))}
             </Grid>
-        </Box>
+        </StyledBox>
     );
 }
 


### PR DESCRIPTION
## Description

- Previous PR #111 somehow introduced a warning, where a particular file was throwing errors (unknown why the file was missing in that PR). Also fixes a warning, but doesn't fix the other warnings that have suddenly cropped up now that we're in develop.

## Expected Behaviour

- The full screen warning no longer shows up.

## Screenshots (if appropriate)

### Before PR

![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/407a5739-8c4c-4c1f-af44-a97a6e57e0c1)

### After PR

(No warning)

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
