### PR TITLE
Fix the data-grid not responding at all

### DIFF
--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -13,7 +13,7 @@ import { useSearchQueryWriterContext, useSearchResultsReaderContext } from '../S
 function ClinicalView() {
     const theme = useTheme();
     const [paginationModel, setPaginationModel] = React.useState({
-        pageSize: 25,
+        pageSize: 10,
         page: 0
     });
 
@@ -79,9 +79,8 @@ function ClinicalView() {
                 <DataGrid
                     rows={rows}
                     columns={columns}
-                    pageSize={10}
                     rowCount={totalRows}
-                    rowsPerPageOptions={[10]}
+                    pageSizeOptions={[10]}
                     onRowClick={(rowData) => handleRowClick(rowData.row)}
                     paginationModel={paginationModel}
                     onPaginationModelChange={HandlePageChange}

--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -57,14 +57,11 @@ function ClinicalView() {
         { field: 'date_of_death', headerName: 'Date of Death', minWidth: 220, sortable: false }
     ];
 
-    const HandlePageChange = (newPage) => {
-        if (newPage !== paginationModel.page) {
-            writerContext((old) => ({ ...old, query: { ...old.query, page: newPage } }));
+    const HandlePageChange = (newModel) => {
+        if (newModel.page !== paginationModel.page) {
+            writerContext((old) => ({ ...old, query: { ...old.query, page: newModel.page, page_size: newModel.pageSize } }));
         }
-        setPaginationModel({
-            pageSize: 10,
-            page: newPage
-        });
+        setPaginationModel(newModel);
     };
 
     const totalRows = searchResults
@@ -87,7 +84,7 @@ function ClinicalView() {
                     rowsPerPageOptions={[10]}
                     onRowClick={(rowData) => handleRowClick(rowData.row)}
                     paginationModel={paginationModel}
-                    onPageChange={HandlePageChange}
+                    onPaginationModelChange={HandlePageChange}
                     paginationMode="server"
                     hideFooterSelectedRowCount
                 />


### PR DESCRIPTION
## Ticket(s)

- None, emergency PR

## Description

- Data-Grid changed its event from onPageChange to onPaginationModelChange, which broke the next/previous buttons and page size buttons.

## Expected Behaviour

- Data-grid works again

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [x] Dev server tested
-   [ ] Production tested when merging into stable/production branch
