### PR TITLE
Fix an issue where removing a single filter would result in the wrong number of results

### DIFF
--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -135,7 +135,6 @@ function StyledCheckboxList(props) {
                 } else {
                     retVal.query[groupName] = ids;
                 }
-                console.log(retVal);
                 return retVal;
             });
         } else {
@@ -160,7 +159,6 @@ function StyledCheckboxList(props) {
                 } else {
                     retVal.query[groupName] = ids;
                 }
-                console.log(newList);
                 return retVal;
             });
         }

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -135,7 +135,7 @@ function StyledCheckboxList(props) {
                 } else {
                     retVal.query[groupName] = ids;
                 }
-
+                console.log(retVal);
                 return retVal;
             });
         } else {
@@ -154,8 +154,13 @@ function StyledCheckboxList(props) {
                     return retVal;
                 }
 
-                const newList = Object.fromEntries(Object.entries(old.query).filter(([name, _]) => name !== groupName));
-                retVal.query = newList;
+                const newList = Object.fromEntries(Object.entries(old.query).filter(([name, _]) => name === groupName));
+                if (ids.length === 0) {
+                    delete retVal.query[groupName];
+                } else {
+                    retVal.query[groupName] = ids;
+                }
+                console.log(newList);
                 return retVal;
             });
         }
@@ -184,10 +189,6 @@ function StyledCheckboxList(props) {
             // set width to match parent
             sx={{ width: '100%', paddingTop: '0.5em', paddingBottom: '0.5em' }}
             onChange={(_, value, reason, details) => {
-                console.log(_);
-                console.log(value);
-                console.log(reason);
-                console.log(details);
                 HandleChange(value, reason === 'selectOption');
             }}
         />


### PR DESCRIPTION
## Ticket(s)

- https://github.com/CanDIG/CanDIGv2/pull/387#issuecomment-1900715686

## Description

- Removing a single item from a filter with two or more things selected would result in the wrong number of results, as it was removing the entire list instead of just one thing.

## Expected Behaviour

- Add the medium Katsu dataset
- Under Treatment, select Bone Marrow Transplant
- You should have 22 patients
- Under Treatment, add Chemotherapy
- You should end up with 29 results (remember it's an OR filter if it's in the same category)
- Remove the Chemotherapy filter
- You should go back to 22 patients, not 30.

## Screenshots (if appropriate)

### Before PR

From @lilyyangyi301 
![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/c9af6516-aa91-49f7-9afd-2c061ae75978)
![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/da842e3b-58d7-48cb-9c04-d7a66befe3fa)
![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/2419e51b-1a0c-44a3-919e-d135334370a6)

### After PR

![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/d0b03a62-4cad-4698-a424-4ee991195958)
![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/188c5858-e6f4-4c51-9b02-17b5630e5232)
![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/60a58f72-0439-4e4c-9f65-54912d87bf33)

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
