### PR TITLE
Feature/reset button

### DIFF
--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -246,7 +246,9 @@ StyledCheckboxList.propTypes = {
     remap: PropTypes.func,
     onWrite: PropTypes.func,
     options: PropTypes.array,
-    useAutoComplete: PropTypes.bool
+    useAutoComplete: PropTypes.bool,
+    setChecked: PropTypes.func,
+    checked: PropTypes.object
 };
 
 // A group of genomics data
@@ -371,7 +373,15 @@ GenomicsGroup.propTypes = {
     chromosomes: PropTypes.array,
     genes: PropTypes.array,
     hide: PropTypes.bool,
-    onWrite: PropTypes.func
+    onWrite: PropTypes.func,
+    endPos: PropTypes.string,
+    setEndPos: PropTypes.func,
+    startPos: PropTypes.string,
+    setStartPos: PropTypes.func,
+    selectedGenes: PropTypes.string,
+    setSelectedGenes: PropTypes.func,
+    selectedChromosomes: PropTypes.string,
+    setSelectedChromosomes: PropTypes.func
 };
 
 function Sidebar() {
@@ -381,12 +391,10 @@ function Sidebar() {
 
     // Genomic data
     // const referenceGenomes = ['hg38'];
-    const [selectedGenome, _setSelectedGenome] = useState('hg38');
     const [selectedChromosomes, setSelectedChromosomes] = useState('');
     const [selectedGenes, setSelectedGenes] = useState('');
     const [startPos, setStartPos] = useState(0);
     const [endPos, setEndPos] = useState(0);
-    const [_timeout, setNewTimeout] = useState(null);
 
     // Clinical Data
     const [selectedNodes, setSelectedNodes] = useState({});

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -132,7 +132,19 @@ function StyledCheckboxList(props) {
         }
 
         if (isExclusion ? !isChecked : isChecked) {
-            setChecked((old) => ({ ...old, [ids]: true }));
+            if (useAutoComplete) {
+                // Autcomplete's onChange will have IDs be a list of options that are checked
+                setChecked((_) => {
+                    const retVal = {};
+                    ids.forEach((id) => {
+                        retVal[id] = true;
+                    });
+                    return retVal;
+                });
+            } else {
+                // FormControlLabel's onChange will have IDs be a list of IDs that have _changed_
+                setChecked((old) => ({ ...old, [ids]: true }));
+            }
             onWrite((old) => {
                 const retVal = { donorLists: {}, filter: {}, query: {}, ...old };
 
@@ -147,6 +159,16 @@ function StyledCheckboxList(props) {
             });
         } else {
             setChecked((old) => {
+                // Autocomplete's onChange will return a list
+                if (useAutoComplete) {
+                    const retVal = {};
+                    ids.forEach((id) => {
+                        retVal[id] = true;
+                    });
+                    return retVal;
+                }
+
+                // FormControlLabel's onChange
                 const { [ids]: _, ...rest } = old;
                 return rest;
             });

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -168,6 +168,8 @@ function StyledCheckboxList(props) {
         }
     };
 
+    const checkedList = Object.keys(checked);
+
     return useAutoComplete ? (
         <Autocomplete
             size="small"
@@ -193,6 +195,7 @@ function StyledCheckboxList(props) {
             onChange={(_, value, reason) => {
                 HandleChange(value, reason === 'selectOption');
             }}
+            value={checkedList}
         />
     ) : (
         options?.map((option) => (


### PR DESCRIPTION
## Ticket(s)
[DIG-1353](https://candig.atlassian.net/browse/DIG-1353)

## Description
Implementation of a reset button in the sidebar. This reset button works for checkboxes, text input, autocomplete, and autcomplete using renderOption. 

## Expected Behaviour
- Reset button when pressed will reset to the default setting of all nodes, and cohorts selected and everything else empty.

## Screenshots
![image](https://github.com/CanDIG/candig-data-portal/assets/37649170/1184fbf1-15ac-41ea-a66c-877d4e1f68ba)

## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [x] My change requires a change to the documentation
-   [x] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [x] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [x] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-1353]: https://candig.atlassian.net/browse/DIG-1353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ