### PR TITLE
Field-Level Completeness Stats

### DIFF
--- a/src/menu-items/clinicalGenomicSearch.js
+++ b/src/menu-items/clinicalGenomicSearch.js
@@ -1,5 +1,5 @@
 // assets
-import { IconReportMedical } from '@tabler/icons-react';
+import { IconReportSearch } from '@tabler/icons-react';
 
 // import project config
 import config from 'config';
@@ -8,7 +8,7 @@ import config from 'config';
 const { basename } = config;
 
 const icons = {
-    IconReportMedical
+    IconReportSearch
 };
 
 // ===========================|| Clinical MENU ITEMS ||=========================== //
@@ -23,7 +23,7 @@ const clinicalGenomicSearch = {
             title: 'Clinical & Genomic Search',
             type: 'item',
             url: `${basename}/clinicalGenomicSearch `,
-            icon: icons.IconReportMedical,
+            icon: icons.IconReportSearch,
             breadcrumbs: false
         }
     ]

--- a/src/menu-items/completenessStats.js
+++ b/src/menu-items/completenessStats.js
@@ -1,5 +1,5 @@
 // assets
-import { IconReportMedical } from '@tabler/icons';
+import { IconReportMedical } from '@tabler/icons-react';
 
 // import project config
 import config from 'config';

--- a/src/menu-items/completenessStats.js
+++ b/src/menu-items/completenessStats.js
@@ -1,0 +1,32 @@
+// assets
+import { IconReportMedical } from '@tabler/icons';
+
+// import project config
+import config from 'config';
+
+// constant
+const { basename } = config;
+
+const icons = {
+    IconReportMedical
+};
+
+// ===========================|| Completeness Stats MENU ITEMS ||=========================== //
+
+const completenessStats = {
+    id: 'completenessStats',
+    title: 'Completeness Stats',
+    type: 'group',
+    children: [
+        {
+            id: 'Completeness Stats',
+            title: 'Completeness Stats',
+            type: 'item',
+            url: `${basename}/completeness `,
+            icon: icons.IconReportMedical,
+            breadcrumbs: false
+        }
+    ]
+};
+
+export default completenessStats;

--- a/src/menu-items/completenessStats.js
+++ b/src/menu-items/completenessStats.js
@@ -1,5 +1,5 @@
 // assets
-import { IconReportMedical } from '@tabler/icons-react';
+import { IconTrendingUp } from '@tabler/icons-react';
 
 // import project config
 import config from 'config';
@@ -8,7 +8,7 @@ import config from 'config';
 const { basename } = config;
 
 const icons = {
-    IconReportMedical
+    IconTrendingUp
 };
 
 // ===========================|| Completeness Stats MENU ITEMS ||=========================== //
@@ -23,7 +23,7 @@ const completenessStats = {
             title: 'Completeness Stats',
             type: 'item',
             url: `${basename}/completeness `,
-            icon: icons.IconReportMedical,
+            icon: icons.IconTrendingUp,
             breadcrumbs: false
         }
     ]

--- a/src/menu-items/index.js
+++ b/src/menu-items/index.js
@@ -1,5 +1,6 @@
 import clinicalGenomicSearch from './clinicalGenomicSearch';
 import summary from './summary';
+import completenessStats from './completenessStats';
 // import ingest from './ingest';
 
 // import pages from './pages';
@@ -9,7 +10,7 @@ import summary from './summary';
 // ===========================|| MENU ITEMS ||=========================== //
 
 const menuItems = {
-    items: [summary, clinicalGenomicSearch /* , ingest, pages, utilities, other */]
+    items: [summary, clinicalGenomicSearch, completenessStats /* , ingest, pages, utilities, other */]
 };
 
 export default menuItems;

--- a/src/menu-items/summary.js
+++ b/src/menu-items/summary.js
@@ -1,5 +1,5 @@
 // assets
-import { IconReportMedical } from '@tabler/icons-react';
+import { IconLayoutDashboard } from '@tabler/icons-react';
 
 // import project config
 import config from 'config';
@@ -8,7 +8,7 @@ import config from 'config';
 const { basename } = config;
 
 const icons = {
-    IconReportMedical
+    IconLayoutDashboard
 };
 
 // ===========================|| Clinical MENU ITEMS ||=========================== //
@@ -23,7 +23,7 @@ const summary = {
             title: 'Summary',
             type: 'item',
             url: `${basename}/summary`,
-            icon: icons.IconReportMedical,
+            icon: icons.IconLayoutDashboard,
             breadcrumbs: false
         }
     ]

--- a/src/routes/MainRoutes.js
+++ b/src/routes/MainRoutes.js
@@ -23,6 +23,9 @@ const IngestPortal = Loadable(lazy(() => import('views/ingest/ingest')));
 // Ingest Portal
 // const IngestPortal = Loadable(lazy(() => import('views/ingest/ingest')));
 
+// Completeness
+const CompletenessStats = Loadable(lazy(() => import('views/completeness/completeness')));
+
 // Error Pages
 const ErrorNotFoundPage = Loadable(lazy(() => import('views/errorPages/ErrorNotFoundPage')));
 
@@ -47,6 +50,10 @@ const MainRoutes = {
         {
             path: `${basename}/clinicalGenomicSearch`,
             element: <ClinicalGenomicSearch />
+        },
+        {
+            path: `${basename}/completeness`,
+            element: <CompletenessStats />
         },
         /* {
             path: `${basename}/data-ingest`,

--- a/src/store/constant.js
+++ b/src/store/constant.js
@@ -141,7 +141,7 @@ export const DataVisualizationChartInfo = {
         yAxis: 'Number of Patients'
     },
     full_clinical_data: {
-        title: 'Mock Data: Complete Clinical',
+        title: 'Complete Clinical',
         xAxis: 'Site',
         yAxis: 'Number of Patients'
     },

--- a/src/store/constant.js
+++ b/src/store/constant.js
@@ -146,7 +146,7 @@ export const DataVisualizationChartInfo = {
         yAxis: 'Number of Patients'
     },
     full_genomic_data: {
-        title: 'Mock Data: Complete Genomic',
+        title: 'Complete Genomic',
         xAxis: 'Site',
         yAxis: 'Number of Patients'
     }

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -75,7 +75,6 @@ function SearchHandler() {
     // Query 2: when the search query changes, re-query the server
     useEffect(() => {
         // First, we abort any currently-running search promises
-        // controller.abort();
         const CollateSummary = (data, statName) => {
             const summaryStat = {};
             data.forEach((site) => {
@@ -155,7 +154,7 @@ function SearchHandler() {
                     )
                     .flat(1);
 
-                writer((old) => ({ ...old, clinical: clinicalData, counts: discoveryCounts, genomic: genomicData }));
+                writer((old) => ({ ...old, clinical: clinicalData, counts: discoveryCounts, genomic: genomicData, loading: false }));
             });
 
         if (lastPromise === null) {

--- a/src/views/clinicalGenomic/widgets/dataVisualization.js
+++ b/src/views/clinicalGenomic/widgets/dataVisualization.js
@@ -29,35 +29,7 @@ function DataVisualization() {
         patients_per_cohort: resultsContext?.patients_per_cohort || {},
         diagnosis_age_count: resultsContext?.diagnosis_age_count || {},
         treatment_type_count: resultsContext?.treatment_type_count || {},
-        cancer_type_count: resultsContext?.cancer_type_count || {},
-        full_clinical_data: {
-            BCGSC: {
-                POG: 30
-            },
-            UHN: {
-                POG: 14,
-                Inspire: 20,
-                Biocan: 20,
-                Biodiva: 10
-            },
-            C3G: {
-                MOCK: 30
-            }
-        },
-        full_genomic_data: {
-            BCGSC: {
-                POG: 10
-            },
-            UHN: {
-                POG: 4,
-                Inspire: 10,
-                Biocan: 12,
-                Biodiva: 12
-            },
-            C3G: {
-                MOCK: 3
-            }
-        }
+        cancer_type_count: resultsContext?.cancer_type_count || {}
     };
     const theme = useTheme();
 
@@ -170,7 +142,6 @@ function DataVisualization() {
         );
     }
 
-    const completenessData = ['full_clinical_data', 'full_genomic_data'];
     function returndataVisData() {
         const data = dataVisData.map((item, index) => (
             <Grid item xs={12} sm={12} md={6} lg={3} key={item + index}>
@@ -184,7 +155,6 @@ function DataVisualization() {
                     dropDown
                     onRemoveChart={() => removeChart(index)}
                     edit={edit}
-                    grayscale={completenessData.includes(item)}
                     orderByFrequency={item !== 'diagnosis_age_count'}
                     orderAlphabetically={item === 'diagnosis_age_count'}
                     trimByDefault={dataVisTrim[index]}

--- a/src/views/completeness/completeness.jsx
+++ b/src/views/completeness/completeness.jsx
@@ -107,7 +107,7 @@ function Completeness() {
         fetchFederation('genomic-completeness', 'query').then((data) => {
             const numCompleteGenomic = {};
             data.filter((site) => site.status === 200).forEach((site) => {
-                numCompleteGenomic[site.location.name] = site.results;
+                numCompleteGenomic[site.location.name] = site.results.all;
             });
             setNumGenomicComplete(numCompleteGenomic);
         });

--- a/src/views/completeness/completeness.jsx
+++ b/src/views/completeness/completeness.jsx
@@ -9,19 +9,18 @@ import CustomOfflineChart from 'views/summary/CustomOfflineChart';
 
 // project imports
 import { fetchFederation } from 'store/api';
-import { aggregateObj, aggregateObjStack } from 'utils/utils';
 
 // assets
-import { Hive, CheckCircleOutline, WarningAmber, Person, Public } from '@mui/icons-material';
+import { CheckCircleOutline, WarningAmber, Person } from '@mui/icons-material';
 
 // Test data
-import { fullClinicalData, fullGenomicData } from '../../store/constant';
-
 import { useSidebarWriterContext } from 'layout/MainLayout/Sidebar/SidebarContext';
+import MainCard from 'ui-component/cards/MainCard';
+import FieldLevelCompletenessGraph from './fieldLevelCompletenessGraph';
 
 function Completeness() {
     const theme = useTheme();
-    const [clinicalComplete, setClinicalComplete] = useState({});
+    const [clinicalComplete, setClinicalComplete] = useState([]);
     const [numNodes, setNumNodes] = useState(0);
     const [numErrorNodes, setNumErrorNodes] = useState(0);
     const [numDonors, setNumDonors] = useState(0);
@@ -185,7 +184,7 @@ function Completeness() {
                     dataObject={numClinicalComplete || {}}
                     data="full_clinical_data"
                     dataVis=""
-                    chartType="bar"
+                    chartType="column"
                     height="400px; auto"
                     dropDown={false}
                     loading={undefined}
@@ -198,13 +197,19 @@ function Completeness() {
                     dataObject={numGenomicComplete || {}}
                     data="full_genomic_data"
                     dataVis=""
-                    chartType="bar"
+                    chartType="column"
                     height="400px; auto"
                     dropDown={false}
                     loading={undefined}
                     orderByFrequency
                     cutoff={10}
                 />
+            </Grid>
+            {/* <Grid item xs={12} sm={12} md={6} lg={6}>
+                <MainCard>(Percentage complete graph)</MainCard>
+            </Grid> */}
+            <Grid item xs={12} sm={12} md={6} lg={6}>
+                <FieldLevelCompletenessGraph data={clinicalComplete} loading={clinicalComplete.length === 0} />
             </Grid>
         </Grid>
     );

--- a/src/views/completeness/completeness.jsx
+++ b/src/views/completeness/completeness.jsx
@@ -1,4 +1,4 @@
-import { createRef, useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 // mui
 // import { useTheme, makeStyles } from '@mui/styles';
@@ -15,7 +15,6 @@ import { CheckCircleOutline, WarningAmber, Person } from '@mui/icons-material';
 
 // Test data
 import { useSidebarWriterContext } from 'layout/MainLayout/Sidebar/SidebarContext';
-import MainCard from 'ui-component/cards/MainCard';
 import FieldLevelCompletenessGraph from './fieldLevelCompletenessGraph';
 
 function Completeness() {
@@ -161,10 +160,10 @@ function Completeness() {
                     dataObject={numClinicalComplete || {}}
                     data="full_clinical_data"
                     dataVis=""
-                    chartType="column"
+                    chartType="bar"
                     height="400px; auto"
                     dropDown={false}
-                    loading={undefined}
+                    loading={isLoading}
                     orderByFrequency
                     cutoff={10}
                 />
@@ -174,10 +173,10 @@ function Completeness() {
                     dataObject={numGenomicComplete || {}}
                     data="full_genomic_data"
                     dataVis=""
-                    chartType="column"
+                    chartType="bar"
                     height="400px; auto"
                     dropDown={false}
-                    loading={undefined}
+                    loading={isLoading}
                     orderByFrequency
                     cutoff={10}
                 />

--- a/src/views/completeness/completeness.jsx
+++ b/src/views/completeness/completeness.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 // mui
 // import { useTheme, makeStyles } from '@mui/styles';
 import Grid from '@mui/material/Grid';
-import useTheme from '@mui/styles/useTheme';
+import useTheme from '@mui/system/useTheme';
 import SmallCountCard from 'ui-component/cards/SmallCountCard';
 import CustomOfflineChart from 'views/summary/CustomOfflineChart';
 

--- a/src/views/completeness/completeness.jsx
+++ b/src/views/completeness/completeness.jsx
@@ -1,0 +1,213 @@
+import { useState, useEffect } from 'react';
+
+// mui
+// import { useTheme, makeStyles } from '@mui/styles';
+import Grid from '@mui/material/Grid';
+import useTheme from '@mui/styles/useTheme';
+import SmallCountCard from 'ui-component/cards/SmallCountCard';
+import CustomOfflineChart from 'views/summary/CustomOfflineChart';
+
+// project imports
+import { fetchFederation } from 'store/api';
+import { aggregateObj, aggregateObjStack } from 'utils/utils';
+
+// assets
+import { Hive, CheckCircleOutline, WarningAmber, Person, Public } from '@mui/icons-material';
+
+// Test data
+import { fullClinicalData, fullGenomicData } from '../../store/constant';
+
+import { useSidebarWriterContext } from 'layout/MainLayout/Sidebar/SidebarContext';
+
+function Completeness() {
+    const theme = useTheme();
+    const [clinicalComplete, setClinicalComplete] = useState({});
+    const [numNodes, setNumNodes] = useState(0);
+    const [numErrorNodes, setNumErrorNodes] = useState(0);
+    const [numDonors, setNumDonors] = useState(0);
+    const [numCompleteDonors, setNumCompleteDonors] = useState(0);
+    const [numProvinces, setNumProvinces] = useState(0);
+    const [numClinicalComplete, setNumClinicalComplete] = useState(0);
+    const [numGenomicComplete, setNumGenomicComplete] = useState(0);
+    const [isLoading, setLoading] = useState(false);
+
+    // Clear the sidebar, if available
+    const sidebarWriter = useSidebarWriterContext();
+    useEffect(() => {
+        sidebarWriter(null);
+    }, [sidebarWriter]);
+
+    useEffect(() => {
+        fetchFederation('v2/authorized/programs', 'katsu').then((data) => {
+            // Step 1: Determine the number of provinces
+            const provinces = data.map((site) => site?.location?.province);
+            const uniqueProvinces = [...new Set(provinces)];
+            setNumProvinces(uniqueProvinces.length);
+
+            // Step 2: Determine the number of nodes
+            setNumNodes(data.length);
+
+            // Step 3: Determine the number of donors
+            let totalSites = 0;
+            let totalErroredSites = 0;
+            let totalCases = 0;
+            let completeCases = 0;
+            const completeClinical = {};
+            data.forEach((site) => {
+                totalSites += 1;
+                totalErroredSites += site.status === 200 ? 0 : 1;
+                site?.results?.results?.forEach((program) => {
+                    if (program?.metadata?.summary_cases) {
+                        totalCases += program.metadata.summary_cases.total_cases;
+                        completeCases += program.metadata.summary_cases.complete_cases;
+                        if (!(site.location.name in completeClinical)) {
+                            completeClinical[site.location.name] = {};
+                        }
+                        completeClinical[site.location.name][program.program_id] = program.metadata.summary_cases.total_cases;
+                    }
+                });
+            });
+            setNumNodes(totalSites);
+            setNumErrorNodes(totalErroredSites);
+            setNumDonors(totalCases);
+            setNumCompleteDonors(completeCases);
+            setNumClinicalComplete(completeClinical);
+            setClinicalComplete(data);
+        });
+
+        /*
+        // TODO: This should be a query microservice endpoint, due to the amount of data that needs to be processed
+        // Also! This isn't a count of donors, but of samples. That also kind of messes with the counts
+        fetchFederation('ga4gh/drs/v1/objects', 'htsget').then((data) => {
+            // Find all samples
+            const samples = data.filter((drs) => drs.description === 'sample');
+            let numCompleteSamples = 0;
+
+            samples.forEach((sample) => {
+                let hasGenome = false;
+                let hasTranscriptome = false;
+
+                sample.contents.forEach((content) => {
+                    const asdf = data.find((drs) => drs.self_uri === content.self_uri);
+                    if (asdf?.description === 'wgs') {
+                        hasGenome = true;
+                    } else if (asdf?.description === 'wts') {
+                        hasTranscriptome = true;
+                    }
+                });
+
+                if (hasGenome && hasTranscriptome) {
+                    numCompleteSamples += 1;
+                }
+            });
+
+            setNumGenomicComplete(numCompleteSamples);
+        });
+        */
+
+        fetchFederation('genomic-completeness', 'query').then((data) => {
+            const numCompleteGenomic = {};
+            data.filter((site) => site.status === 200).forEach((site) => {
+                numCompleteGenomic[site.location.name] = site.results;
+            });
+            setNumGenomicComplete(numCompleteGenomic);
+        });
+    }, []);
+
+    console.log(numGenomicComplete);
+
+    return (
+        <Grid container spacing={1}>
+            {numErrorNodes > 0 ? (
+                <Grid item xs={12} sm={12} md={6} lg={3} pt={1} pl={1}>
+                    <Grid container>
+                        <Grid item xs={3} pr={1}>
+                            <SmallCountCard
+                                title="Nodes"
+                                count={`${numNodes}/${numNodes + numErrorNodes}`}
+                                icon={<CheckCircleOutline fontSize="inherit" />}
+                                color={theme.palette.secondary.main}
+                            />
+                        </Grid>
+                        <Grid item xs={3}>
+                            <SmallCountCard
+                                title="Connection Error"
+                                count={`${numErrorNodes}/${numNodes + numErrorNodes}`}
+                                icon={<WarningAmber fontSize="inherit" />}
+                                color={theme.palette.error.main}
+                            />
+                        </Grid>
+                    </Grid>
+                </Grid>
+            ) : (
+                <Grid item xs={12} sm={12} md={6} lg={3}>
+                    <SmallCountCard
+                        isLoading={isLoading}
+                        title="Nodes"
+                        count={numNodes}
+                        icon={<CheckCircleOutline fontSize="inherit" />}
+                        color={theme.palette.secondary.main}
+                    />
+                </Grid>
+            )}
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+                <SmallCountCard
+                    isLoading={isLoading}
+                    title="Number of Patients"
+                    count={numDonors || 0}
+                    primary
+                    icon={<Person fontSize="inherit" />}
+                    color={theme.palette.primary.main}
+                />
+            </Grid>
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+                <SmallCountCard
+                    isLoading={isLoading}
+                    title="Number of Patients With Complete Data"
+                    count={numCompleteDonors || 0}
+                    primary
+                    icon={<Person fontSize="inherit" />}
+                    color={theme.palette.secondary.main}
+                />
+            </Grid>
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+                <SmallCountCard
+                    isLoading={isLoading}
+                    title="Provinces"
+                    count={numProvinces || 0}
+                    primary
+                    icon={<Person fontSize="inherit" />}
+                    color={theme.palette.tertiary.main}
+                />
+            </Grid>
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+                <CustomOfflineChart
+                    dataObject={numClinicalComplete || {}}
+                    data="full_clinical_data"
+                    dataVis=""
+                    chartType="bar"
+                    height="400px; auto"
+                    dropDown={false}
+                    loading={undefined}
+                    orderByFrequency
+                    cutoff={10}
+                />
+            </Grid>
+            <Grid item xs={12} sm={12} md={6} lg={3}>
+                <CustomOfflineChart
+                    dataObject={numGenomicComplete || {}}
+                    data="full_genomic_data"
+                    dataVis=""
+                    chartType="bar"
+                    height="400px; auto"
+                    dropDown={false}
+                    loading={undefined}
+                    orderByFrequency
+                    cutoff={10}
+                />
+            </Grid>
+        </Grid>
+    );
+}
+
+export default Completeness;

--- a/src/views/completeness/fieldLevelCompletenessGraph.jsx
+++ b/src/views/completeness/fieldLevelCompletenessGraph.jsx
@@ -1,4 +1,5 @@
 import { createRef, useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
 
 // mui
 // import { useTheme, makeStyles } from '@mui/styles';
@@ -58,6 +59,7 @@ function FieldLevelCompletenessGraph(props) {
     const [filter, setFilter] = useState('All cohorts');
     const theme = useTheme();
     const chartRef = createRef();
+    const events = useSelector((state) => state);
 
     NoDataToDisplay(Highcharts);
 
@@ -130,6 +132,7 @@ function FieldLevelCompletenessGraph(props) {
             enabled: false
         },
         chart: {
+            height: '360px; auto',
             type: 'bar',
             plotBackgroundColor: null,
             plotBorderWidth: null,
@@ -189,7 +192,7 @@ function FieldLevelCompletenessGraph(props) {
     // Determine what we can do with the data
     return (
         <Root sx={{ position: 'relative' }}>
-            <MainCard sx={{ borderRadius: 0.25, height: 500 }}>
+            <MainCard sx={{ borderRadius: events.customization.borderRadius * 0.25, height: '440px; auto' }}>
                 <div className={classes.titleBar}>
                     {/* <div className={classes.titleBox}>
                         <div className={classes.title}>{title}</div>

--- a/src/views/completeness/fieldLevelCompletenessGraph.jsx
+++ b/src/views/completeness/fieldLevelCompletenessGraph.jsx
@@ -12,7 +12,7 @@ import NoDataToDisplay from 'highcharts/modules/no-data-to-display';
 
 // assets
 import MainCard from 'ui-component/cards/MainCard';
-import { useTheme } from '@mui/styles';
+import { useTheme } from '@mui/system';
 
 window.Highcharts = Highcharts;
 

--- a/src/views/completeness/fieldLevelCompletenessGraph.jsx
+++ b/src/views/completeness/fieldLevelCompletenessGraph.jsx
@@ -1,0 +1,177 @@
+import { createRef, useState, useEffect } from 'react';
+
+// mui
+// import { useTheme, makeStyles } from '@mui/styles';
+import { Box, MenuItem, Select, Typography } from '@mui/material';
+import PropTypes from 'prop-types';
+
+// project imports
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+import NoDataToDisplay from 'highcharts/modules/no-data-to-display';
+
+// assets
+import MainCard from 'ui-component/cards/MainCard';
+import { useTheme } from '@mui/styles';
+
+window.Highcharts = Highcharts;
+
+function FieldLevelCompletenessGraph(props) {
+    const { data, loading } = props;
+    const [filter, setFilter] = useState('All sites');
+    const theme = useTheme();
+    const chartRef = createRef();
+
+    NoDataToDisplay(Highcharts);
+
+    useEffect(() => {
+        const chartObj = chartRef?.current?.chart;
+
+        if (loading) {
+            chartObj?.showLoading();
+        } else {
+            chartObj?.hideLoading();
+        }
+    }, [chartRef, loading]);
+
+    // TODO: Filter fields here
+    const fields = {};
+    const allCohorts = ['All sites'];
+    if (data) {
+        Object.values(data).forEach((site) => {
+            const cohorts = site.results?.results;
+            if (!cohorts) {
+                return;
+            }
+
+            // Convert each one into a singular field
+            // Category -> Field name -> { missing & total }
+            cohorts.forEach((cohort) => {
+                allCohorts.push(cohort.program_id);
+                if (cohort.program_id !== filter && filter !== 'All sites') {
+                    return;
+                }
+
+                const theseFields = cohort?.metadata?.required_but_missing;
+                Object.keys(theseFields).forEach((fieldCategory) => {
+                    Object.keys(theseFields[fieldCategory]).forEach((fieldName) => {
+                        const concatenatedName = `${fieldCategory}/${fieldName}`;
+                        if (!(concatenatedName in fields)) {
+                            fields[concatenatedName] = {
+                                missing: theseFields[fieldCategory][fieldName].missing,
+                                total: theseFields[fieldCategory][fieldName].total
+                            };
+                        } else {
+                            fields[concatenatedName].missing += theseFields[fieldCategory][fieldName].missing;
+                            fields[concatenatedName].total += theseFields[fieldCategory][fieldName].total;
+                        }
+                    });
+                });
+            });
+        });
+    }
+
+    /* Object.keys(fields).forEach((field) => {
+        fields[field].pct = 1 - fields[field].missing / fields[field].total;
+    }); */
+
+    // Convert this into something HighCharts can understand
+    // First, we need to convert the fields into a list, sorted by their width
+    const series = Object.keys(fields)
+        .map((field) => {
+            const pct = fields[field].total === 0 ? 0 : 1 - fields[field].missing / fields[field].total;
+            return [field, pct * 100];
+        })
+        .sort((a, b) => a[1] - b[1]);
+    const categories = series.map((point) => point[0]);
+    const dataPoints = series.map((point) => point[1]);
+    console.log(categories);
+    console.log(dataPoints);
+    const highChartSettings = {
+        credits: {
+            enabled: false
+        },
+        chart: {
+            type: 'bar',
+            plotBackgroundColor: null,
+            plotBorderWidth: null,
+            plotShadow: false
+        },
+        colors: [
+            theme.palette.primary[200],
+            theme.palette.primary.main,
+            theme.palette.primary.dark,
+            theme.palette.primary[800],
+            theme.palette.secondary[200],
+            theme.palette.secondary.main,
+            theme.palette.secondary.dark,
+            theme.palette.secondary[800],
+            theme.palette.tertiary[200],
+            theme.palette.tertiary.main,
+            theme.palette.tertiary.dark,
+            theme.palette.tertiary[800]
+        ],
+        plotOptions: {
+            bar: {
+                dataLabels: {
+                    enabled: true,
+                    format: '{y}%'
+                }
+            }
+        },
+        title: {
+            text: 'Data Completeness'
+        },
+        xAxis: {
+            labels: {
+                // Anonymous functions don't appear to work with highcharts for some reason?
+                /* eslint-disable */
+                formatter: function() {
+                    const identifier = this.value.toString().split('/');
+                    const field = identifier.slice(1).join('/').replaceAll('_', ' ');
+                    let title = identifier[0][0].toUpperCase() + identifier[0].slice(1).toLowerCase();
+                    return `<b>${title}</b> <span style="text-transform:uppercase">${field}</span>`;
+                }
+                /* eslint-enable */
+            },
+            min: 0,
+            max: 10,
+            type: 'category'
+        },
+        yAxis: {
+            title: null,
+            min: 0,
+            max: 100
+        },
+        scrollbar: {
+            enabled: true
+        },
+        series: [{ data: series, colorByPoint: true, showInLegend: false }],
+        tooltip: {
+            pointFormat: '<b>{point.name}:</b> {point.y}%'
+        }
+    };
+
+    // Determine what we can do with the data
+    return (
+        <Box sx={{ position: 'relative' }}>
+            <MainCard sx={{ borderRadius: 0.25 }}>
+                <Select value={filter} onChange={(event) => setFilter(event.target.value)}>
+                    {allCohorts.map((cohort) => (
+                        <MenuItem value={cohort} key={cohort}>
+                            {cohort}
+                        </MenuItem>
+                    ))}
+                </Select>
+                <HighchartsReact Highcharts={Highcharts} options={highChartSettings} ref={chartRef} />
+            </MainCard>
+        </Box>
+    );
+}
+
+FieldLevelCompletenessGraph.propTypes = {
+    data: PropTypes.array,
+    loading: PropTypes.bool
+};
+
+export default FieldLevelCompletenessGraph;

--- a/src/views/completeness/fieldLevelCompletenessGraph.jsx
+++ b/src/views/completeness/fieldLevelCompletenessGraph.jsx
@@ -157,7 +157,7 @@ function FieldLevelCompletenessGraph(props) {
             labels: {
                 // Anonymous functions don't appear to work with highcharts for some reason?
                 /* eslint-disable */
-                formatter: function() {
+                formatter: function () {
                     const identifier = this.value.toString().split('/');
                     const field = identifier.slice(1).join('/').replaceAll('_', ' ');
                     let title = identifier[0][0].toUpperCase() + identifier[0].slice(1).toLowerCase();

--- a/src/views/completeness/fieldLevelCompletenessGraph.jsx
+++ b/src/views/completeness/fieldLevelCompletenessGraph.jsx
@@ -42,7 +42,10 @@ const Root = styled(Box)(({ _ }) => ({
         flex: 2,
         display: 'inline-flex',
         flexDirection: 'row-reverse',
-        marginLeft: 'auto'
+        marginLeft: 'auto',
+        fontSize: '1.4em',
+        fontWeight: 'normal',
+        fontFamily: 'Helvetica, Arial, sans-serif' // Taken from HighCharts
     },
     [`& .${classes.spacer}`]: {
         flexGrow: 3,
@@ -119,8 +122,6 @@ function FieldLevelCompletenessGraph(props) {
             return [field, pct * 100];
         })
         .sort((a, b) => a[1] - b[1]);
-    const categories = series.map((point) => point[0]);
-    const dataPoints = series.map((point) => point[1]);
     const highChartSettings = {
         legend: {
             enabled: false
@@ -191,13 +192,7 @@ function FieldLevelCompletenessGraph(props) {
         <Root sx={{ position: 'relative' }}>
             <MainCard sx={{ borderRadius: events.customization.borderRadius * 0.25, height: '440px; auto' }}>
                 <div className={classes.titleBar}>
-                    {/* <div className={classes.titleBox}>
-                        <div className={classes.title}>{title}</div>
-                        <div className={classes.title}>{title}</div>
-                    </div> */}
-                    <Typography className={classes.title} variant="h2">
-                        {title}
-                    </Typography>
+                    <Typography className={classes.title}>{title}</Typography>
                     <div className={classes.spacer} />
                     <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
                         <Select value={filter} onChange={(event) => setFilter(event.target.value)} className={classes.siteSelection}>

--- a/src/views/completeness/fieldLevelCompletenessGraph.jsx
+++ b/src/views/completeness/fieldLevelCompletenessGraph.jsx
@@ -77,7 +77,6 @@ function FieldLevelCompletenessGraph(props) {
     const fields = {};
     const allCohorts = ['All cohorts'];
     if (data) {
-        console.log(data);
         Object.values(data).forEach((site) => {
             const cohorts = site.results?.programs;
             if (!cohorts) {
@@ -122,8 +121,6 @@ function FieldLevelCompletenessGraph(props) {
         .sort((a, b) => a[1] - b[1]);
     const categories = series.map((point) => point[0]);
     const dataPoints = series.map((point) => point[1]);
-    console.log(categories);
-    console.log(dataPoints);
     const highChartSettings = {
         legend: {
             enabled: false

--- a/src/views/completeness/fieldLevelCompletenessGraph.jsx
+++ b/src/views/completeness/fieldLevelCompletenessGraph.jsx
@@ -85,8 +85,9 @@ function FieldLevelCompletenessGraph(props) {
             // Convert each one into a singular field
             // Category -> Field name -> { missing & total }
             cohorts.forEach((cohort) => {
-                allCohorts.push(cohort.program_id);
-                if (cohort.program_id !== filter && filter !== 'All cohorts') {
+                const concatName = `${site.location.name} - ${cohort.program_id}`;
+                allCohorts.push(concatName);
+                if (concatName !== filter && filter !== 'All cohorts') {
                     return;
                 }
 

--- a/src/views/summary/CustomOfflineChart.js
+++ b/src/views/summary/CustomOfflineChart.js
@@ -216,7 +216,9 @@ function CustomOfflineChart(props) {
                                 dataSum += point.y;
                             });
                             const pcnt = (this.y / dataSum) * 100;
-                            return `<b> ${this.key}</b><br> - ${this.y} (${Highcharts.numberFormat(pcnt)}%) total patient(s)`;
+                            return `<b> ${this.key}</b><br> - ${this.y} (${Highcharts.numberFormat(
+                                pcnt
+                            )}%) total ${this.series.yAxis.axisTitle.textStr.toLowerCase()}`;
                         }
                         /* eslint-enable func-names */
                     }

--- a/src/views/summary/summary.js
+++ b/src/views/summary/summary.js
@@ -8,14 +8,11 @@ import CustomOfflineChart from 'views/summary/CustomOfflineChart';
 import TreatingCentreMap from 'views/summary/TreatingCentreMap';
 
 // project imports
-import { fetchFederationStat } from 'store/api';
+import { fetchClinicalCompleteness, fetchFederationStat, fetchGenomicCompleteness } from 'store/api';
 import { aggregateObj, aggregateObjStack } from 'utils/utils';
 
 // assets
 import { Hive, CheckCircleOutline, WarningAmber, Person, Public } from '@mui/icons-material';
-
-// Test data
-import { fullClinicalData, fullGenomicData } from '../../store/constant';
 
 import { useSidebarWriterContext } from 'layout/MainLayout/Sidebar/SidebarContext';
 
@@ -30,8 +27,8 @@ function Summary() {
     const [cohortCount, setCohortCount] = useState(undefined);
     const [patientsPerCohort, setPatientsPerCohort] = useState(undefined);
     const [diagnosisAgeCount, setDiagnosisAgeCount] = useState(undefined);
-    // const [fullClinicalData, setFullClinicalData] = useState({});
-    // const [fullGenomicData, setFullGenomicData] = useState({});
+    const [numClinicalComplete, setNumClinicalComplete] = useState({});
+    const [numGenomicComplete, setNumGenomicComplete] = useState({});
     const [connectionError, setConnectionError] = useState(0);
     const [sites, setSites] = useState(0);
     const [totalSites, setTotalSites] = useState(0);
@@ -134,6 +131,18 @@ function Summary() {
         }
     }
 
+    function fetchClinical() {
+        fetchClinicalCompleteness().then((data) => {
+            setNumClinicalComplete(data.numClinicalComplete);
+        });
+    }
+
+    function fetchGenomic() {
+        fetchGenomicCompleteness().then((numCompleteGenomic) => {
+            setNumGenomicComplete(numCompleteGenomic);
+        });
+    }
+
     useEffect(() => {
         function fetchData(endpoint) {
             return fetchFederationStat(endpoint)
@@ -155,6 +164,8 @@ function Summary() {
             .then(() => fetchData('/patients_per_cohort'))
             .then(() => fetchData('/treatment_type_count'))
             .then(() => fetchData('/diagnosis_age_count'))
+            .then(() => fetchGenomic())
+            .then(() => fetchClinical())
             .finally(() => setLoading(false));
     }, []);
 
@@ -272,28 +283,26 @@ function Summary() {
             </Grid>
             <Grid item xs={12} sm={12} md={6} lg={3}>
                 <CustomOfflineChart
-                    dataObject={fullClinicalData || {}}
+                    dataObject={numClinicalComplete || {}}
                     data="full_clinical_data"
                     dataVis=""
                     chartType="bar"
                     height="400px; auto"
                     dropDown={false}
-                    loading={fullClinicalData === undefined}
-                    grayscale
+                    loading={numClinicalComplete === undefined}
                     orderByFrequency
                     cutoff={10}
                 />
             </Grid>
             <Grid item xs={12} sm={12} md={6} lg={3}>
                 <CustomOfflineChart
-                    dataObject={fullGenomicData || {}}
+                    dataObject={numGenomicComplete || {}}
                     data="full_genomic_data"
                     dataVis=""
                     chartType="bar"
                     height="400px; auto"
                     dropDown={false}
-                    loading={fullGenomicData === undefined}
-                    grayscale
+                    loading={numGenomicComplete === undefined}
                     orderByFrequency
                     cutoff={10}
                 />


### PR DESCRIPTION
## Ticket(s)

- [DIG-1234](https://candig.atlassian.net/browse/DIG-1234)

## Description

- This PR adds field-level completeness stats to a new tab on the right

## Expected Behaviour

- The new tab properly displays completeness stats. To test completeness, try deleting a field from the `tests/clinical_ingest.json` before ingesting it.

## Related Issues (if appropriate)

-

## Screenshots (if appropriate)

### After PR

![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/0c2bc2a6-ce9f-4283-85e4-210e112ed9eb)

## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-1234]: https://candig.atlassian.net/browse/DIG-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ