### PR TITLE
Remove the ability for decimals to appear in any of the summary graphs

### DIFF
--- a/src/views/summary/CustomOfflineChart.js
+++ b/src/views/summary/CustomOfflineChart.js
@@ -154,8 +154,8 @@ function CustomOfflineChart(props) {
                             fontWeight: 'normal'
                         }
                     },
-                    xAxis: { title: { text: DataVisualizationChartInfo[chartData].xAxis }, categories },
-                    yAxis: { title: { text: DataVisualizationChartInfo[chartData].yAxis } },
+                    xAxis: { title: { text: DataVisualizationChartInfo[chartData].xAxis }, categories, allowDecimals: false },
+                    yAxis: { title: { text: DataVisualizationChartInfo[chartData].yAxis }, allowDecimals: false },
                     colors: stackedTheme,
                     plotOptions: {
                         series: {
@@ -202,8 +202,8 @@ function CustomOfflineChart(props) {
                             fontWeight: 'normal'
                         }
                     },
-                    xAxis: { title: { text: DataVisualizationChartInfo[chartData]?.xAxis }, categories },
-                    yAxis: { title: { text: DataVisualizationChartInfo[chartData]?.yAxis } },
+                    xAxis: { title: { text: DataVisualizationChartInfo[chartData]?.xAxis }, categories, allowDecimals: false },
+                    yAxis: { title: { text: DataVisualizationChartInfo[chartData]?.yAxis }, allowDecimals: false },
                     colors: [theme.palette.primary.dark],
                     series: [{ data, colorByPoint: true, showInLegend: false }],
                     tooltip: {
@@ -253,8 +253,8 @@ function CustomOfflineChart(props) {
                             fontWeight: 'normal'
                         }
                     },
-                    xAxis: { title: { text: DataVisualizationChartInfo[chartData].xAxis } },
-                    yAxis: { title: { text: DataVisualizationChartInfo[chartData].yAxis } },
+                    xAxis: { title: { text: DataVisualizationChartInfo[chartData].xAxis }, allowDecimals: false },
+                    yAxis: { title: { text: DataVisualizationChartInfo[chartData].yAxis }, allowDecimals: false },
                     tooltip: {
                         pointFormat: '<b>{point.name}:</b> {point.y}'
                     },


### PR DESCRIPTION
## Ticket(s)

- [DIG-1447](https://candig.atlassian.net/browse/DIG-1447)

## Description

- This PR removes the decimals that can appear in the summary statistics graphs.

## Expected Behaviour

- Even when selecting a small number of patients via the sidebar, there are no "0.25" axis labels for number of donors, etc.

## Screenshots (if appropriate)

### Before PR

![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/588327b5-5b02-4797-9931-57a1c19d7d21)


### After PR

![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/88d6024d-e54f-4281-8d8e-8f09622d773f)

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-1447]: https://candig.atlassian.net/browse/DIG-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ