### PR TITLE
Interval dates added

### DIFF
--- a/src/store/constant.js
+++ b/src/store/constant.js
@@ -121,7 +121,7 @@ export const DataVisualizationChartInfo = {
         yAxis: 'Number of Patients'
     },
     diagnosis_age_count: {
-        title: ' Age at Diagnosis Distribution',
+        title: ' Age at First Diagnosis',
         xAxis: 'Age Range',
         yAxis: 'Number of Patients'
     },

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -30,7 +30,7 @@ function useClinicalPatientData(patientId, programId) {
                         value === '' ||
                         key === ''
                     ) &&
-                    (!(typeof obj[key] === 'object') || (typeof obj[key] === 'object' && 'month_interval' in obj[key]))
+                    (!(typeof obj[key] === 'object') || (typeof obj[key] === 'object' && 'month_interval' in obj[key])) // Accept interval date objects remove all other objects
             )
         );
     }

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -27,10 +27,10 @@ function useClinicalPatientData(patientId, programId) {
                     value !== null &&
                     !(
                         (Array.isArray(value) && value.length === 0) || // Exclude empty arrays
-                        typeof value === 'object' || // Exclude all objects
                         value === '' ||
                         key === ''
-                    )
+                    ) &&
+                    (!(typeof obj[key] === 'object') || (typeof obj[key] === 'object' && 'month_interval' in obj[key]))
             )
         );
     }
@@ -47,13 +47,25 @@ function useClinicalPatientData(patientId, programId) {
                     const result = await fetchFederation(url, 'katsu');
                     // Extract patientData from the fetched result or use an empty object
                     const patientData = result[0].results || {};
-
-                    // Update the sidebar with patientData using the PatientSidebar component
-                    sidebarWriter(<PatientSidebar sidebar={patientData} setRows={setRows} setColumns={setColumns} setTitle={setTitle} />);
                     // Filter patientData to create topLevel data excluding arrays, objects, and empty values
                     const filteredData = filterNestedObject(patientData);
+                    const ageInMonths = filteredData.date_of_death.month_interval - filteredData.date_of_birth.month_interval;
+                    filteredData.age_at_death = Math.floor(ageInMonths / 12);
+                    filteredData.age_at_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
+                    delete filteredData.date_of_death;
+                    delete filteredData.date_of_birth;
                     setTopLevel(filteredData);
                     setData(patientData);
+                    // Update the sidebar with patientData using the PatientSidebar component
+                    sidebarWriter(
+                        <PatientSidebar
+                            sidebar={patientData}
+                            setRows={setRows}
+                            setColumns={setColumns}
+                            setTitle={setTitle}
+                            ageAtDiagnosis={filteredData.age_at_diagnosis}
+                        />
+                    );
                 }
             } catch (error) {
                 console.error('Error fetching clinical patient data:', error);

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -54,6 +54,7 @@ function useClinicalPatientData(patientId, programId) {
                     filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
                     delete filteredData.date_of_death;
                     delete filteredData.date_of_birth;
+
                     setTopLevel(filteredData);
                     setData(patientData);
                     // Update the sidebar with patientData using the PatientSidebar component
@@ -63,7 +64,7 @@ function useClinicalPatientData(patientId, programId) {
                             setRows={setRows}
                             setColumns={setColumns}
                             setTitle={setTitle}
-                            ageAtDiagnosis={filteredData.age_at_diagnosis}
+                            ageAtFirstDiagnosis={filteredData.age_at_first_diagnosis}
                             resolution={filteredData.date_resolution}
                         />
                     );

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -51,7 +51,7 @@ function useClinicalPatientData(patientId, programId) {
                     const filteredData = filterNestedObject(patientData);
                     const ageInMonths = filteredData.date_of_death.month_interval - filteredData.date_of_birth.month_interval;
                     filteredData.age_at_death = Math.floor(ageInMonths / 12);
-                    filteredData.age_at_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
+                    filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
                     delete filteredData.date_of_death;
                     delete filteredData.date_of_birth;
                     setTopLevel(filteredData);
@@ -64,6 +64,7 @@ function useClinicalPatientData(patientId, programId) {
                             setColumns={setColumns}
                             setTitle={setTitle}
                             ageAtDiagnosis={filteredData.age_at_diagnosis}
+                            resolution={filteredData.date_resolution}
                         />
                     );
                 }

--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -33,6 +33,14 @@ function ClinicalView() {
                     // Make sure each row has an ID and a deceased status
                     patient.id = index;
                     patient.deceased = !!patient.date_of_death;
+                    if (patient.date_of_birth && patient.date_of_death) {
+                        const ageInMonths = patient.date_of_death.month_interval - patient.date_of_birth.month_interval;
+                        patient.date_of_death = Math.floor(ageInMonths / 12);
+                        patient.date_of_birth = Math.floor(-patient.date_of_birth.month_interval / 12);
+                    } else {
+                        delete patient.date_of_birth;
+                        delete patient.date_of_death;
+                    }
 
                     return patient;
                 }) || [];
@@ -53,8 +61,8 @@ function ClinicalView() {
         { field: 'submitter_donor_id', headerName: 'Donor ID', minWidth: 220, sortable: false },
         { field: 'sex_at_birth', headerName: 'Sex At Birth', minWidth: 170, sortable: false },
         { field: 'deceased', headerName: 'Deceased', minWidth: 170, sortable: false },
-        { field: 'date_of_birth', headerName: 'Date of Birth', minWidth: 200, sortable: false },
-        { field: 'date_of_death', headerName: 'Date of Death', minWidth: 220, sortable: false }
+        { field: 'date_of_birth', headerName: 'Age at First Diagnosis', minWidth: 200, sortable: false },
+        { field: 'date_of_death', headerName: 'Age at Death', minWidth: 220, sortable: false }
     ];
 
     const HandlePageChange = (newModel) => {

--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -37,6 +37,8 @@ function ClinicalView() {
                         const ageInMonths = patient.date_of_death.month_interval - patient.date_of_birth.month_interval;
                         patient.date_of_death = Math.floor(ageInMonths / 12);
                         patient.date_of_birth = Math.floor(-patient.date_of_birth.month_interval / 12);
+                    } else if (patient.date_of_birth && patient.deceased) {
+                        patient.date_of_birth = Math.floor(-patient.date_of_birth.month_interval / 12);
                     } else {
                         delete patient.date_of_birth;
                         delete patient.date_of_death;

--- a/src/views/clinicalGenomic/widgets/patientSidebar.js
+++ b/src/views/clinicalGenomic/widgets/patientSidebar.js
@@ -45,7 +45,8 @@ const SubHeaderTypography = styled(Typography)(({ theme, selected }) => ({
     paddingLeft: `1.5em`
 }));
 
-function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtDiagnosis }) {
+function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtDiagnosis, resolution }) {
+    console.log(resolution);
     const [initialHeader, setInitialHeader] = useState(true);
     const [expandedSections, setExpandedSections] = useState({});
     const [selected, setSelected] = useState('');
@@ -85,17 +86,14 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtDiag
 
             let value = key;
             if (key === 'date_of_diagnosis') {
-                // Calculate age at diagnosis using the difference between date of diagnosis and date of birth
-                // const ageAtDiagnosisMonths = obj['date_of_diagnosis'].month_interval - obj['date_of_birth'].month_interval;
-                // const yearsAtDiagnosis = Math.floor(ageAtDiagnosisMonths / 12);
-                // const remainingMonthsAtDiagnosis = ageAtDiagnosisMonths % 12;
-                // const formattedAgeAtDiagnosis = `${yearsAtDiagnosis}y${remainingMonthsAtDiagnosis}m`;
                 value = `Age at Diagnosis`;
             } else if (key.endsWith('_start_date')) {
                 value = `Diagnosis_to_${key}`;
+                startDate = key;
             } else if (key.endsWith('_end_date')) {
                 value = key.split('_end_date')[0];
                 value = `${value.trim()} Duration`;
+                endDate = key;
             } else if (key.startsWith('date_of_')) {
                 value = key.split('date_of_')[1];
                 value = `Diagnosis_to_${value.trim()}`;
@@ -305,7 +303,8 @@ PatientSidebar.propTypes = {
     setColumns: PropTypes.func.isRequired,
     setRows: PropTypes.func.isRequired,
     setTitle: PropTypes.func.isRequired,
-    ageAtDiagnosis: PropTypes.number
+    ageAtDiagnosis: PropTypes.number,
+    resolution: PropTypes.string
 };
 
 export default PatientSidebar;

--- a/src/views/clinicalGenomic/widgets/patientSidebar.js
+++ b/src/views/clinicalGenomic/widgets/patientSidebar.js
@@ -45,8 +45,7 @@ const SubHeaderTypography = styled(Typography)(({ theme, selected }) => ({
     paddingLeft: `1.5em`
 }));
 
-function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtDiagnosis, resolution }) {
-    console.log(resolution);
+function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtFirstDiagnosis, resolution }) {
     const [initialHeader, setInitialHeader] = useState(true);
     const [expandedSections, setExpandedSections] = useState({});
     const [selected, setSelected] = useState('');
@@ -128,7 +127,33 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtDiag
             const row = { id: index };
 
             filteredColumns.forEach((column) => {
-                if (Object.prototype.hasOwnProperty.call(obj[column.field], 'month_interval')) {
+                if (
+                    resolution === 'day' &&
+                    Object.prototype.hasOwnProperty.call(obj[column.field], 'day_interval') &&
+                    column.field !== 'date_of_diagnosis'
+                ) {
+                    if (column.field === 'endDate') {
+                        const ageInDays = obj[endDate].day_interval - obj[startDate].day_interval;
+                        const years = Math.floor(ageInDays / 365);
+                        const remainingDays = ageInDays % 365;
+                        const months = Math.floor(remainingDays / 30);
+                        const days = remainingDays % 30;
+
+                        row[column.field] = `${years}y ${months}m ${days}d`;
+                    } else {
+                        const ageInDays = obj[column.field].day_interval;
+                        const years = Math.floor(ageInDays / 365);
+                        const remainingDays = ageInDays % 365;
+                        const months = Math.floor(remainingDays / 30);
+                        const days = remainingDays % 30;
+
+                        row[column.field] = `${years}y ${months}m ${days}d`;
+                    }
+                } else if (
+                    resolution === 'month' &&
+                    Object.prototype.hasOwnProperty.call(obj[column.field], 'month_interval') &&
+                    column.field !== 'date_of_diagnosis'
+                ) {
                     if (column.field === endDate) {
                         const ageInMonths = obj[endDate].month_interval - obj[startDate].month_interval;
                         const years = Math.floor(ageInMonths / 12);
@@ -137,8 +162,6 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtDiag
                         // Format the years and months into a single string
                         const formattedAge = years > 0 ? `${years}y ${remainingMonths}m` : `${remainingMonths}m`;
                         row[column.field] = formattedAge;
-                    } else if (column.field === 'date_of_diagnosis') {
-                        row[column.field] = ageAtDiagnosis;
                     } else {
                         const ageInMonths = obj[column.field].month_interval;
                         const years = Math.floor(ageInMonths / 12);
@@ -148,6 +171,8 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtDiag
                         const formattedAge = years > 0 ? `${years}y ${remainingMonths}m` : `${remainingMonths}m`;
                         row[column.field] = formattedAge;
                     }
+                } else if (column.field === 'date_of_diagnosis') {
+                    row[column.field] = ageAtFirstDiagnosis + Math.floor(obj[column.field].month_interval / 12);
                 } else {
                     row[column.field] = obj[column.field];
                 }
@@ -303,7 +328,7 @@ PatientSidebar.propTypes = {
     setColumns: PropTypes.func.isRequired,
     setRows: PropTypes.func.isRequired,
     setTitle: PropTypes.func.isRequired,
-    ageAtDiagnosis: PropTypes.number,
+    ageAtFirstDiagnosis: PropTypes.number,
     resolution: PropTypes.string
 };
 


### PR DESCRIPTION
## Ticket(s)
[DIG-1415](https://candig.atlassian.net/browse/DIG-1415)

## Description
Update all fields to work with interval dates based on decisions in data-portal channel. All current pages (summary, search, patient info) have had changes to work with itnerval dates.

## Screenshots
![image](https://github.com/CanDIG/candig-data-portal/assets/37649170/3bff67b2-d10c-4532-8a28-f6a513fa0df6)
![image](https://github.com/CanDIG/candig-data-portal/assets/37649170/589f3e8e-9be6-44a3-b625-d7dd4123516d)
![image](https://github.com/CanDIG/candig-data-portal/assets/37649170/085e001e-f73b-4a7a-bbac-052e8b95293b)
![image](https://github.com/CanDIG/candig-data-portal/assets/37649170/032fefd4-4072-4109-aca5-4a6143fc8ffe)

## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [x] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-1415]: https://candig.atlassian.net/browse/DIG-1415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ