### PR TITLE
DIG-1524: Fix the completeness stats showing the wrong number

### DIFF
--- a/src/store/api.js
+++ b/src/store/api.js
@@ -312,7 +312,7 @@ export function fetchClinicalCompleteness() {
                     if (!(site.location.name in completeClinical)) {
                         completeClinical[site.location.name] = {};
                     }
-                    completeClinical[site.location.name][program.program_id] = program.metadata.summary_cases.total_cases;
+                    completeClinical[site.location.name][program.program_id] = program.metadata.summary_cases.completeCases;
                 }
             });
         });


### PR DESCRIPTION
## Ticket(s)

- [DIG-1524](https://candig.atlassian.net/browse/DIG-1524)

## Description

- Fixes the completeness stats counting total instead of complete

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-1524]: https://candig.atlassian.net/browse/DIG-1524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ