### PR TITLE
DIG-1523: Update NodeJS and round field level completeness 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG alpine_version
 ARG katsu_api_target_url
 
-FROM node:17.7.1-alpine${alpine_version} as build
+FROM node:21.7.0-alpine${alpine_version} as build
 
 LABEL Maintainer="CanDIG Project"
 LABEL "candigv2"="candig-data-portal"

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -49,11 +49,16 @@ function useClinicalPatientData(patientId, programId) {
                     const patientData = result[0].results || {};
                     // Filter patientData to create topLevel data excluding arrays, objects, and empty values
                     const filteredData = filterNestedObject(patientData);
-                    const ageInMonths = filteredData.date_of_death.month_interval - filteredData.date_of_birth.month_interval;
-                    filteredData.age_at_death = Math.floor(ageInMonths / 12);
-                    filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
-                    delete filteredData.date_of_death;
-                    delete filteredData.date_of_birth;
+                    if (filteredData.date_of_death && filteredData.date_of_death.month_interval) {
+                        const ageInMonths = filteredData.date_of_death.month_interval - filteredData.date_of_birth.month_interval;
+                        filteredData.age_at_death = Math.floor(ageInMonths / 12);
+                        filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
+                        delete filteredData.date_of_death;
+                        delete filteredData.date_of_birth;
+                    } else {
+                        filteredData.age_at_death = null;
+                        filteredData.age_at_first_diagnosis = null;
+                    }
 
                     setTopLevel(filteredData);
                     setData(patientData);

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -49,7 +49,7 @@ function useClinicalPatientData(patientId, programId) {
                     const patientData = result[0].results || {};
                     // Filter patientData to create topLevel data excluding arrays, objects, and empty values
                     const filteredData = filterNestedObject(patientData);
-                    if (filteredData.date_of_death && filteredData.date_of_death.month_interval) {
+                    if (filteredData?.date_of_death?.month_interval && filteredData?.date_of_birth?.month_interval) {
                         const ageInMonths = filteredData.date_of_death.month_interval - filteredData.date_of_birth.month_interval;
                         filteredData.age_at_death = Math.floor(ageInMonths / 12);
                         filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);

--- a/src/views/clinicalGenomic/widgets/patientSidebar.js
+++ b/src/views/clinicalGenomic/widgets/patientSidebar.js
@@ -219,6 +219,8 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtFirs
                 handleHeaderClick(firstHeaderKey, sidebar, null);
             }
         }
+        // Ignore deps on the next line as it appears to prevent this component from working otherwise
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [initialHeader, sidebar]);
 
     function createSubSidebarHeaders(array = [], depth = 0, hasChildren = false) {

--- a/src/views/completeness/completeness.jsx
+++ b/src/views/completeness/completeness.jsx
@@ -8,7 +8,7 @@ import SmallCountCard from 'ui-component/cards/SmallCountCard';
 import CustomOfflineChart from 'views/summary/CustomOfflineChart';
 
 // project imports
-import { fetchClinicalCompleteness, fetchFederation, fetchGenomicCompleteness } from 'store/api';
+import { fetchClinicalCompleteness, fetchGenomicCompleteness } from 'store/api';
 
 // assets
 import { CheckCircleOutline, WarningAmber, Person } from '@mui/icons-material';

--- a/src/views/completeness/fieldLevelCompletenessGraph.jsx
+++ b/src/views/completeness/fieldLevelCompletenessGraph.jsx
@@ -119,7 +119,7 @@ function FieldLevelCompletenessGraph(props) {
     const series = Object.keys(fields)
         .map((field) => {
             const pct = fields[field].total === 0 ? 0 : 1 - fields[field].missing / fields[field].total;
-            return [field, pct * 100];
+            return [field, Math.round(pct * 100)];
         })
         .sort((a, b) => a[1] - b[1]);
     const highChartSettings = {


### PR DESCRIPTION
## Ticket(s)

- [DIG-1523](https://candig.atlassian.net/browse/DIG-1523)

## Description

- Update NodeJS to latest 21.7.0 which incorporates updated npm version 10.5.0
- Round field level completeness for neater display

## Screenshots (if appropriate)

Uploaded data is from the small synthetic dataset: https://github.com/CanDIG/mohccn-synthetic-data

### Before PR

<img width="719" alt="Screenshot 2024-03-06 at 5 18 55 PM" src="https://github.com/CanDIG/candig-data-portal/assets/13007987/7837952a-becd-400a-a877-b5ef31e5ec12">

### After PR

<img width="715" alt="Screenshot 2024-03-08 at 10 35 38 AM" src="https://github.com/CanDIG/candig-data-portal/assets/13007987/ff97a06e-e1a8-4f19-bae6-f69f5a61a458">

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-1523]: https://candig.atlassian.net/browse/DIG-1523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ