### PR TITLE
Bugfix/missing dob

### DIFF
--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -49,11 +49,16 @@ function useClinicalPatientData(patientId, programId) {
                     const patientData = result[0].results || {};
                     // Filter patientData to create topLevel data excluding arrays, objects, and empty values
                     const filteredData = filterNestedObject(patientData);
-                    const ageInMonths = filteredData.date_of_death.month_interval - filteredData.date_of_birth.month_interval;
-                    filteredData.age_at_death = Math.floor(ageInMonths / 12);
-                    filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
-                    delete filteredData.date_of_death;
-                    delete filteredData.date_of_birth;
+                    if (filteredData.date_of_death && filteredData.date_of_death.month_interval) {
+                        const ageInMonths = filteredData.date_of_death.month_interval - filteredData.date_of_birth.month_interval;
+                        filteredData.age_at_death = Math.floor(ageInMonths / 12);
+                        filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
+                        delete filteredData.date_of_death;
+                        delete filteredData.date_of_birth;
+                    } else {
+                        filteredData.age_at_death = null;
+                        filteredData.age_at_first_diagnosis = null;
+                    }
 
                     setTopLevel(filteredData);
                     setData(patientData);

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -49,7 +49,7 @@ function useClinicalPatientData(patientId, programId) {
                     const patientData = result[0].results || {};
                     // Filter patientData to create topLevel data excluding arrays, objects, and empty values
                     const filteredData = filterNestedObject(patientData);
-                    if (filteredData.date_of_death && filteredData.date_of_death.month_interval) {
+                    if (filteredData?.date_of_death?.month_interval && filteredData?.date_of_birth?.month_interval) {
                         const ageInMonths = filteredData.date_of_death.month_interval - filteredData.date_of_birth.month_interval;
                         filteredData.age_at_death = Math.floor(ageInMonths / 12);
                         filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);

--- a/src/views/clinicalGenomic/widgets/patientSidebar.js
+++ b/src/views/clinicalGenomic/widgets/patientSidebar.js
@@ -219,6 +219,8 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtFirs
                 handleHeaderClick(firstHeaderKey, sidebar, null);
             }
         }
+        // Ignore deps on the next line as it appears to prevent this component from working otherwise
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [initialHeader, sidebar]);
 
     function createSubSidebarHeaders(array = [], depth = 0, hasChildren = false) {

--- a/src/views/completeness/completeness.jsx
+++ b/src/views/completeness/completeness.jsx
@@ -8,7 +8,7 @@ import SmallCountCard from 'ui-component/cards/SmallCountCard';
 import CustomOfflineChart from 'views/summary/CustomOfflineChart';
 
 // project imports
-import { fetchClinicalCompleteness, fetchFederation, fetchGenomicCompleteness } from 'store/api';
+import { fetchClinicalCompleteness, fetchGenomicCompleteness } from 'store/api';
 
 // assets
 import { CheckCircleOutline, WarningAmber, Person } from '@mui/icons-material';


### PR DESCRIPTION
## Description

- Fix a bug where a missing date of birth causes the patient info page to whitescreen

## Expected Behaviour

- You can go to the patient info page with a patient loaded who is missing a date of birth.

## Screenshots (if appropriate)

### Before PR

![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/db41c8dd-5f8c-4fbd-85bb-be47bd31a21e)

### After PR

![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/2830bae8-688b-46b3-b552-c636db41256e)

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
