### PR TITLE
Show arrays, strings, numbers, and applicable objects in patient info tables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG alpine_version
 ARG katsu_api_target_url
 
-FROM node:17.7.1-alpine${alpine_version} as build
+FROM node:21.7.0-alpine${alpine_version} as build
 
 LABEL Maintainer="CanDIG Project"
 LABEL "candigv2"="candig-data-portal"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG alpine_version
 ARG katsu_api_target_url
 
-FROM node:21.7.0-alpine${alpine_version} as build
+FROM node:17.7.1-alpine${alpine_version} as build
 
 LABEL Maintainer="CanDIG Project"
 LABEL "candigv2"="candig-data-portal"

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -49,11 +49,16 @@ function useClinicalPatientData(patientId, programId) {
                     const patientData = result[0].results || {};
                     // Filter patientData to create topLevel data excluding arrays, objects, and empty values
                     const filteredData = filterNestedObject(patientData);
-                    const ageInMonths = filteredData.date_of_death.month_interval - filteredData.date_of_birth.month_interval;
-                    filteredData.age_at_death = Math.floor(ageInMonths / 12);
-                    filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
-                    delete filteredData.date_of_death;
-                    delete filteredData.date_of_birth;
+                    if (filteredData.date_of_death && filteredData.date_of_death.month_interval) {
+                        const ageInMonths = filteredData.date_of_death.month_interval - filteredData.date_of_birth.month_interval;
+                        filteredData.age_at_death = Math.floor(ageInMonths / 12);
+                        filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
+                        delete filteredData.date_of_death;
+                        delete filteredData.date_of_birth;
+                    } else {
+                        filteredData.age_at_death = null;
+                        filteredData.age_at_first_diagnosis = null;
+                    }
 
                     setTopLevel(filteredData);
                     setData(patientData);

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -30,7 +30,8 @@ function useClinicalPatientData(patientId, programId) {
                         value === '' ||
                         key === ''
                     ) &&
-                    (!(typeof obj[key] === 'object') || (typeof obj[key] === 'object' && 'month_interval' in obj[key])) // Accept interval date objects remove all other objects
+                    (!(typeof value === 'object') ||
+                        (typeof value === 'object' && ('month_interval' in value || value.every((item) => typeof item === 'string')))) // Accept interval date objects remove all other objects
             )
         );
     }

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -49,7 +49,7 @@ function useClinicalPatientData(patientId, programId) {
                     const patientData = result[0].results || {};
                     // Filter patientData to create topLevel data excluding arrays, objects, and empty values
                     const filteredData = filterNestedObject(patientData);
-                    if (filteredData.date_of_death && filteredData.date_of_death.month_interval) {
+                    if (filteredData?.date_of_death?.month_interval && filteredData?.date_of_birth?.month_interval) {
                         const ageInMonths = filteredData.date_of_death.month_interval - filteredData.date_of_birth.month_interval;
                         filteredData.age_at_death = Math.floor(ageInMonths / 12);
                         filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -22,17 +22,25 @@ function useClinicalPatientData(patientId, programId) {
 
     function filterNestedObject(obj) {
         return Object.fromEntries(
-            Object.entries(obj).filter(
-                ([key, value]) =>
-                    value !== null &&
-                    !(
-                        (Array.isArray(value) && value.length === 0) || // Exclude empty arrays
-                        value === '' ||
-                        key === ''
-                    ) &&
-                    (!(typeof value === 'object') ||
-                        (typeof value === 'object' && ('month_interval' in value || value.every((item) => typeof item === 'string')))) // Accept interval date objects remove all other objects
-            )
+            Object.entries(obj)
+                .filter(
+                    ([key, value]) =>
+                        value !== null &&
+                        !(
+                            (Array.isArray(value) && value.length === 0) || // Exclude empty arrays
+                            value === '' ||
+                            key === ''
+                        ) &&
+                        (!(typeof value === 'object') ||
+                            (typeof value === 'object' && ('month_interval' in value || value.every((item) => typeof item === 'string'))))
+                )
+                .map(([key, value]) => {
+                    if (Array.isArray(value)) {
+                        return [key, value.join(', ')];
+                    }
+
+                    return [key, value];
+                })
         );
     }
 
@@ -56,9 +64,23 @@ function useClinicalPatientData(patientId, programId) {
                         filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
                         delete filteredData.date_of_death;
                         delete filteredData.date_of_birth;
+                    } else if (filteredData?.date_of_birth?.month_interval && !filteredData?.date_of_death?.month_interval) {
+                        filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
+                        delete filteredData.date_of_birth;
                     } else {
                         filteredData.age_at_death = null;
                         filteredData.age_at_first_diagnosis = null;
+                    }
+
+                    if (filteredData.date_alive_after_lost_to_followup.day_interval) {
+                        const ageInDays = filteredData.date_alive_after_lost_to_followup.day_interval;
+                        const years = Math.floor(ageInDays / 365);
+                        const remainingDays = ageInDays % 365;
+                        const months = Math.floor(remainingDays / 30);
+                        const days = remainingDays % 30;
+
+                        filteredData.date_last_known_alive_since_diagnosis = `${years}y ${months}m ${days}d`;
+                        delete filteredData.date_alive_after_lost_to_followup;
                     }
 
                     setTopLevel(filteredData);

--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -33,11 +33,11 @@ function ClinicalView() {
                     // Make sure each row has an ID and a deceased status
                     patient.id = index;
                     patient.deceased = !!patient.date_of_death;
-                    if (patient.date_of_birth && patient.date_of_death) {
+                    if (patient?.date_of_birth?.month_interval && patient?.date_of_death?.month_interval) {
                         const ageInMonths = patient.date_of_death.month_interval - patient.date_of_birth.month_interval;
                         patient.date_of_death = Math.floor(ageInMonths / 12);
                         patient.date_of_birth = Math.floor(-patient.date_of_birth.month_interval / 12);
-                    } else if (patient.date_of_birth && patient.deceased) {
+                    } else if (patient?.date_of_birth?.month_interval && !patient?.date_of_death?.month_interval) {
                         patient.date_of_birth = Math.floor(-patient.date_of_birth.month_interval / 12);
                     } else {
                         delete patient.date_of_birth;

--- a/src/views/clinicalGenomic/widgets/patientSidebar.js
+++ b/src/views/clinicalGenomic/widgets/patientSidebar.js
@@ -75,13 +75,19 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtFirs
         let startDate;
         let endDate;
         const columns = uniqueKeys.map((key) => {
-            const hasNonEmptyValue = array.some(
-                (obj) =>
+            const hasNonEmptyValue = array.some((obj) => {
+                if (Array.isArray(obj[key])) {
+                    // Include arrays of strings
+                    return obj[key].length > 0 && obj[key].every((item) => typeof item === 'string');
+                }
+
+                return (
                     obj[key] !== null &&
                     obj[key] !== undefined &&
                     obj[key] !== '' &&
                     (!(typeof obj[key] === 'object') || (typeof obj[key] === 'object' && 'month_interval' in obj[key]))
-            );
+                );
+            });
 
             let value = key;
             if (key === 'date_of_diagnosis') {

--- a/src/views/clinicalGenomic/widgets/patientSidebar.js
+++ b/src/views/clinicalGenomic/widgets/patientSidebar.js
@@ -219,6 +219,8 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtFirs
                 handleHeaderClick(firstHeaderKey, sidebar, null);
             }
         }
+        // Ignore deps on the next line as it appears to prevent this component from working otherwise
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [initialHeader, sidebar]);
 
     function createSubSidebarHeaders(array = [], depth = 0, hasChildren = false) {

--- a/src/views/clinicalGenomic/widgets/patientSidebar.js
+++ b/src/views/clinicalGenomic/widgets/patientSidebar.js
@@ -133,11 +133,8 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtFirs
             const row = { id: index };
 
             filteredColumns.forEach((column) => {
-                if (
-                    resolution === 'day' &&
-                    Object.prototype.hasOwnProperty.call(obj[column.field], 'day_interval') &&
-                    column.field !== 'date_of_diagnosis'
-                ) {
+                // eslint-disable-next-line no-prototype-builtins
+                if (resolution === 'day' && obj[column.field]?.hasOwnProperty('day_interval') && column.field !== 'date_of_diagnosis') {
                     if (column.field === 'endDate') {
                         const ageInDays = obj[endDate].day_interval - obj[startDate].day_interval;
                         const years = Math.floor(ageInDays / 365);
@@ -157,7 +154,8 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtFirs
                     }
                 } else if (
                     resolution === 'month' &&
-                    Object.prototype.hasOwnProperty.call(obj[column.field], 'month_interval') &&
+                    // eslint-disable-next-line no-prototype-builtins
+                    obj[column.field]?.hasOwnProperty('day_interval') &&
                     column.field !== 'date_of_diagnosis'
                 ) {
                     if (column.field === endDate) {
@@ -180,7 +178,8 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtFirs
                 } else if (column.field === 'date_of_diagnosis') {
                     row[column.field] = ageAtFirstDiagnosis + Math.floor(obj[column.field].month_interval / 12);
                 } else {
-                    row[column.field] = obj[column.field];
+                    console.log(obj[column.field]);
+                    row[column.field] = Array.isArray(obj[column.field]) ? obj[column.field].join(', ') : obj[column.field]; // Add spaces to arrays
                 }
             });
 

--- a/src/views/completeness/completeness.jsx
+++ b/src/views/completeness/completeness.jsx
@@ -8,7 +8,7 @@ import SmallCountCard from 'ui-component/cards/SmallCountCard';
 import CustomOfflineChart from 'views/summary/CustomOfflineChart';
 
 // project imports
-import { fetchClinicalCompleteness, fetchFederation, fetchGenomicCompleteness } from 'store/api';
+import { fetchClinicalCompleteness, fetchGenomicCompleteness } from 'store/api';
 
 // assets
 import { CheckCircleOutline, WarningAmber, Person } from '@mui/icons-material';

--- a/src/views/completeness/fieldLevelCompletenessGraph.jsx
+++ b/src/views/completeness/fieldLevelCompletenessGraph.jsx
@@ -119,7 +119,7 @@ function FieldLevelCompletenessGraph(props) {
     const series = Object.keys(fields)
         .map((field) => {
             const pct = fields[field].total === 0 ? 0 : 1 - fields[field].missing / fields[field].total;
-            return [field, pct * 100];
+            return [field, Math.round(pct * 100)];
         })
         .sort((a, b) => a[1] - b[1]);
     const highChartSettings = {


### PR DESCRIPTION
## Ticket(s)
[DIG-1531](https://candig.atlassian.net/browse/DIG-1531)

## Description
Arrays were being filtered out from the tables based on an assumption that all of our arrays contained objects. Arrays are now shown in the table if they contain strings. This allows for patient info to show the treatment type in the treatment table.

## Expected Behaviour
- Treatment type shown in treatment table of patient info page

## Screenshots
### After PR
![screencapture-candig-docker-internal-5080-patientView-2024-03-12-13_43_48](https://github.com/CanDIG/candig-data-portal/assets/37649170/c1eb941f-eba3-4f0d-bfef-8fb118f37d5e)

## Types of Change(s)
-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [x] My change requires a change to the runbook visuals
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-1531]: https://candig.atlassian.net/browse/DIG-1531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ