### PR TITLE
Fix clinical completeness graph

### DIFF
--- a/src/store/api.js
+++ b/src/store/api.js
@@ -312,7 +312,7 @@ export function fetchClinicalCompleteness() {
                     if (!(site.location.name in completeClinical)) {
                         completeClinical[site.location.name] = {};
                     }
-                    completeClinical[site.location.name][program.program_id] = program.metadata.summary_cases.completeCases;
+                    completeClinical[site.location.name][program.program_id] = program.metadata.summary_cases.complete_cases;
                 }
             });
         });

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -72,7 +72,7 @@ function useClinicalPatientData(patientId, programId) {
                         filteredData.age_at_first_diagnosis = null;
                     }
 
-                    if (filteredData.date_alive_after_lost_to_followup.day_interval) {
+                    if (filteredData?.date_alive_after_lost_to_followup?.day_interval) {
                         const ageInDays = filteredData.date_alive_after_lost_to_followup.day_interval;
                         const years = Math.floor(ageInDays / 365);
                         const remainingDays = ageInDays % 365;

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -81,16 +81,11 @@ function useClinicalPatientData(patientId, programId) {
                             const ageInDays = filteredData.date_of_death.day_interval - filteredData.date_of_birth.day_interval;
                             filteredData.age_at_death = Math.floor(ageInDays / 365);
                             filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.day_interval / 365);
-                            delete filteredData.date_of_death;
-                            delete filteredData.date_of_birth;
                         } else if (filteredData?.date_of_birth?.day_interval && !filteredData?.date_of_death?.day_interval) {
                             filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.day_interval / 365);
-                            delete filteredData.date_of_birth;
-                            delete filteredData.date_of_death;
-                        } else {
-                            delete filteredData.date_of_death;
-                            delete filteredData.date_of_birth;
                         }
+                        delete filteredData.date_of_death;
+                        delete filteredData.date_of_birth;
 
                         if (filteredData?.date_alive_after_lost_to_followup?.day_interval) {
                             const ageInDays = filteredData.date_alive_after_lost_to_followup.day_interval;

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -58,29 +58,58 @@ function useClinicalPatientData(patientId, programId) {
                     const patientData = result[0].results || {};
                     // Filter patientData to create topLevel data excluding arrays, objects, and empty values
                     const filteredData = filterNestedObject(patientData);
-                    if (filteredData?.date_of_death?.month_interval && filteredData?.date_of_birth?.month_interval) {
-                        const ageInMonths = filteredData.date_of_death.month_interval - filteredData.date_of_birth.month_interval;
-                        filteredData.age_at_death = Math.floor(ageInMonths / 12);
-                        filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
-                        delete filteredData.date_of_death;
-                        delete filteredData.date_of_birth;
-                    } else if (filteredData?.date_of_birth?.month_interval && !filteredData?.date_of_death?.month_interval) {
-                        filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
-                        delete filteredData.date_of_birth;
+                    if (filteredData?.date_resolution === 'month') {
+                        if (filteredData?.date_of_death?.month_interval && filteredData?.date_of_birth?.month_interval) {
+                            const ageInMonths = filteredData.date_of_death.month_interval - filteredData.date_of_birth.month_interval;
+                            filteredData.age_at_death = Math.floor(ageInMonths / 12);
+                            filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
+                            delete filteredData.date_of_death;
+                            delete filteredData.date_of_birth;
+                        } else if (filteredData?.date_of_birth?.month_interval && !filteredData?.date_of_death?.month_interval) {
+                            filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
+                            delete filteredData.date_of_birth;
+                            delete filteredData.date_of_death;
+                        } else {
+                            delete filteredData.date_of_death;
+                            delete filteredData.date_of_birth;
+                        }
+
+                        if (filteredData?.date_alive_after_lost_to_followup?.month_interval) {
+                            const ageInMonths = filteredData.date_alive_after_lost_to_followup.month_interval;
+                            const years = Math.floor(ageInMonths / 12);
+                            const remainingMonths = ageInMonths % 12;
+                            filteredData.time_from_diagnosis_to_last_followup = `${years}y ${remainingMonths}m`;
+                            delete filteredData.date_alive_after_lost_to_followup;
+                        }
+                    } else if (filteredData?.date_resolution === 'day') {
+                        if (filteredData?.date_of_death?.day_interval && filteredData?.date_of_birth?.day_interval) {
+                            const ageInDays = filteredData.date_of_death.day_interval - filteredData.date_of_birth.day_interval;
+                            filteredData.age_at_death = Math.floor(ageInDays / 365);
+                            filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.day_interval / 365);
+                            delete filteredData.date_of_death;
+                            delete filteredData.date_of_birth;
+                        } else if (filteredData?.date_of_birth?.day_interval && !filteredData?.date_of_death?.day_interval) {
+                            filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.day_interval / 365);
+                            delete filteredData.date_of_birth;
+                            delete filteredData.date_of_death;
+                        } else {
+                            delete filteredData.date_of_death;
+                            delete filteredData.date_of_birth;
+                        }
+
+                        if (filteredData?.date_alive_after_lost_to_followup?.day_interval) {
+                            const ageInDays = filteredData.date_alive_after_lost_to_followup.day_interval;
+                            const years = Math.floor(ageInDays / 365);
+                            const remainingDays = ageInDays % 365;
+                            const months = Math.floor(remainingDays / 30);
+                            const days = remainingDays % 30;
+
+                            filteredData.time_from_diagnosis_to_last_followup = `${years}y ${months}m ${days}d`;
+                            delete filteredData.date_alive_after_lost_to_followup;
+                        }
                     } else {
-                        filteredData.age_at_death = null;
+                        delete filteredData.date_of_death;
                         filteredData.age_at_first_diagnosis = null;
-                    }
-
-                    if (filteredData?.date_alive_after_lost_to_followup?.day_interval) {
-                        const ageInDays = filteredData.date_alive_after_lost_to_followup.day_interval;
-                        const years = Math.floor(ageInDays / 365);
-                        const remainingDays = ageInDays % 365;
-                        const months = Math.floor(remainingDays / 30);
-                        const days = remainingDays % 30;
-
-                        filteredData.date_last_known_alive_since_diagnosis = `${years}y ${months}m ${days}d`;
-                        delete filteredData.date_alive_after_lost_to_followup;
                     }
 
                     setTopLevel(filteredData);

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -63,16 +63,11 @@ function useClinicalPatientData(patientId, programId) {
                             const ageInMonths = filteredData.date_of_death.month_interval - filteredData.date_of_birth.month_interval;
                             filteredData.age_at_death = Math.floor(ageInMonths / 12);
                             filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
-                            delete filteredData.date_of_death;
-                            delete filteredData.date_of_birth;
                         } else if (filteredData?.date_of_birth?.month_interval && !filteredData?.date_of_death?.month_interval) {
                             filteredData.age_at_first_diagnosis = Math.floor(-filteredData.date_of_birth.month_interval / 12);
-                            delete filteredData.date_of_birth;
-                            delete filteredData.date_of_death;
-                        } else {
-                            delete filteredData.date_of_death;
-                            delete filteredData.date_of_birth;
                         }
+                        delete filteredData.date_of_death;
+                        delete filteredData.date_of_birth;
 
                         if (filteredData?.date_alive_after_lost_to_followup?.month_interval) {
                             const ageInMonths = filteredData.date_alive_after_lost_to_followup.month_interval;

--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -33,12 +33,28 @@ function ClinicalView() {
                     // Make sure each row has an ID and a deceased status
                     patient.id = index;
                     patient.deceased = !!patient.date_of_death;
-                    if (patient?.date_of_birth?.month_interval && patient?.date_of_death?.month_interval) {
-                        const ageInMonths = patient.date_of_death.month_interval - patient.date_of_birth.month_interval;
-                        patient.date_of_death = Math.floor(ageInMonths / 12);
-                        patient.date_of_birth = Math.floor(-patient.date_of_birth.month_interval / 12);
-                    } else if (patient?.date_of_birth?.month_interval && !patient?.date_of_death?.month_interval) {
-                        patient.date_of_birth = Math.floor(-patient.date_of_birth.month_interval / 12);
+                    if (patient?.date_resolution === 'month') {
+                        if (patient?.date_of_birth?.month_interval && patient?.date_of_death?.month_interval) {
+                            const ageInMonths = patient.date_of_death.month_interval - patient.date_of_birth.month_interval;
+                            patient.date_of_death = Math.floor(ageInMonths / 12);
+                            patient.date_of_birth = Math.floor(-patient.date_of_birth.month_interval / 12);
+                        } else if (patient?.date_of_birth?.month_interval && !patient?.date_of_death?.month_interval) {
+                            patient.date_of_birth = Math.floor(-patient.date_of_birth.month_interval / 12);
+                        } else {
+                            delete patient.date_of_birth;
+                            delete patient.date_of_death;
+                        }
+                    } else if (patient?.date_resolution === 'day') {
+                        if (patient?.date_of_death?.day_interval && patient?.date_of_birth?.day_interval) {
+                            const ageInDays = patient.date_of_death.day_interval - patient.date_of_birth.day_interval;
+                            patient.date_of_death = Math.floor(ageInDays / 365);
+                            patient.date_of_birth = Math.floor(-patient.date_of_birth.day_interval / 365);
+                        } else if (patient?.date_of_birth?.day_interval && !patient?.date_of_death?.day_interval) {
+                            patient.date_of_birth = Math.floor(-patient.date_of_birth.day_interval / 365);
+                        } else {
+                            delete patient.date_of_birth;
+                            delete patient.date_of_death;
+                        }
                     } else {
                         delete patient.date_of_birth;
                         delete patient.date_of_death;


### PR DESCRIPTION
## Ticket(s)

- DIG-1524

## Description

- based off of Courtney's prior fix but the specific change here is to `src/store/api.js` to correct a variable name so that complete clinical cases are being properly passed into the complete clinical cases graph
- Relies on the changes in https://github.com/CanDIG/candigv2-query/pull/25

## Expected Behaviour

- the complete clinical graph shows the actual number of complete cases

## Related Issues (if appropriate)

-

## Screenshots (if appropriate)

### Before PR



### After PR

![Screenshot 2024-03-15 at 5 24 53 PM](https://github.com/CanDIG/candig-data-portal/assets/13007987/4a5fdb58-0d0d-4dc8-b42e-8474dc63541f)

## To do/Tickets to be made before merging branch

- related query change as stated above https://github.com/CanDIG/candigv2-query/pull/25/files

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
