### PR TITLE
DIG-1372: Query can assemble discovery queries

### DIFF
--- a/src/store/api.js
+++ b/src/store/api.js
@@ -215,6 +215,34 @@ export function searchVariantByGene(geneName) {
         });
 }
 
+export function queryDiscovery(parameters, abort) {
+    const payload = {
+        ...parameters
+    };
+
+    return fetch(`${federation}/fanout`, {
+        method: 'post',
+        signal: abort,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            method: 'GET',
+            path: 'discovery/query',
+            service: 'query',
+            payload
+        })
+    })
+        .then((response) => {
+            if (response.ok) {
+                return response.json();
+            }
+            return [];
+        })
+        .catch((error) => {
+            console.log('Error:', error);
+            return 'error';
+        });
+}
+
 export function query(parameters, abort) {
     const payload = {
         ...parameters

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -3,39 +3,7 @@ import { useEffect, useState } from 'react';
 import { trackPromise } from 'react-promise-tracker';
 
 import { useSearchResultsWriterContext, useSearchQueryReaderContext } from '../SearchResultsContext';
-import { fetchFederationStat, fetchFederation, query } from 'store/api';
-
-// This will grab all of the results from a query, but continue to consume all "next" from the pagination until we are complete
-// This defeats the purpose of pagination, and is frowned upon, but... deadlines
-/* function ConsumeAllPages(url, resultConsumer, service = 'katsu') {
-    const parsedData = {};
-    const RecursiveQuery = (data, idx) => {
-        let nextQuery = null;
-
-        // Collect all donor IDs
-        data.forEach((loc) => {
-            if (!(loc.location.name in parsedData)) {
-                parsedData[loc.location.name] = [];
-            }
-
-            if (loc.results?.next) {
-                nextQuery = `${url}${url.includes('?') ? '&' : '?'}page=${idx + 1}`;
-            }
-
-            if (loc.results?.results) {
-                parsedData[loc.location.name] = parsedData[loc.location.name].concat(loc.results.results.map(resultConsumer));
-            }
-        });
-
-        if (nextQuery) {
-            return fetchFederation(nextQuery, service).then((newData) => RecursiveQuery(newData, idx + 1));
-        }
-
-        return new Promise((resolve) => resolve(parsedData));
-    };
-
-    return fetchFederation(url, service).then((data) => RecursiveQuery(data, 1));
-} */
+import { fetchFederationStat, fetchFederation, query, queryDiscovery } from 'store/api';
 
 // NB: I assign to lastPromise a bunch to keep track of whether or not we need to chain promises together
 // However, the linter really dislikes this, and assumes I want to put everything inside one useEffect?
@@ -78,7 +46,7 @@ function SearchHandler() {
         const CollateSummary = (data, statName) => {
             const summaryStat = {};
             data.forEach((site) => {
-                const thisStat = site.results?.summary?.[statName];
+                const thisStat = site.results?.[statName];
                 if (!thisStat) {
                     return;
                 }
@@ -95,67 +63,77 @@ function SearchHandler() {
         };
 
         const donorQueryPromise = () =>
-            query(reader.query, controller.signal).then((data) => {
-                if (reader.filter?.node) {
-                    data = data.filter((site) => !reader.filter.node.includes(site.location.name));
-                }
-
-                // We need to collate the discovery statistics from each site
-                const discoveryCounts = {
-                    diagnosis_age_count: CollateSummary(data, 'age_at_diagnosis'),
-                    treatment_type_count: CollateSummary(data, 'treatment_type_count'),
-                    cancer_type_count: CollateSummary(data, 'cancer_type_count'),
-                    patients_per_cohort: {},
-
-                    // Below is test data
-                    full_clinical_data: {
-                        BCGSC: {
-                            POG: 30
-                        },
-                        UHN: {
-                            POG: 14,
-                            Inspire: 20,
-                            Biocan: 20,
-                            Biodiva: 10
-                        },
-                        C3G: {
-                            MOCK: 30
-                        }
-                    },
-                    full_genomic_data: {
-                        BCGSC: {
-                            POG: 10
-                        },
-                        UHN: {
-                            POG: 4,
-                            Inspire: 10,
-                            Biocan: 12,
-                            Biodiva: 12
-                        },
-                        C3G: {
-                            MOCK: 3
-                        }
+            queryDiscovery(reader.query, controller.signal)
+                .then((data) => {
+                    if (reader.filter?.node) {
+                        data = data.filter((site) => !reader.filter.node.includes(site.location.name));
                     }
-                };
 
-                // Reorder the data, and fill out the patients per cohort
-                const clinicalData = {};
-                data.forEach((site) => {
-                    discoveryCounts.patients_per_cohort[site.location.name] = site.results?.summary?.patients_per_cohort;
-                    clinicalData[site.location.name] = site?.results;
-                });
+                    const discoveryCounts = {
+                        diagnosis_age_count: CollateSummary(data, 'age_at_diagnosis'),
+                        treatment_type_count: CollateSummary(data, 'treatment_type_count'),
+                        cancer_type_count: CollateSummary(data, 'cancer_type_count'),
+                        patients_per_cohort: {},
 
-                const genomicData = data
-                    .map((site) =>
-                        site.results.genomic?.map((caseData) => {
-                            caseData.location = site.location;
-                            return caseData;
-                        })
-                    )
-                    .flat(1);
+                        // Below is test data
+                        full_clinical_data: {
+                            BCGSC: {
+                                POG: 30
+                            },
+                            UHN: {
+                                POG: 14,
+                                Inspire: 20,
+                                Biocan: 20,
+                                Biodiva: 10
+                            },
+                            C3G: {
+                                MOCK: 30
+                            }
+                        },
+                        full_genomic_data: {
+                            BCGSC: {
+                                POG: 10
+                            },
+                            UHN: {
+                                POG: 4,
+                                Inspire: 10,
+                                Biocan: 12,
+                                Biodiva: 12
+                            },
+                            C3G: {
+                                MOCK: 3
+                            }
+                        }
+                    };
+                    data.forEach((site) => {
+                        discoveryCounts.patients_per_cohort[site.location.name] = site.results?.patients_per_cohort;
+                    });
 
-                writer((old) => ({ ...old, clinical: clinicalData, counts: discoveryCounts, genomic: genomicData, loading: false }));
-            });
+                    writer((old) => ({ ...old, counts: discoveryCounts }));
+                })
+                .then(() =>
+                    query(reader.query, controller.signal).then((data) => {
+                        if (reader.filter?.node) {
+                            data = data.filter((site) => !reader.filter.node.includes(site.location.name));
+                        }
+                        // Reorder the data, and fill out the patients per cohort
+                        const clinicalData = {};
+                        data.forEach((site) => {
+                            clinicalData[site.location.name] = site?.results;
+                        });
+
+                        const genomicData = data
+                            .map((site) =>
+                                site.results.genomic?.map((caseData) => {
+                                    caseData.location = site.location;
+                                    return caseData;
+                                })
+                            )
+                            .flat(1);
+
+                        writer((old) => ({ ...old, clinical: clinicalData, genomic: genomicData, loading: false }));
+                    })
+                );
 
         if (lastPromise === null) {
             lastPromise = donorQueryPromise();

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -73,37 +73,7 @@ function SearchHandler() {
                         diagnosis_age_count: CollateSummary(data, 'age_at_diagnosis'),
                         treatment_type_count: CollateSummary(data, 'treatment_type_count'),
                         cancer_type_count: CollateSummary(data, 'cancer_type_count'),
-                        patients_per_cohort: {},
-
-                        // Below is test data
-                        full_clinical_data: {
-                            BCGSC: {
-                                POG: 30
-                            },
-                            UHN: {
-                                POG: 14,
-                                Inspire: 20,
-                                Biocan: 20,
-                                Biodiva: 10
-                            },
-                            C3G: {
-                                MOCK: 30
-                            }
-                        },
-                        full_genomic_data: {
-                            BCGSC: {
-                                POG: 10
-                            },
-                            UHN: {
-                                POG: 4,
-                                Inspire: 10,
-                                Biocan: 12,
-                                Biodiva: 12
-                            },
-                            C3G: {
-                                MOCK: 3
-                            }
-                        }
+                        patients_per_cohort: {}
                     };
                     data.forEach((site) => {
                         discoveryCounts.patients_per_cohort[site.location.name] = site.results?.patients_per_cohort;

--- a/src/views/clinicalGenomic/widgets/patientCounts.js
+++ b/src/views/clinicalGenomic/widgets/patientCounts.js
@@ -24,8 +24,6 @@ const Root = styled('div')(({ theme }) => ({
 function PatientCounts() {
     const context = useSearchResultsReaderContext();
     const sites = context?.federation;
-    const searchResults = context?.clinical;
-    const filters = useSearchQueryReaderContext()?.filter;
     const programs = context?.programs;
 
     // Generate the map of site->cohort->numbers
@@ -33,40 +31,13 @@ function PatientCounts() {
     let siteData = [];
     if (Array.isArray(sites)) {
         siteData = sites.map((entry) => {
-            // Find this site within our search results
-            const counts = {};
-            if (searchResults && entry.location.name in searchResults) {
-                // Has this node been excluded from the results?
-                if (!(filters && filters?.node?.includes(entry.location.name))) {
-                    const match = searchResults[entry.location.name];
-                    Object.keys(match.summary.patients_per_cohort).forEach((cohort) => {
-                        if (cohort in counts) {
-                            counts[cohort] += match.summary.patients_per_cohort[cohort];
-                        } else {
-                            counts[cohort] = match.summary.patients_per_cohort[cohort];
-                        }
-                    });
-                    /* // Iterate through each donor in this site
-                    match.forEach((donor) => {
-                        if (filters && filters?.program_id?.includes(donor.program_id)) {
-                            // Exclude based on cohort
-                            return;
-                        }
-
-                        if (donor.program_id in counts) {
-                            counts[donor.program_id] += 1;
-                        } else {
-                            counts[donor.program_id] = 1;
-                        }
-                    }); */
-                }
-            }
+            const counts = context?.counts?.patients_per_cohort?.[entry.location.name] || {};
 
             let unlockedPrograms = [];
             if (Array.isArray(programs)) {
                 unlockedPrograms = programs
                     .filter((search) => entry.location.name === search.location.name)?.[0]
-                    ?.results?.results?.map((program) => program.program_id);
+                    ?.results?.items?.map((program) => program.program_id);
             }
 
             // Return the data that PatientCountSingle needs


### PR DESCRIPTION
## Ticket(s)

- [DIG-1372: Query can assemble discovery queries](https://candig.atlassian.net/browse/DIG-1372)

## Description

- This changes the behaviour of the summary statistics by grabbing their counts from the new Query endpoint (located [here](https://github.com/CanDIG/candigv2-query/pull/28)). This must be tested with that branch active.

## Expected Behaviour

- Summary statistics can be obtained even if you do not have permissions to that particular cohort.

## Screenshots (if appropriate)

### After PR

![Screenshot from 2024-04-12 15-36-47](https://github.com/CanDIG/candig-data-portal/assets/4656440/c52bee16-c658-4a23-9521-c55420bc24cc)

Here, the logged in user has no access to the TEST-2 user, but the numbers still add up to 5.

## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
