### PR TITLE
Fix to work with Query: Filter elements are now pipe delimited

### DIFF
--- a/src/layout/MainLayout/Header/ProfileSection/index.js
+++ b/src/layout/MainLayout/Header/ProfileSection/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { styled } from '@mui/material/styles';
 import { useSelector } from 'react-redux';
 
@@ -157,9 +157,9 @@ function ProfileSection() {
     const theme = useTheme();
     const customization = useSelector((state) => state.customization);
 
-    const [selectedIndex] = React.useState(1);
+    const [selectedIndex] = useState(1);
 
-    const [open, setOpen] = React.useState(false);
+    const [open, setOpen] = useState(false);
 
     const anchorRef = React.useRef(null);
 
@@ -175,7 +175,7 @@ function ProfileSection() {
     };
 
     const prevOpen = React.useRef(open);
-    React.useEffect(() => {
+    useEffect(() => {
         if (prevOpen.current === true && open === false) {
             anchorRef.current.focus();
         }
@@ -243,7 +243,7 @@ function ProfileSection() {
                                     <CardContent className={classes.cardContent}>
                                         <Grid container direction="column" spacing={0}>
                                             <Grid item className={classes.flex}>
-                                                <Typography variant="h4">Hello!</Typography>
+                                                <Typography variant="h4">Hello, !</Typography>
                                                 {/* <Typography component="span" variant="h4" className={classes.name}>
                                                     First Name Last Name
                                                 </Typography> */}

--- a/src/layout/MainLayout/Header/ProfileSection/index.js
+++ b/src/layout/MainLayout/Header/ProfileSection/index.js
@@ -243,7 +243,7 @@ function ProfileSection() {
                                     <CardContent className={classes.cardContent}>
                                         <Grid container direction="column" spacing={0}>
                                             <Grid item className={classes.flex}>
-                                                <Typography variant="h4">Hello, !</Typography>
+                                                <Typography variant="h4">Hello!</Typography>
                                                 {/* <Typography component="span" variant="h4" className={classes.name}>
                                                     First Name Last Name
                                                 </Typography> */}

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -134,7 +134,6 @@ function StyledCheckboxList(props) {
         } else {
             ids = [ids];
         }
-        console.log(ids);
 
         if (isExclusion ? !isChecked : isChecked) {
             setChecked((_) => {


### PR DESCRIPTION
## Description

- [The internal pipe-delimitter Query PR](https://github.com/CanDIG/candigv2-query/pull/32) turns out to also disable multi-value parameters. This changes the behaviour of the filters to use pipe-delimited things instead.

## Expected Behaviour

- The filters work again.

## To do/Tickets to be made before merging branch

- Run through the runbook.

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
