### PR TITLE
DIG-1628: Change axis label to sample registrations

### DIFF
--- a/src/store/constant.js
+++ b/src/store/constant.js
@@ -148,7 +148,7 @@ export const DataVisualizationChartInfo = {
     full_genomic_data: {
         title: 'Complete Genomic',
         xAxis: 'Site',
-        yAxis: 'Number of Patients'
+        yAxis: 'Number of Sample Registrations'
     }
 };
 export const validCharts = ['bar', 'line', 'scatter', 'column'];


### PR DESCRIPTION
## Ticket(s)

- DIG-1628

## Description

- update the axis for genomic completeness graphs so that it reflects what is being counted

## Expected Behaviour

- x axis on genomic completeness graphs is 'Number of Sample Registrations' instead of 'Number of Patients'

## Screenshots (if appropriate)

### Before PR
![Screenshot 2024-05-03 at 2 08 38 PM](https://github.com/CanDIG/candig-data-portal/assets/13007987/7ebb5bd7-5e12-4a15-b6c5-9a3b66aec21b)

### After PR
![Screenshot 2024-05-03 at 2 07 43 PM](https://github.com/CanDIG/candig-data-portal/assets/13007987/1a217e5a-0b83-44e1-ae2d-cd522df6c077)


## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
