### PR TITLE
Switch "number of samples" to "number of donors"

### DIFF
--- a/src/store/constant.js
+++ b/src/store/constant.js
@@ -148,7 +148,7 @@ export const DataVisualizationChartInfo = {
     full_genomic_data: {
         title: 'Complete Genomic',
         xAxis: 'Site',
-        yAxis: 'Number of Patients'
+        yAxis: 'Number of Samples'
     }
 };
 export const validCharts = ['bar', 'line', 'scatter', 'column'];


### PR DESCRIPTION
## Description

- The "Complete Genomic" graph in both the summary page and completeness stats page has an x axis of "samples" instead of donors

## Screenshots (if appropriate)

### After PR
![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/f604c621-2401-4d5a-9c75-a2ff464fecc0)

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
