### PR TITLE
Remove the footer with MOHCCN and also the node filtering

### DIFF
--- a/src/layout/MainLayout/Footer/index.js
+++ b/src/layout/MainLayout/Footer/index.js
@@ -277,9 +277,10 @@ function Footer(props) {
                         </div>
                     </div>
                 </div>
-                <a href="https://www.marathonofhopecancercentres.ca/" target="_blank" rel="noreferrer">
+	    {/*
+	    <a href="https://www.marathonofhopecancercentres.ca/" target="_blank" rel="noreferrer">
                     <img src={MOHLogo} alt="MOH logo hyperlink" style={{ position: 'relative', top: '-1em', width: '6.5em' }} />
-                </a>
+                </a>*/}
             </ResponsiveFundingContainer>
         </ResponsiveFooterContainer>
     );

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -490,7 +490,7 @@ function Sidebar() {
                     Reset Filters
                 </Button>
             </div>
-            <SidebarGroup name="Node">
+            {/* <SidebarGroup name="Node">
                 <StyledCheckboxList
                     options={sites}
                     onWrite={writerContext}
@@ -509,7 +509,7 @@ function Sidebar() {
                     checked={selectedCohorts}
                     setChecked={setSelectedCohorts}
                 />
-            </SidebarGroup>
+            </SidebarGroup> */}
             <GenomicsGroup
                 chromosomes={chromosomes}
                 genes={genes}


### PR DESCRIPTION
## Description

- Removes the node/cohort filtering on the sidebar and the MOHCCN logo (Daisie's work). They have just been commented out for demo processes because they might come back

## Screenshots (if appropriate)

### After PR

![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/891c3cd7-e4cf-4508-92a0-1d5f79d47ce4)


![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/0642305f-4555-4a8c-ac41-7b85d656fa6f)


## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
