### PR TITLE
DIG-1448: Disable per column filtering, DIG-1641: Disable chart exporting menu

### DIFF
--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -76,11 +76,11 @@ function ClinicalView() {
 
     // JSON on bottom now const screenWidth = desktopResolution ? '48%' : '100%';
     const columns = [
-        { field: 'submitter_donor_id', headerName: 'Donor ID', minWidth: 220, sortable: false },
-        { field: 'sex_at_birth', headerName: 'Sex At Birth', minWidth: 170, sortable: false },
-        { field: 'deceased', headerName: 'Deceased', minWidth: 170, sortable: false },
-        { field: 'date_of_birth', headerName: 'Age at First Diagnosis', minWidth: 200, sortable: false },
-        { field: 'date_of_death', headerName: 'Age at Death', minWidth: 220, sortable: false }
+        { field: 'submitter_donor_id', headerName: 'Donor ID', minWidth: 220, sortable: false, filterable: false },
+        { field: 'sex_at_birth', headerName: 'Sex At Birth', minWidth: 170, sortable: false, filterable: false },
+        { field: 'deceased', headerName: 'Deceased', minWidth: 170, sortable: false, filterable: false },
+        { field: 'date_of_birth', headerName: 'Age at First Diagnosis', minWidth: 200, sortable: false, filterable: false },
+        { field: 'date_of_death', headerName: 'Age at Death', minWidth: 220, sortable: false, filterable: false }
     ];
 
     const HandlePageChange = (newModel) => {

--- a/src/views/clinicalGenomic/widgets/genomicData.js
+++ b/src/views/clinicalGenomic/widgets/genomicData.js
@@ -47,14 +47,14 @@ function GenomicData() {
 
     // JSON on bottom now const screenWidth = desktopResolution ? '48%' : '100%';
     const columns = [
-        { field: 'location', headerName: 'Node', minWidth: 120, sortable: false },
-        { field: 'donor_id', headerName: 'Donor ID', minWidth: 150, sortable: false },
-        { field: 'program_id', headerName: 'Cohort ID', minWidth: 150, sortable: false },
-        { field: 'position', headerName: 'Position', minWidth: 150, sortable: false },
-        { field: 'tumour_normal_designation', headerName: 'Tumour/Normal', minWidth: 200, sortable: false },
-        { field: 'submitter_specimen_id', headerName: 'Sample Registration ID', minWidth: 300, sortable: false },
-        { field: 'genotypeLabel', headerName: 'Genotype', minWidth: 300, sortable: false },
-        { field: 'zygosityLabel', headerName: 'Zygosity', minWidth: 200, sortable: false }
+        { field: 'location', headerName: 'Node', minWidth: 120, sortable: false, filterable: false },
+        { field: 'donor_id', headerName: 'Donor ID', minWidth: 150, sortable: false, filterable: false },
+        { field: 'program_id', headerName: 'Cohort ID', minWidth: 150, sortable: false, filterable: false },
+        { field: 'position', headerName: 'Position', minWidth: 150, sortable: false, filterable: false },
+        { field: 'tumour_normal_designation', headerName: 'Tumour/Normal', minWidth: 200, sortable: false, filterable: false },
+        { field: 'submitter_specimen_id', headerName: 'Sample Registration ID', minWidth: 300, sortable: false, filterable: false },
+        { field: 'genotypeLabel', headerName: 'Genotype', minWidth: 300, sortable: false, filterable: false },
+        { field: 'zygosityLabel', headerName: 'Zygosity', minWidth: 200, sortable: false, filterable: false }
     ];
 
     const queryParams = query?.gene || query?.chrom;

--- a/src/views/clinicalGenomic/widgets/timeline.js
+++ b/src/views/clinicalGenomic/widgets/timeline.js
@@ -625,7 +625,10 @@ function Timeline({ data, onEventClick }) {
                     }
                 }
             },
-            series: Updatedseries
+            series: Updatedseries,
+            exporting: {
+                enabled: false
+            }
         });
 
         setChartOptions((prevOptions) => ({

--- a/src/views/summary/CustomOfflineChart.js
+++ b/src/views/summary/CustomOfflineChart.js
@@ -223,12 +223,18 @@ function CustomOfflineChart(props) {
                             )}%) total ${this.series.yAxis.axisTitle.textStr.toLowerCase()}`;
                         }
                         /* eslint-enable func-names */
+                    },
+                    exporting: {
+                        enabled: false
                     }
                 });
             } else {
                 // Pie Chart
                 setChartOptions({
                     credits: {
+                        enabled: false
+                    },
+                    exporting: {
                         enabled: false
                     },
                     colors: [

--- a/src/views/summary/TreatingCentreMap.js
+++ b/src/views/summary/TreatingCentreMap.js
@@ -38,7 +38,10 @@ const initialState = {
                 }
             }
         }
-    ]
+    ],
+    exporting: {
+        enabled: false
+    }
 };
 
 function reducer(state, action) {


### PR DESCRIPTION
## Ticket(s)

- [DIG-1448](https://candig.atlassian.net/browse/DIG-1448)
- [DIG-1641](https://candig.atlassian.net/browse/DIG-1641)

## Description

- On the search page, sets 'filterable' to false on the clinical and genomic data table columns so that a user cannot filter (since it doesn't actually work when there are multiple pages of results). I did not disable this on the patient info pages because I don't think we have pagination so filtering should work there (?)
- Explicitly disables exporting on highcharts which should mean the hamburger menus don't show up. I couldn't recreate this behaviour on local, so not 100% sure this will fix it. Would be good to have some input on the data portal experts if they think this should fix it and whether I have put it in the right spot for all our charts. sources:
  - https://api.highcharts.com/highcharts/exporting.enabled
  - https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/exporting/enabled-false/

## Expected Behaviour

- No filtering option shows when selecting the three dot menus on the clinical and genomic data tables on the search page
- No hamburger menus show up randomly on highcharts

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-1448]: https://candig.atlassian.net/browse/DIG-1448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DIG-1641]: https://candig.atlassian.net/browse/DIG-1641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ