### PR TITLE
DIG-898: Show username of the authenticated user in data portal

### DIFF
--- a/src/layout/MainLayout/Header/ProfileSection/index.js
+++ b/src/layout/MainLayout/Header/ProfileSection/index.js
@@ -161,6 +161,8 @@ function ProfileSection() {
 
     const [open, setOpen] = useState(false);
 
+    const [username, setUsername] = useState('');
+
     const anchorRef = React.useRef(null);
 
     const handleToggle = () => {
@@ -182,6 +184,25 @@ function ProfileSection() {
 
         prevOpen.current = open;
     }, [open]);
+
+    // Grab the user key for the logged in user
+    useEffect(() => {
+        fetch(`/query/whoami`)
+            .then((response) => {
+                if (response.ok) {
+                    return response.json();
+                }
+                console.log(`whoami could not determine logged in user: ${response}`);
+                throw new Error(`${response}`);
+            })
+            .then((response) => {
+                setUsername(response?.key);
+            })
+            .catch((error) => {
+                console.log(`Whoami error: ${error}`);
+                return '';
+            });
+    }, []);
 
     const setSite = () => {
         switch (SITE) {
@@ -243,10 +264,10 @@ function ProfileSection() {
                                     <CardContent className={classes.cardContent}>
                                         <Grid container direction="column" spacing={0}>
                                             <Grid item className={classes.flex}>
-                                                <Typography variant="h4">Hello!</Typography>
-                                                {/* <Typography component="span" variant="h4" className={classes.name}>
-                                                    First Name Last Name
-                                                </Typography> */}
+                                                <Typography variant="h4">Hello,</Typography>
+                                                <Typography component="span" variant="h4" className={classes.name}>
+                                                    {username}
+                                                </Typography>
                                             </Grid>
                                             <Grid item className={classes.usernamePadding}>
                                                 <Typography variant="subtitle2">{SITE}</Typography>

--- a/src/layout/MainLayout/Header/ProfileSection/index.js
+++ b/src/layout/MainLayout/Header/ProfileSection/index.js
@@ -19,9 +19,6 @@ import {
 } from '@mui/material';
 import ListItemButton from '@mui/material/ListItemButton';
 
-// third-party
-import PerfectScrollbar from 'react-perfect-scrollbar';
-
 // project imports
 import MainCard from 'ui-component/cards/MainCard';
 import Transitions from 'ui-component/extended/Transitions';
@@ -93,6 +90,7 @@ const PopperRoot = styled(Popper)(({ theme }) => ({
         minWidth: '300px',
         backgroundColor: theme.palette.background.paper,
         borderRadius: '10px',
+        overflow: 'hidden',
         [theme.breakpoints.down('md')]: {
             minWidth: '100%'
         }
@@ -141,7 +139,7 @@ const PopperRoot = styled(Popper)(({ theme }) => ({
     [`& .${classes.ScrollHeight}`]: {
         height: '100%',
         maxHeight: 'calc(100vh - 250px)',
-        overflowX: 'hidden'
+        overflow: 'hidden'
     },
 
     [`& .${classes.badgeWarning}`]: {
@@ -307,22 +305,19 @@ function ProfileSection() {
                                             </Grid>
                                         </Grid>
                                         <Divider />
-                                        <PerfectScrollbar className={classes.ScrollHeight}>
-                                            <Divider />
-                                            <List component="nav" className={classes.navContainer}>
-                                                <ListItemButton
-                                                    className={classes.listItem}
-                                                    sx={{ borderRadius: `${customization.borderRadius}px` }}
-                                                    selected={selectedIndex === 4}
-                                                    to="/auth/logout"
-                                                >
-                                                    <ListItemIcon>
-                                                        <IconLogout stroke={1.5} size="1.3rem" />
-                                                    </ListItemIcon>
-                                                    <ListItemText primary={<Typography variant="body2">Logout</Typography>} />
-                                                </ListItemButton>
-                                            </List>
-                                        </PerfectScrollbar>
+                                        <List component="nav" className={classes.navContainer}>
+                                            <ListItemButton
+                                                className={classes.listItem}
+                                                sx={{ borderRadius: `${customization.borderRadius}px` }}
+                                                selected={selectedIndex === 4}
+                                                to="/auth/logout"
+                                            >
+                                                <ListItemIcon>
+                                                    <IconLogout stroke={1.5} size="1.3rem" />
+                                                </ListItemIcon>
+                                                <ListItemText primary={<Typography variant="body2">Logout</Typography>} />
+                                            </ListItemButton>
+                                        </List>
                                     </CardContent>
                                 </MainCard>
                             </ClickAwayListener>

--- a/src/layout/MainLayout/Header/ProfileSection/index.js
+++ b/src/layout/MainLayout/Header/ProfileSection/index.js
@@ -179,27 +179,18 @@ function ProfileSection() {
 
     const [username, setUsername] = useState('');
 
-    const anchorRef = React.useRef(null);
+    const anchorEl = React.useRef(null);
 
     const handleToggle = () => {
         setOpen((prevOpen) => !prevOpen);
     };
     const handleClose = (event) => {
-        if (anchorRef.current && anchorRef.current.contains(event.target)) {
+        if (anchorEl?.current?.contains(event.target)) {
             return;
         }
 
         setOpen(false);
     };
-
-    const prevOpen = React.useRef(open);
-    useEffect(() => {
-        if (prevOpen.current === true && open === false) {
-            anchorRef.current.focus();
-        }
-
-        prevOpen.current = open;
-    }, [open]);
 
     // Grab the user key for the logged in user
     useEffect(() => {
@@ -240,7 +231,6 @@ function ProfileSection() {
                     <Avatar
                         src={setSite()}
                         className={classes.headerAvatar}
-                        ref={anchorRef}
                         aria-controls={open ? 'menu-list-grow' : undefined}
                         aria-haspopup="true"
                         color="inherit"
@@ -248,16 +238,16 @@ function ProfileSection() {
                 }
                 label={<IconSettings stroke={1.5} size="1.5rem" color={theme.palette.primary.main} />}
                 variant="outlined"
-                ref={anchorRef}
                 aria-controls={open ? 'menu-list-grow' : undefined}
                 aria-haspopup="true"
                 onClick={handleToggle}
+                ref={anchorEl}
                 color="primary"
             />
             <PopperRoot
                 placement="bottom-end"
                 open={open}
-                anchorEl={anchorRef.current}
+                anchorEl={anchorEl.current}
                 role={undefined}
                 transition
                 className={classes.showOnTop}
@@ -297,7 +287,6 @@ function ProfileSection() {
                                                 <Avatar
                                                     src={setSite()}
                                                     className={classes.smallAvatar}
-                                                    ref={anchorRef}
                                                     aria-controls={open ? 'menu-list-grow' : undefined}
                                                     aria-haspopup="true"
                                                     color="inherit"

--- a/src/layout/MainLayout/Header/ProfileSection/index.js
+++ b/src/layout/MainLayout/Header/ProfileSection/index.js
@@ -50,7 +50,10 @@ const classes = {
     name: `${PREFIX}-name`,
     ScrollHeight: `${PREFIX}-ScrollHeight`,
     badgeWarning: `${PREFIX}-badgeWarning`,
-    usernamePadding: `${PREFIX}-usernamePadding`
+    loggedInAs: `${PREFIX}-loggedInAs`,
+    usernamePadding: `${PREFIX}-usernamePadding`,
+    username: `${PREFIX}-username`,
+    smallAvatar: `${PREFIX}-smallAvatar`
 };
 
 const ChipRoot = styled(Chip)(({ theme }) => ({
@@ -148,6 +151,21 @@ const PopperRoot = styled(Popper)(({ theme }) => ({
 
     [`& .${classes.usernamePadding}`]: {
         paddingBottom: '1em'
+    },
+
+    [`& .${classes.loggedInAs}`]: {
+        fontSize: 18
+    },
+
+    [`& .${classes.username}`]: {
+        fontSize: 16
+    },
+
+    [`& .${classes.smallAvatar}`]: {
+        cursor: 'pointer',
+        ...theme.typography.mediumAvatar,
+        marginLeft: 'auto',
+        marginRight: 0
     }
 }));
 
@@ -262,15 +280,30 @@ function ProfileSection() {
                             <ClickAwayListener onClickAway={handleClose}>
                                 <MainCard border={false} elevation={16} content={false} boxShadow shadow={theme.shadows[16]}>
                                     <CardContent className={classes.cardContent}>
-                                        <Grid container direction="column" spacing={0}>
-                                            <Grid item className={classes.flex}>
-                                                <Typography variant="h4">Hello,</Typography>
-                                                <Typography component="span" variant="h4" className={classes.name}>
-                                                    {username}
-                                                </Typography>
+                                        <Grid container direction="row" spacing={0}>
+                                            <Grid item xs={8} className={classes.flex}>
+                                                <Grid container direction="column" spacing={0}>
+                                                    <Grid item className={classes.flex}>
+                                                        <Typography variant="h4" className={classes.loggedInAs}>
+                                                            Logged in as:
+                                                        </Typography>
+                                                    </Grid>
+                                                    <Grid item className={classes.usernamePadding}>
+                                                        <Typography variant="body1" className={classes.username}>
+                                                            {username}, {SITE}
+                                                        </Typography>
+                                                    </Grid>
+                                                </Grid>
                                             </Grid>
-                                            <Grid item className={classes.usernamePadding}>
-                                                <Typography variant="subtitle2">{SITE}</Typography>
+                                            <Grid item xs={4} className={classes.flex}>
+                                                <Avatar
+                                                    src={setSite()}
+                                                    className={classes.smallAvatar}
+                                                    ref={anchorRef}
+                                                    aria-controls={open ? 'menu-list-grow' : undefined}
+                                                    aria-haspopup="true"
+                                                    color="inherit"
+                                                />
                                             </Grid>
                                         </Grid>
                                         <Divider />

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -4,7 +4,6 @@ import { trackPromise } from 'react-promise-tracker';
 
 import { useSearchResultsWriterContext, useSearchQueryReaderContext } from '../SearchResultsContext';
 import { fetchFederationStat, fetchFederation, query, queryDiscovery } from 'store/api';
-import { invertkatsu } from 'utils/utils';
 
 // NB: I assign to lastPromise a bunch to keep track of whether or not we need to chain promises together
 // However, the linter really dislikes this, and assumes I want to put everything inside one useEffect?


### PR DESCRIPTION
## Ticket(s)

- [DIG-898](Show username of the authenticated user in data portal)

## Description

- This adjusts the profile button at the top right to show the user key of the currently-signed-in user (usually their email address). **This requires the corresponding branch from Query [here](https://github.com/CanDIG/candigv2-query/pull/42)**

## Screenshots (if appropriate)

### Before PR

### After PR
![image](https://github.com/CanDIG/candig-data-portal/assets/4656440/7db7ecba-54a8-4550-8cf8-c73899d1d285)

## To do/Tickets to be made before merging branch

- Requires the Query PR [here](https://github.com/CanDIG/candigv2-query/pull/42)

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-898]: https://candig.atlassian.net/browse/DIG-898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ