### PR TITLE
DIG-1639: Discovery queries fail when navigating to subsequent page of clinical data results

### DIFF
--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -53,7 +53,6 @@ function SearchHandler({ setLoading }) {
     }
     useEffect(() => {
         // First, we abort any currently-running search promises
-        setLoading(true);
         const CollateSummary = (data, statName) => {
             const summaryStat = {};
             data.forEach((site) => {
@@ -101,6 +100,7 @@ function SearchHandler({ setLoading }) {
 
     // Query 2: when the search query changes, re-query the server
     useEffect(() => {
+        setLoading(true);
         const donorQueryPromise = () =>
             query(reader.query, controller.signal).then((data) => {
                 if (reader.filter?.node) {
@@ -122,7 +122,8 @@ function SearchHandler({ setLoading }) {
                     .flat(1);
 
                     writer((old) => ({ ...old, clinical: clinicalData, genomic: genomicData, loading: false }));
-                });
+                })
+                .finally(() => setLoading(false));
 
         if (lastPromise === null) {
             lastPromise = donorQueryPromise();

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -45,10 +45,10 @@ function SearchHandler({ setLoading }) {
 
     // Query 2: when the search query changes (but not the page number), re-query the discovery stats
     const { ...queryNoPageSize } = reader.query || {};
-    if (queryNoPageSize.page) {
+    if ('page' in queryNoPageSize) {
         delete queryNoPageSize.page;
     }
-    if (queryNoPageSize.page_size) {
+    if ('page_size' in queryNoPageSize) {
         delete queryNoPageSize.page_size;
     }
     useEffect(() => {
@@ -121,33 +121,8 @@ function SearchHandler({ setLoading }) {
                     )
                     .flat(1);
 
-                    writer((old) => ({ ...old, counts: discoveryCounts }));
-                })
-                .then(() =>
-                    query(reader.query, controller.signal)
-                        .then((data) => {
-                            if (reader.filter?.node) {
-                                data = data.filter((site) => !reader.filter.node.includes(site.location.name));
-                            }
-                            // Reorder the data, and fill out the patients per cohort
-                            const clinicalData = {};
-                            data.forEach((site) => {
-                                clinicalData[site.location.name] = site?.results;
-                            });
-
-                            const genomicData = data
-                                .map((site) =>
-                                    site.results.genomic?.map((caseData) => {
-                                        caseData.location = site.location;
-                                        return caseData;
-                                    })
-                                )
-                                .flat(1);
-
-                            writer((old) => ({ ...old, clinical: clinicalData, genomic: genomicData, loading: false }));
-                        })
-                        .finally(() => setLoading(false))
-                );
+                    writer((old) => ({ ...old, clinical: clinicalData, genomic: genomicData, loading: false }));
+                });
 
         if (lastPromise === null) {
             lastPromise = donorQueryPromise();

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -102,24 +102,25 @@ function SearchHandler({ setLoading }) {
     useEffect(() => {
         setLoading(true);
         const donorQueryPromise = () =>
-            query(reader.query, controller.signal).then((data) => {
-                if (reader.filter?.node) {
-                    data = data.filter((site) => !reader.filter.node.includes(site.location.name));
-                }
-                // Reorder the data, and fill out the patients per cohort
-                const clinicalData = {};
-                data.forEach((site) => {
-                    clinicalData[site.location.name] = site?.results;
-                });
+            query(reader.query, controller.signal)
+                .then((data) => {
+                    if (reader.filter?.node) {
+                        data = data.filter((site) => !reader.filter.node.includes(site.location.name));
+                    }
+                    // Reorder the data, and fill out the patients per cohort
+                    const clinicalData = {};
+                    data.forEach((site) => {
+                        clinicalData[site.location.name] = site?.results;
+                    });
 
-                const genomicData = data
-                    .map((site) =>
-                        site.results.genomic?.map((caseData) => {
-                            caseData.location = site.location;
-                            return caseData;
-                        })
-                    )
-                    .flat(1);
+                    const genomicData = data
+                        .map((site) =>
+                            site.results.genomic?.map((caseData) => {
+                                caseData.location = site.location;
+                                return caseData;
+                            })
+                        )
+                        .flat(1);
 
                     writer((old) => ({ ...old, clinical: clinicalData, genomic: genomicData, loading: false }));
                 })

--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -8,19 +8,16 @@ import { Box, Typography } from '@mui/material';
 // REDUX
 
 // project imports
-import { useSearchQueryWriterContext, useSearchResultsReaderContext } from '../SearchResultsContext';
+import { useSearchQueryWriterContext, useSearchResultsReaderContext, useSearchQueryReaderContext } from '../SearchResultsContext';
 
 function ClinicalView() {
     const theme = useTheme();
-    const [paginationModel, setPaginationModel] = React.useState({
-        pageSize: 10,
-        page: 0
-    });
 
     // Mobile
     const [desktopResolution, setdesktopResolution] = React.useState(window.innerWidth > 1200);
     const searchResults = useSearchResultsReaderContext().clinical;
     const writerContext = useSearchQueryWriterContext();
+    const queryReader = useSearchQueryReaderContext();
 
     // Function to add location to each patient
     function addLocationToPatients(searchResults) {
@@ -109,10 +106,9 @@ function ClinicalView() {
     ];
 
     const HandlePageChange = (newModel) => {
-        if (newModel.page !== paginationModel.page) {
+        if (newModel.page !== queryReader.query?.page) {
             writerContext((old) => ({ ...old, query: { ...old.query, page: newModel.page, page_size: newModel.pageSize } }));
         }
-        setPaginationModel(newModel);
     };
 
     const totalRows = searchResults
@@ -120,6 +116,11 @@ function ClinicalView() {
               ?.map((site) => site.count)
               .reduce((partial, a) => partial + a, 0)
         : 0;
+
+    const paginationModel = {
+        page: queryReader.query?.page || 0,
+        pageSize: queryReader.query?.pageSize || 10
+    };
 
     return (
         <Box mr={2} ml={1} p={1} sx={{ border: 1, borderRadius: 2, boxShadow: 2, borderColor: theme.palette.primary[200] + 75 }}>

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 
 import {
-    Chip,
     Checkbox,
     FormControl,
     FormControlLabel,

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import {
+    Chip,
     Checkbox,
     FormControl,
     FormControlLabel,


### PR DESCRIPTION
## Ticket(s)

- [DIG-1639](https://candig.atlassian.net/browse/DIG-1639)

## Description

- Going to page 2 of search results causes all of the discovery queries to fail, because the discovery queries don't really handle the page/page_size parameter. This cleans the request of that before sending it off.

## Expected Behaviour

- Going to page 2 does not blank out the discovery charts.

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-1639]: https://candig.atlassian.net/browse/DIG-1639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ