### PR TITLE
Add open table icon and move toplevel up

### DIFF
--- a/src/views/clinicalGenomic/clinicalPatientView.js
+++ b/src/views/clinicalGenomic/clinicalPatientView.js
@@ -13,15 +13,14 @@ import Timeline from './widgets/timeline';
 
 const StyledTopLevelBox = styled(Box)(({ theme }) => ({
     border: `1px solid ${theme.palette.primary.main}`,
-    marginTop: '1em',
+    marginBottom: '1em',
     padding: '1em',
-    borderBottomLeftRadius: '10px',
-    borderBottomRightRadius: '10px',
+    borderTopLeftRadius: '10px',
+    borderTopRightRadius: '10px',
     display: 'flex',
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: '1em',
-    boxShadow: '5px 5px 10px rgba(0, 0, 0, 0.2)'
+    gap: '1em'
 }));
 
 const TimelineContainer = styled(Box)(({ theme }) => ({
@@ -77,9 +76,6 @@ function ClinicalPatientView() {
             <Typography pb={1} variant="h6">
                 {patientId}
             </Typography>
-            <div style={{ width: '100%', height: '68vh' }}>
-                <DataGrid rows={rows} columns={columns} pageSize={10} rowsPerPageOptions={[10]} hideFooterSelectedRowCount />
-            </div>
             <StyledTopLevelBox className={clsx(additionalClass)}>
                 {Object.entries(topLevel).map(([key, value]) => (
                     <div
@@ -95,6 +91,9 @@ function ClinicalPatientView() {
                     </div>
                 ))}
             </StyledTopLevelBox>
+            <div style={{ width: '100%', height: '68vh' }}>
+                <DataGrid rows={rows} columns={columns} pageSize={10} rowsPerPageOptions={[10]} hideFooterSelectedRowCount />
+            </div>
             {dateOfBirth && (
                 <TimelineContainer>
                     <Timeline data={data} onEventClick={handleEventClick} />

--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -4,7 +4,8 @@ import * as React from 'react';
 import { useTheme } from '@mui/system';
 import { DataGrid } from '@mui/x-data-grid';
 import { Box, Typography } from '@mui/material';
-
+import Tooltip from '@mui/material/Tooltip';
+import { IconTableShare } from '@tabler/icons-react';
 // REDUX
 
 // project imports
@@ -99,7 +100,37 @@ function ClinicalView() {
 
     // JSON on bottom now const screenWidth = desktopResolution ? '48%' : '100%';
     const columns = [
-        { field: 'submitter_donor_id', headerName: 'Donor ID', minWidth: 220, sortable: false },
+        {
+            field: 'submitter_donor_id',
+            headerName: 'Donor ID',
+            minWidth: 220,
+            sortable: false,
+            renderCell: (params) => (
+                <Tooltip title="Open Patient View" placement="right">
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            '&:hover': {
+                                color: theme.palette.primary.main
+                            }
+                        }}
+                    >
+                        <Box
+                            component="span"
+                            sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                marginRight: '1em'
+                            }}
+                        >
+                            <IconTableShare stroke={1.5} size="1.3rem" />
+                        </Box>
+                        <Typography>{params.value}</Typography>
+                    </Box>
+                </Tooltip>
+            )
+        },
         { field: 'location', headerName: 'Location', minWidth: 220, sortable: false },
         { field: 'program_id', headerName: 'Program ID', minWidth: 220, sortable: false },
         { field: 'sex_at_birth', headerName: 'Sex At Birth', minWidth: 170, sortable: false },


### PR DESCRIPTION
## Ticket(s)
[DIG-1615: Clinical Table row icon](https://candig.atlassian.net/browse/DIG-1615)
[DIG-1655: Move donor info to top of patient info table](https://candig.atlassian.net/browse/DIG-1655)

## Description
This PR includes 2 tickets one to add an icon and hover to inform users that they can click the row as well as moving the toplevel above the patient info table.

## Screenshots 
![image](https://github.com/CanDIG/candig-data-portal/assets/37649170/a6fddeec-fb84-4433-b3e2-2b275910cdd5)
![chrome_DzEQm6xdXh](https://github.com/CanDIG/candig-data-portal/assets/37649170/d08624b0-c8ef-4d97-a6d0-e30da95824e9)


## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [x] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
