### PR TITLE
Authorized Locks, Sidebar checkbox bugs, and styling changes

### DIFF
--- a/src/views/clinicalGenomic/clinicalGenomicSearch.js
+++ b/src/views/clinicalGenomic/clinicalGenomicSearch.js
@@ -14,6 +14,7 @@ import { COHORTS } from 'store/constant';
 import SearchHandler from './search/SearchHandler';
 import GenomicData from './widgets/genomicData';
 import { SearchIndicator } from 'ui-component/LoadingIndicator/SearchIndicator';
+import AuthorizationSections from './widgets/authorizationSections';
 
 const PREFIX = 'ClinicalGenomicSearch';
 
@@ -76,6 +77,11 @@ const StyledMainCard = styled(MainCard)((_) => ({
 
 const sections = [
     {
+        id: 'cohorts summary',
+        header: 'Cohorts Summary',
+        component: <AuthorizationSections title="Cohorts Summary" />
+    },
+    {
         id: 'counts',
         header: 'Patient Counts',
         component: <PatientCounts />
@@ -84,6 +90,11 @@ const sections = [
         id: 'visualization',
         header: 'Data Visualization',
         component: <DataVisualization />
+    },
+    {
+        id: 'authorized cohorts',
+        header: 'Authorized Cohorts',
+        component: <AuthorizationSections title="Authorized Cohorts" />
     },
     {
         id: 'clinical',
@@ -96,7 +107,6 @@ const sections = [
         component: <GenomicData />
     }
 ];
-
 function ClinicalGenomicSearch() {
     const customization = useSelector((state) => state.customization);
 

--- a/src/views/clinicalGenomic/widgets/authorizationSections.js
+++ b/src/views/clinicalGenomic/widgets/authorizationSections.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import { Box, Grid, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 
@@ -25,7 +26,7 @@ function AuthorizationSections({ title }) {
 }
 
 AuthorizationSections.propTypes = {
-    title: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired
 };
 
 export default AuthorizationSections;

--- a/src/views/clinicalGenomic/widgets/authorizationSections.js
+++ b/src/views/clinicalGenomic/widgets/authorizationSections.js
@@ -9,6 +9,8 @@ function AuthorizationSections({ title }) {
         <Box>
             <Box
                 mt={2}
+                mr={1}
+                ml={1}
                 sx={{
                     borderBottom: `1px ${theme.palette.primary.main} solid`
                 }}

--- a/src/views/clinicalGenomic/widgets/authorizationSections.js
+++ b/src/views/clinicalGenomic/widgets/authorizationSections.js
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Box, Grid, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+
+function AuthorizationSections({ title }) {
+    const theme = useTheme();
+
+    return (
+        <Box>
+            <Box
+                mt={2}
+                sx={{
+                    borderBottom: `1px ${theme.palette.primary.main} solid`
+                }}
+            >
+                <Grid container justifyContent="start" alignItems="center" spacing={2}>
+                    <Grid item xs={2}>
+                        <Typography variant="h3">{title}</Typography>
+                    </Grid>
+                </Grid>
+            </Box>
+        </Box>
+    );
+}
+
+export default AuthorizationSections;

--- a/src/views/clinicalGenomic/widgets/authorizationSections.js
+++ b/src/views/clinicalGenomic/widgets/authorizationSections.js
@@ -24,4 +24,8 @@ function AuthorizationSections({ title }) {
     );
 }
 
+AuthorizationSections.propTypes = {
+    title: PropTypes.string.isRequired,
+};
+
 export default AuthorizationSections;

--- a/src/views/clinicalGenomic/widgets/authorizationSections.js
+++ b/src/views/clinicalGenomic/widgets/authorizationSections.js
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Box, Grid, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 

--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -155,7 +155,7 @@ function ClinicalView() {
         : 0;
 
     return (
-        <Box mr={2} ml={1} p={1} sx={{ border: 1, borderRadius: 2, boxShadow: 2, borderColor: theme.palette.primary[200] + 75 }}>
+        <Box mr={1} ml={1} p={1} sx={{ border: 1, borderRadius: 2, boxShadow: 2, borderColor: theme.palette.primary[200] + 75 }}>
             <Typography pb={1} variant="h4">
                 Clinical Data
             </Typography>

--- a/src/views/clinicalGenomic/widgets/dataVisualization.js
+++ b/src/views/clinicalGenomic/widgets/dataVisualization.js
@@ -226,16 +226,10 @@ function DataVisualization() {
                 color="primary"
                 size="large"
                 sx={{
-                    background: 'white',
-                    border: 1,
-                    borderRadius: '100%',
-                    borderColor: theme.palette.primary.main,
-                    boxShadow: theme.shadows[8],
                     position: 'absolute',
                     zIndex: '1000',
-                    padding: '0.5em',
-                    right: -15,
-                    top: -25
+                    right: -5,
+                    top: -5
                 }}
                 onClick={() => setEdit(!edit)}
             >
@@ -252,18 +246,16 @@ function DataVisualization() {
             {edit && (
                 <IconButton
                     color="primary"
-                    size="large"
+                    size="small"
                     sx={{
-                        background: 'white',
-                        border: 1,
-                        borderRadius: '100%',
-                        borderColor: theme.palette.primary.main,
-                        boxShadow: theme.shadows[8],
                         position: 'absolute',
                         zIndex: '1000',
-                        padding: '0.5em',
-                        right: 50,
-                        top: -25
+                        right: 40,
+                        top: 5,
+                        borderRadius: '100%',
+                        border: 1,
+                        borderColor: theme.palette.primary.main,
+                        padding: '0.01em'
                     }}
                     onClick={() => handleToggleDialog()}
                 >

--- a/src/views/clinicalGenomic/widgets/genomicData.js
+++ b/src/views/clinicalGenomic/widgets/genomicData.js
@@ -67,7 +67,7 @@ function GenomicData() {
     const hasValidQuery = (query?.assembly && query?.chrom) || query?.gene;
 
     return (
-        <Box mr={2} ml={1} p={1} sx={{ border: 1, borderRadius: 2, boxShadow: 2, borderColor: theme.palette.primary[200] + 75 }}>
+        <Box mr={1} ml={1} p={1} sx={{ border: 1, borderRadius: 2, boxShadow: 2, borderColor: theme.palette.primary[200] + 75 }}>
             <Typography pb={1} variant="h4">
                 {hasValidQuery ? `Genomic Variants: ${queryParams}` : 'Genomic Variants: Please query from the sidebar to populate'}
             </Typography>

--- a/src/views/clinicalGenomic/widgets/patientCountSingle.js
+++ b/src/views/clinicalGenomic/widgets/patientCountSingle.js
@@ -1,16 +1,17 @@
-import { useState } from 'react';
-
-import { Avatar, Box, Button, CardHeader, Divider, Grid, Typography } from '@mui/material';
+import React, { useState } from 'react';
+import { Avatar, Box, Button, CardHeader, Divider, Grid, Tooltip, Typography } from '@mui/material';
 import { useTheme } from '@mui/system';
 import { styled } from '@mui/material/styles';
 import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
 import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import PropTypes from 'prop-types';
 
 const PREFIX = 'PatientCountSingle';
 
 const classes = {
     patientEntry: `${PREFIX}-patientEntry`,
+    lockIcon: `${PREFIX}-lockIcon`,
     container: `${PREFIX}-container`,
     siteName: `${PREFIX}-siteName`,
     locked: `${PREFIX}-locked`,
@@ -20,7 +21,15 @@ const classes = {
 
 const StyledBox = styled(Box)(({ theme }) => ({
     [`& .${classes.patientEntry}`]: {
-        // React center span?
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
+    },
+
+    [`& .${classes.lockIcon}`]: {
+        color: theme.palette.primary.main,
+        marginLeft: '0.25em',
+        fontSize: '1.25em'
     },
 
     [`& .${classes.container}`]: {
@@ -28,7 +37,6 @@ const StyledBox = styled(Box)(({ theme }) => ({
     },
 
     [`& .${classes.siteName}`]: {
-        // Left-aligned
         width: 120
     },
 
@@ -37,7 +45,6 @@ const StyledBox = styled(Box)(({ theme }) => ({
     },
 
     [`& .${classes.button}`]: {
-        // Right-aligned
         float: 'right',
         marginLeft: 'auto'
     },
@@ -55,12 +62,10 @@ function PatientCountSingle(props) {
 
     const [expanded, setExpanded] = useState(false);
 
-    // Sum together an array of either numbers, or objects with patients_count in them
     const SumCensoredTotals = (countsArray) =>
         countsArray.reduce(
             (partialSum, cohortTotal) => {
                 if (typeof cohortTotal === 'object') {
-                    // New notation
                     if (cohortTotal.patients_count.startsWith('<')) {
                         return [partialSum[0], partialSum[1] + parseInt(cohortTotal.patients_count.substring(1), 10)];
                     }
@@ -80,13 +85,6 @@ function PatientCountSingle(props) {
     const totalPatients = SumCensoredTotals(Object.values(counts.totals)) || [0, 0];
     const patientsInSearch = SumCensoredTotals(Object.values(counts.counts)) || [0, 0];
     const numCohorts = Object.values(counts.totals)?.length || 0;
-
-    /* const avatarProps = locked
-        ? {
-              // If we're locked out, gray out the avatar
-              sx: { bgcolor: theme.palette.action.disabled }
-          }
-        : {}; */
 
     return (
         <StyledBox pr={2} sx={{ border: 1, borderRadius: 2, boxShadow: 2, borderColor: 'primary.main' }}>
@@ -145,7 +143,14 @@ function PatientCountSingle(props) {
                           >
                               <Grid item xs={2}>
                                   <Typography variant="h5" align="center" className={classes.patientEntry}>
-                                      <b>{cohort.program_id}</b>
+                                      <b className={classes.patientEntry}>
+                                          {cohort.program_id}
+                                          {locked && (
+                                              <Tooltip title="Unauthorized Cohort" placement="right">
+                                                  <LockOutlinedIcon className={classes.lockIcon} />
+                                              </Tooltip>
+                                          )}
+                                      </b>
                                   </Typography>
                               </Grid>
                               <Divider flexItem orientation="vertical" className={classes.divider} />
@@ -161,9 +166,6 @@ function PatientCountSingle(props) {
                                   </Typography>
                               </Grid>
                               <Divider flexItem orientation="vertical" className={classes.divider} />
-                              <Grid item xs={2}>
-                                  {/* Num cohorts doesn't make any sense here */}
-                              </Grid>
                               <Grid item ml="auto" className={classes.button}>
                                   {locked ? (
                                       <Button type="submit" variant="contained" disabled sx={{ borderRadius: 1.8 }}>

--- a/src/views/clinicalGenomic/widgets/patientCountSingle.js
+++ b/src/views/clinicalGenomic/widgets/patientCountSingle.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Avatar, Box, Button, CardHeader, Divider, Grid, Tooltip, Typography } from '@mui/material';
 import { useTheme } from '@mui/system';
 import { styled } from '@mui/material/styles';

--- a/src/views/clinicalGenomic/widgets/patientCounts.js
+++ b/src/views/clinicalGenomic/widgets/patientCounts.js
@@ -1,23 +1,25 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
-
 import { Box, Grid, Typography } from '@mui/material';
-
 import { useSearchResultsReaderContext } from '../SearchResultsContext';
 import PatientCountSingle from './patientCountSingle';
 
 const PREFIX = 'PatientCounts';
 
-const classes = {
-    divider: `${PREFIX}-divider`
-};
-
-// TODO jss-to-styled codemod: The Fragment root was replaced by div. Change the tag if needed.
 const Root = styled('div')(({ theme }) => ({
-    [`& .${classes.divider}`]: {
+    marginLeft: '0.5em',
+    marginRight: '0.5em',
+    [`& .${PREFIX}-divider`]: {
         borderColor: theme.palette.primary.main,
         marginTop: 20,
         marginBottom: 4
+    },
+    [`& .${PREFIX}-header`]: {
+        textAlign: 'center'
+    },
+    [`& .${PREFIX}-spacing`]: {
+        marginTop: theme.spacing(2),
+        marginBottom: theme.spacing(2)
     }
 }));
 
@@ -27,12 +29,10 @@ function PatientCounts() {
     const programs = context?.programs;
 
     // Generate the map of site->cohort->numbers
-    // First, we need to match each site within federation with the site within clinical
     let siteData = [];
     if (Array.isArray(sites)) {
         siteData = sites.map((entry) => {
             const counts = context?.counts?.patients_per_cohort?.[entry.location.name] || {};
-
             let unlockedPrograms = [];
             if (Array.isArray(programs)) {
                 unlockedPrograms = programs
@@ -40,7 +40,6 @@ function PatientCounts() {
                     ?.results?.items?.map((program) => program.program_id);
             }
 
-            // Return the data that PatientCountSingle needs
             return {
                 location: entry.location.name,
                 counts,
@@ -53,27 +52,27 @@ function PatientCounts() {
     return (
         <Root>
             {/* Header */}
-            <Box mr={2} ml={1} pr={5} sx={{ border: 1, borderRadius: 2, borderColor: 'white' }}>
+            <Box sx={{ border: 1, borderRadius: 2, borderColor: 'white' }}>
                 <Grid container justifyContent="center" alignItems="center" spacing={2}>
                     <Grid item xs={2}>
                         <Typography variant="h4">Patient Data</Typography>
                     </Grid>
                     <Grid item xs={2}>
-                        <Typography variant="h5" align="center" className={classes.header}>
+                        <Typography variant="h5" className={`${PREFIX}-header`}>
                             Patients In Search
                         </Typography>
                     </Grid>
                     <Grid item xs={2}>
-                        <Typography variant="h5" align="center" className={classes.header}>
+                        <Typography variant="h5" className={`${PREFIX}-header`}>
                             Total Patients
                         </Typography>
                     </Grid>
                     <Grid item xs={2}>
-                        <Typography variant="h5" align="center" className={classes.header}>
+                        <Typography variant="h5" className={`${PREFIX}-header`}>
                             Total Cohorts
                         </Typography>
                     </Grid>
-                    <Grid item xs={1} ml="auto" className={classes.button}>
+                    <Grid item xs={1} ml="auto" className={`${PREFIX}-button`}>
                         {/* Just here for spacing */}
                     </Grid>
                 </Grid>
@@ -82,7 +81,7 @@ function PatientCounts() {
             {siteData.map((site) => (
                 <React.Fragment key={site.location}>
                     <PatientCountSingle site={site.location} counts={site} />
-                    <br />
+                    <Box className={`${PREFIX}-spacing`} />
                 </React.Fragment>
             ))}
         </Root>

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -140,7 +140,6 @@ function StyledCheckboxList(props) {
         if (isExclusion ? !isChecked : isChecked) {
             setChecked((_) => {
                 const retVal = {};
-                console.log(ids);
                 ids.forEach((id) => {
                     retVal[id] = true;
                 });

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import {
     Checkbox,
@@ -256,6 +256,7 @@ function StyledCheckboxList(props) {
 StyledCheckboxList.propTypes = {
     isExclusion: PropTypes.bool,
     groupName: PropTypes.string,
+    authorizedCohorts: PropTypes.array,
     hide: PropTypes.bool,
     isDonorList: PropTypes.bool,
     isFilterList: PropTypes.bool,

--- a/src/views/summary/CustomOfflineChart.js
+++ b/src/views/summary/CustomOfflineChart.js
@@ -429,7 +429,6 @@ function CustomOfflineChart(props) {
                         border: 1,
                         borderRadius: '100%',
                         borderColor: theme.palette.error.main,
-                        boxShadow: theme.shadows[8],
                         position: 'absolute',
                         zIndex: '1000',
                         padding: '0.10em',


### PR DESCRIPTION
## Ticket(s)
[DIG-1643 Cohort and node checkboxes can't be checked/unchecked](https://candig.atlassian.net/browse/DIG-1643)
[DIG-1623 Search page sidebar shows all cohorts not just authorized ones](https://candig.atlassian.net/browse/DIG-1623)

## Description
Node and cohort sidebar checkboxes were not working and needed to be fixed alongside some styling changes. There is also the addition of the unauthorized datasets being present and showing locks beside them 

## Related Issues (if appropriate)
- [Query PR](https://github.com/CanDIG/candigv2-query/pull/44)

## Screenshots
![image](https://github.com/CanDIG/candig-data-portal/assets/37649170/0c8d81f0-8d1b-4085-bbb8-c762134b506b)

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:
-   [x] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
