### PR TITLE
Model v3

### DIFF
--- a/src/store/api.js
+++ b/src/store/api.js
@@ -58,7 +58,7 @@ export function fetchFederationStat(endpoint) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
             method: 'GET',
-            path: `v2/discovery/overview${endpoint}`,
+            path: `v3/discovery/overview${endpoint}`,
             payload: {},
             service: 'katsu'
         })

--- a/src/ui-component/ingest/ClinicalIngest.js
+++ b/src/ui-component/ingest/ClinicalIngest.js
@@ -49,7 +49,7 @@ function ClinicalIngest({ setTab, fileUpload, clinicalData }) {
 
     useEffect(() => {
         function fetchPrograms() {
-            return fetchFederation('v2/discovery/donors/', 'katsu')
+            return fetchFederation('v3/discovery/donors/', 'katsu')
                 .then((result) => {
                     result.forEach((site) => {
                         const programs = site.results.discovery_donor;

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -22,7 +22,7 @@ function SearchHandler({ setLoading }) {
     useEffect(() => {
         setLoading(true);
         lastPromise = trackPromise(
-            fetchFederation('v2/discovery/sidebar_list', 'katsu')
+            fetchFederation('v3/discovery/sidebar_list', 'katsu')
                 .then((data) => {
                     writer((old) => ({ ...old, sidebar: data }));
                 })
@@ -30,7 +30,7 @@ function SearchHandler({ setLoading }) {
                 .then((data) => {
                     writer((old) => ({ ...old, federation: data }));
                 })
-                .then(() => fetchFederation('v2/authorized/programs', 'katsu'))
+                .then(() => fetchFederation('v3/authorized/programs', 'katsu'))
                 .then((data) => {
                     writer((old) => ({ ...old, programs: data }));
                 })
@@ -165,7 +165,7 @@ function SearchHandler({ setLoading }) {
         }
         setLoading(true);
 
-        const url = `v2/authorized/donor_with_clinical_data/program/${reader.cohort}/donor/${reader.donorID}`;
+        const url = `v3/authorized/donor_with_clinical_data/program/${reader.cohort}/donor/${reader.donorID}`;
         trackPromise(
             fetchFederation(url, 'katsu')
                 .then((data) => {

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -53,7 +53,7 @@ function useClinicalPatientData(patientId, programId, location, forceSelection) 
             try {
                 // Construct the API URL based on the provided parameters
                 if (programId && patientId) {
-                    const url = `v2/authorized/donor_with_clinical_data/program/${programId}/donor/${patientId}`;
+                    const url = `v3/authorized/donor_with_clinical_data/program/${programId}/donor/${patientId}`;
 
                     const result = await fetchFederation(url, 'katsu');
                     // Extract patientData from the fetched result or use an empty object

--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -160,7 +160,7 @@ function ClinicalView() {
             <Typography pb={1} variant="h4">
                 Clinical Data
             </Typography>
-            <div style={{ height: 510, width: '100%' }}>
+            <div style={{ height: 680, width: '100%' }}>
                 <DataGrid
                     rows={rows}
                     columns={columns}

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -566,7 +566,7 @@ function Sidebar() {
                 <StyledCheckboxList
                     options={systemicTherapyDrugNames}
                     onWrite={writerContext}
-                    groupName="systemic_therapy"
+                    groupName="drug_name"
                     useAutoComplete={systemicTherapyDrugNames.length >= 5}
                     hide={hideClinical}
                     checked={selectedSystemicTherapy}

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -417,9 +417,7 @@ function Sidebar() {
     const [selectedCohorts, setSelectedCohorts] = useState({});
     const [selectedTreatment, setSelectedTreatment] = useState({});
     const [selectedPrimarySite, setSelectedPrimarySite] = useState({});
-    const [selectedChemotherapy, setSelectedChemotherapy] = useState({});
-    const [selectedImmunotherapy, setSelectedImmunotherapy] = useState({});
-    const [selectedHormoneTherapy, setSelectedHormoneTherapy] = useState({});
+    const [selectedSystemicTherapy, setSelectedSystemicTherapy] = useState({});
 
     // On our first load, remove all query parameters
     useEffect(() => {
@@ -449,9 +447,7 @@ function Sidebar() {
         // Clinical
         setSelectedTreatment({});
         setSelectedPrimarySite({});
-        setSelectedChemotherapy({});
-        setSelectedImmunotherapy({});
-        setSelectedHormoneTherapy({});
+        setSelectedSystemicTherapy({});
 
         // Set context writer to include only nodes and cohorts
         writerContext({
@@ -481,9 +477,7 @@ function Sidebar() {
     const authorizedCohorts = readerContext?.programs?.flatMap((loc) => loc?.results?.items.map((cohort) => cohort.program_id)) || [];
     const treatmentTypes = ExtractSidebarElements('treatment_types');
     const tumourPrimarySites = ExtractSidebarElements('tumour_primary_sites');
-    const chemotherapyDrugNames = ExtractSidebarElements('chemotherapy_drug_names');
-    const immunotherapyDrugNames = ExtractSidebarElements('immunotherapy_drug_names');
-    const hormoneTherapyDrugNames = ExtractSidebarElements('hormone_therapy_drug_names');
+    const systemicTherapyDrugNames = ExtractSidebarElements('drug_names');
     const chromosomes = [];
     const genes = readerContext?.genes;
 
@@ -551,7 +545,7 @@ function Sidebar() {
                     options={treatmentTypes}
                     onWrite={writerContext}
                     groupName="treatment"
-                    useAutoComplete={treatmentTypes.length >= 10}
+                    useAutoComplete={treatmentTypes.length >= 5}
                     hide={hideClinical}
                     checked={selectedTreatment}
                     setChecked={setSelectedTreatment}
@@ -562,43 +556,21 @@ function Sidebar() {
                     options={tumourPrimarySites}
                     onWrite={writerContext}
                     groupName="primary_site"
-                    useAutoComplete={tumourPrimarySites.length >= 10}
+                    useAutoComplete={tumourPrimarySites.length >= 5}
                     hide={hideClinical}
                     checked={selectedPrimarySite}
                     setChecked={setSelectedPrimarySite}
                 />
             </SidebarGroup>
-            <SidebarGroup name="Chemotherapy" hide={hideClinical}>
+            <SidebarGroup name="Systemic Therapy Drug Names" hide={hideClinical}>
                 <StyledCheckboxList
-                    options={chemotherapyDrugNames}
+                    options={systemicTherapyDrugNames}
                     onWrite={writerContext}
-                    groupName="chemotherapy"
-                    useAutoComplete={chemotherapyDrugNames.length >= 10}
+                    groupName="systemic_therapy"
+                    useAutoComplete={systemicTherapyDrugNames.length >= 5}
                     hide={hideClinical}
-                    checked={selectedChemotherapy}
-                    setChecked={setSelectedChemotherapy}
-                />
-            </SidebarGroup>
-            <SidebarGroup name="Immunotherapy" hide={hideClinical}>
-                <StyledCheckboxList
-                    options={immunotherapyDrugNames}
-                    onWrite={writerContext}
-                    groupName="immunotherapy"
-                    useAutoComplete={immunotherapyDrugNames.length >= 10}
-                    hide={hideClinical}
-                    checked={selectedImmunotherapy}
-                    setChecked={setSelectedImmunotherapy}
-                />
-            </SidebarGroup>
-            <SidebarGroup name="Hormone Therapy" hide={hideClinical}>
-                <StyledCheckboxList
-                    options={hormoneTherapyDrugNames}
-                    onWrite={writerContext}
-                    groupName="hormone_therapy"
-                    useAutoComplete={hormoneTherapyDrugNames.length >= 10}
-                    hide={hideClinical}
-                    checked={selectedHormoneTherapy}
-                    setChecked={setSelectedHormoneTherapy}
+                    checked={selectedSystemicTherapy}
+                    setChecked={setSelectedSystemicTherapy}
                 />
             </SidebarGroup>
         </Root>

--- a/src/views/clinicalGenomic/widgets/timeline.js
+++ b/src/views/clinicalGenomic/widgets/timeline.js
@@ -124,7 +124,7 @@ function Timeline({ data, onEventClick }) {
                           }
 
                           // Determine the biomarker name
-                          const biomarkerName = `${namePrefix}${id || ''} Biomarker Test`;
+                          const biomarkerName = `${namePrefix}${id} 'Biomarker Test`;
 
                           // Return the series data point
                           return biomarkerDate

--- a/src/views/clinicalGenomic/widgets/timeline.js
+++ b/src/views/clinicalGenomic/widgets/timeline.js
@@ -65,14 +65,15 @@ function Timeline({ data, onEventClick }) {
     const [isTreatmentsCollapsed, setIsTreatmentsCollapsed] = useState(false);
     const theme = useTheme();
     useEffect(() => {
-        const birthDate = data?.date_of_birth?.month_interval ?? 0;
+        let dob = data?.date_of_birth?.month_interval ?? 0;
+        dob += data?.date_of_birth?.day_interval ? (data.date_of_birth.day_interval % 32) / 32 : 0;
 
         const formatDate = (date) => {
             if (date?.month_interval !== undefined) {
                 if (date?.day_interval) {
-                    return date.month_interval + date.day_interval / 32 - birthDate;
+                    return date.month_interval + (date.day_interval % 32) / 32 - dob;
                 }
-                return date.month_interval - birthDate;
+                return date.month_interval - dob;
             }
             return '';
         };
@@ -150,7 +151,6 @@ function Timeline({ data, onEventClick }) {
                     : []
             ) || [];
 
-        const dob = data?.date_of_birth?.month_interval;
         const dateOfBirthSeries = generateSeriesDataSingle(data?.date_of_birth, 'Date of Birth', 0, theme.palette.primary.light, dob);
         const dateOfDeathSeries = generateSeriesDataSingle(data?.date_of_death, 'Age at Death', 0, theme.palette.primary.main, dob);
         const dateAliveAfterLostToFollowupSeries = generateSeriesDataSingle(

--- a/src/views/clinicalGenomic/widgets/timeline.js
+++ b/src/views/clinicalGenomic/widgets/timeline.js
@@ -17,11 +17,11 @@ const formatHeader = (dateResolution) =>
 
         if (dateResolution === 'Month') {
             const monthsSinceStart = (value % 12) + 1;
-            return `${monthsSinceStart} Month(s)`;
+            return `${monthsSinceStart}M`;
         }
         if (dateResolution === 'Year') {
             const yearsSinceStart = Math.floor(value / 12);
-            return `${yearsSinceStart} Year(s) Old`;
+            return `${yearsSinceStart}Y`;
         }
         return `Age Unknown`;
     };
@@ -124,9 +124,30 @@ function Timeline({ data, onEventClick }) {
                           }
 
                           // Determine the biomarker name
-                          const biomarkerName = `${namePrefix}${id} 'Biomarker Test`;
+                          let dateLabel = '';
 
-                          // Return the series data point
+                          if (!id) {
+                              if (biomarkerDate || linkedObjectDate) {
+                                  const dateObject = biomarkerDate || linkedObjectDate;
+                                  if (dateObject.day_interval) {
+                                      const ageInDays = dateObject.day_interval;
+                                      const years = Math.floor(ageInDays / 365);
+                                      const remainingDays = ageInDays % 365;
+                                      const months = Math.floor(remainingDays / 30);
+                                      const days = remainingDays % 30;
+
+                                      dateLabel = `${years}y ${months}m ${days}d`;
+                                  } else if (dateObject.month_interval) {
+                                      const ageInMonths = dateObject.month_interval;
+                                      const years = Math.floor(ageInMonths / 12);
+                                      const remainingMonths = ageInMonths % 12;
+                                      dateLabel = `${years}y ${remainingMonths}m`;
+                                  }
+                              }
+                          }
+
+                          const biomarkerName = `${namePrefix}${id || ''} Biomarker ${id ? '' : `${dateLabel} since diagnosis`}`;
+                          // Return the series data pointy
                           return biomarkerDate
                               ? {
                                     x: formatDate(biomarkerDate),


### PR DESCRIPTION
## Ticket(s)
[DIG-1687: Data portal model 3 changes](https://candig.atlassian.net/browse/DIG-1687)

## Description
Upgrading the portal to work with Katsu and Query v3 model changes

## Expected Behaviour
- Portal should work as it did before with some minor visual changes like the sidebar now just has systemic therapy vs chemo, hormone, and immuno options

## Related Issues 
- [Query v3 Model](https://github.com/CanDIG/candigv2-query/pull/45l)
- [Katsu v3 Model](https://github.com/CanDIG/katsu/tree/model_3)

## Screenshots (if appropriate)
![image](https://github.com/user-attachments/assets/3fa9c1a4-7897-4a37-8ec2-1e5222b3559f)


## To do/Tickets to be made before merging branch
- To be merged into CanDIGv2 alongside other v3 model changes

## Types of Change(s)
-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:
-   [x] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
