### PR TITLE
DIG-1410: Disappearing sidebar bug mobile size sidebar

### DIFF
--- a/src/layout/MainLayout/Sidebar/index.js
+++ b/src/layout/MainLayout/Sidebar/index.js
@@ -71,8 +71,6 @@ function Sidebar({ useFullScreen, drawerOpen, drawerToggle }) {
     //      To fix this, we're going to manually force the menu closed when we detect useFullScreen changes
     const useOpen = useFullScreen !== lastUsedFullscreen ? false : drawerOpen;
 
-    console.log(`drawerOpen: ${drawerOpen} useFullScreen: ${useFullScreen}`);
-
     return (
         <Root className={classes.drawer} aria-label="mailbox folders">
             <Drawer

--- a/src/layout/MainLayout/Sidebar/index.js
+++ b/src/layout/MainLayout/Sidebar/index.js
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 
 import { styled } from '@mui/material/styles';
+import { useEffect, useState } from 'react';
 
 // mui
-import { useTheme } from '@mui/system';
-import { Box, Drawer, useMediaQuery } from '@mui/material';
+import { Box, Drawer } from '@mui/material';
 
 // third-party
 import PerfectScrollbar from 'react-perfect-scrollbar';
@@ -58,50 +58,50 @@ const Root = styled('nav')(({ theme }) => ({
 }));
 
 // ===========================|| SIDEBAR DRAWER ||=========================== //
-function Sidebar({ drawerOpen, drawerToggle, screen }) {
-    const theme = useTheme();
-    const matchUpMd = useMediaQuery(theme.breakpoints.up('md'));
+function Sidebar({ useFullScreen, drawerOpen, drawerToggle }) {
     const sidebarContext = useSidebarReaderContext();
+    const [lastUsedFullscreen, setLastUsedFullscreen] = useState(useFullScreen);
 
-    const drawer = (
-        <>
-            <Box sx={{ display: { xs: 'block', md: 'none' } }}>
-                <div className={classes.boxContainer}>
-                    <LogoSection />
-                </div>
-            </Box>
-            <BrowserView>
-                <PerfectScrollbar component="div" className={classes.ScrollHeight}>
-                    {
-                        // The fragment below suppresses a warning we get in console due to undefined passed as a child
-                        // eslint-disable-next-line react/jsx-no-useless-fragment
-                        sidebarContext || <></>
-                    }
-                </PerfectScrollbar>
-            </BrowserView>
-            <MobileView>
-                <Box sx={{ px: 2 }}>{sidebarContext || null}</Box>
-            </MobileView>
-        </>
-    );
+    useEffect(() => {
+        setLastUsedFullscreen(useFullScreen);
+    }, [useFullScreen]);
 
-    const container = screen !== undefined ? () => window().document.body : undefined;
+    // NB: There's an issue where changing Drawer's `variant` and `open` too quickly (i.e. in a double-redraw update via useEffect)
+    //      causes a bug where the modal presentation is open (blocking user input) but nothing is displayed
+    //      To fix this, we're going to manually force the menu closed when we detect useFullScreen changes
+    const useOpen = useFullScreen !== lastUsedFullscreen ? false : drawerOpen;
+
+    console.log(`drawerOpen: ${drawerOpen} useFullScreen: ${useFullScreen}`);
 
     return (
         <Root className={classes.drawer} aria-label="mailbox folders">
             <Drawer
-                container={container}
-                variant={matchUpMd ? 'persistent' : 'temporary'}
+                variant={useFullScreen ? 'persistent' : 'temporary'}
                 anchor="left"
-                open={drawerOpen}
+                open={useOpen}
                 onClose={drawerToggle}
                 classes={{
                     paper: classes.drawerPaper
                 }}
-                ModalProps={{ keepMounted: true }}
                 color="inherit"
             >
-                {drawer}
+                <Box sx={{ display: { xs: 'block', md: 'none' } }}>
+                    <div className={classes.boxContainer}>
+                        <LogoSection />
+                    </div>
+                </Box>
+                <BrowserView>
+                    <PerfectScrollbar component="div" className={classes.ScrollHeight}>
+                        {
+                            // The fragment below suppresses a warning we get in console due to undefined passed as a child
+                            // eslint-disable-next-line react/jsx-no-useless-fragment
+                            sidebarContext || <></>
+                        }
+                    </PerfectScrollbar>
+                </BrowserView>
+                <MobileView>
+                    <Box sx={{ px: 2 }}>{sidebarContext || null}</Box>
+                </MobileView>
             </Drawer>
         </Root>
     );
@@ -110,7 +110,7 @@ function Sidebar({ drawerOpen, drawerToggle, screen }) {
 Sidebar.propTypes = {
     drawerOpen: PropTypes.bool,
     drawerToggle: PropTypes.func,
-    screen: PropTypes.object
+    useFullScreen: PropTypes.bool
 };
 
 export default Sidebar;

--- a/src/layout/MainLayout/index.js
+++ b/src/layout/MainLayout/index.js
@@ -145,7 +145,7 @@ function MainLayout() {
                 </AppBar>
 
                 {/* drawer */}
-                <Sidebar drawerOpen={leftDrawerOpened} drawerToggle={handleLeftDrawerToggle} />
+                <Sidebar useFullScreen={!matchDownMd} drawerOpen={leftDrawerOpened} drawerToggle={handleLeftDrawerToggle} />
 
                 {/* main content */}
                 <main


### PR DESCRIPTION
Fix the blocking of user input when the size of the screen changes with the sidebar open on the search page. This can be safely merged into the `model_3` branch.

## Ticket(s)

- [DIG-1410](https://candig.atlassian.net/browse/DIG-1410)

## Description

- This was hard to track down: when the user is on the search page, has the sidebar open, and then resizes their screen past the "medium" screensize breakpoint (about half the size of my monitor), the entire screen stops accepting input. I tracked this down to the following behaviour: 

1. The screensize trips past the Medium threshold, causing the Sidebar's MUI Drawer component to switch variants from "permanent" to "temporary"
2. A separate useEffect in MainLayout sees the switch, and immediately sets off to close the sidebar (so that the user isn't looking at a full-screen sidebar upon switching sizes, intended behaviour)
3. The first rerender partially completes, and React attempts to draw a modal-full-screen sidebar
4. The modal is immediately closed
5. An internal MUI widget known as "Mui-Presentation", which is used to handle modal dialogues, remains open

## Screenshots (if appropriate)

### Before PR

[Screencast from 2024-08-12 02:05:51 PM.webm](https://github.com/user-attachments/assets/aa31b0cb-0904-40fc-a02b-c038ce172de3)

### After PR

[Screencast from 2024-08-12 01:55:46 PM.webm](https://github.com/user-attachments/assets/5f6af804-f836-4136-9df3-94bd1773e041)

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-1410]: https://candig.atlassian.net/browse/DIG-1410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ