### PR TITLE
Reset Filter button selects all nodes

### DIFF
--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -428,13 +428,9 @@ function Sidebar() {
 
     function resetButton() {
         // Reset state variables for checkboxes and dropdowns
-        const locations = readerContext?.programs?.map((loc) => loc.location.name);
+        setSelectedNodes({});
+        setSelectedCohorts({});
 
-        if (locations) {
-            setSelectedNodes(locations);
-        }
-
-        setSelectedCohorts([readerContext?.federation?.map((loc) => loc.results.map((cohort) => cohort.program_id)).flat(1) || []]);
         // Genomic
         setSelectedGenes('');
         setSelectedChromosomes('');

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -431,12 +431,7 @@ function Sidebar() {
         const locations = readerContext?.programs?.map((loc) => loc.location.name);
 
         if (locations) {
-            const selectedNodes = locations.reduce((acc, loc) => {
-                acc[loc] = true;
-                return acc;
-            }, {});
-
-            setSelectedNodes(selectedNodes);
+            setSelectedNodes(locations);
         }
 
         setSelectedCohorts([readerContext?.federation?.map((loc) => loc.results.map((cohort) => cohort.program_id)).flat(1) || []]);


### PR DESCRIPTION
## Ticket(s)
[DIG-1716: Hitting the 'Reset Filters' button unchecks local node](https://candig.atlassian.net/browse/DIG-1716)

## Description
Changing the reset of location to be an array like cohorts

## Expected Behaviour
When you press the reset button all nodes will become selected again

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
