### PR TITLE
Fix summary age at diagnosis + fix timeline

### DIFF
--- a/src/views/clinicalGenomic/widgets/timeline.js
+++ b/src/views/clinicalGenomic/widgets/timeline.js
@@ -86,7 +86,8 @@ function Timeline({ data, onEventClick }) {
                           y,
                           name,
                           color: colour,
-                          customGroupId: name
+                          customGroupId: name,
+                          showInNavigator: true
                       }
                   ]
                 : [];
@@ -98,7 +99,8 @@ function Timeline({ data, onEventClick }) {
                       y,
                       name: `${namePrefix}${item?.[id]}`,
                       color: colour,
-                      customGroupId: name
+                      customGroupId: name,
+                      showInNavigator: true
                   }))
                 : [];
 
@@ -154,7 +156,8 @@ function Timeline({ data, onEventClick }) {
                                     y,
                                     name: biomarkerName,
                                     color: colour,
-                                    customGroupId: name
+                                    customGroupId: name,
+                                    showInNavigator: true
                                 }
                               : null;
                       })
@@ -169,7 +172,8 @@ function Timeline({ data, onEventClick }) {
                           y,
                           name: `${namePrefix}${subItem?.[id]}`,
                           color: colour,
-                          customGroupId: name
+                          customGroupId: name,
+                          showInNavigator: true
                       }))
                     : []
             ) || [];
@@ -185,7 +189,8 @@ function Timeline({ data, onEventClick }) {
                                     y,
                                     name: `${namePrefix}${subItem2?.[id]}`,
                                     color: colour,
-                                    customGroupId: name
+                                    customGroupId: name,
+                                    showInNavigator: true
                                 }))
                               : []
                       )
@@ -572,6 +577,7 @@ function Timeline({ data, onEventClick }) {
                         }
                     },
                     cursor: 'pointer',
+                    showInNavigator: true,
                     events: {
                         click(event) {
                             const seriesID = event.point.series.userOptions.data[0].customGroupId;

--- a/src/views/summary/summary.js
+++ b/src/views/summary/summary.js
@@ -239,6 +239,7 @@ function Summary() {
                     dataVis=""
                     height="400px; auto"
                     loading={diagnosisAgeCount === undefined}
+                    orderAlphabetically
                     chartType="bar"
                     dropDown={false}
                 />


### PR DESCRIPTION
## Ticket(s)

- N/A

## Description

Fixup two bits of behaviour:
1. Age at diagnosis on the summary page is out of order
2. Timeline was not displaying a preview along the bottom

## Screenshots (if appropriate)

### Before PR

![image](https://github.com/user-attachments/assets/b2e31cab-d842-46ad-9191-a17da98fffa8)

![image](https://github.com/user-attachments/assets/146f7a9c-da47-49cc-887e-0e14cf48f949)


### After PR
![image](https://github.com/user-attachments/assets/1abecce1-c58b-4937-bedd-e8c1e49d0eb6)

![image](https://github.com/user-attachments/assets/c47b6e5d-5c81-4cd9-b376-e1f50d9a4170)

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [x] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
