### PR TITLE
Switch summary page loading to asynchronous, and also fixup the usage of isLoading to support per-endpoint loading

### DIFF
--- a/src/views/summary/summary.js
+++ b/src/views/summary/summary.js
@@ -18,7 +18,7 @@ import { useSidebarWriterContext } from 'layout/MainLayout/Sidebar/SidebarContex
 
 function Summary() {
     const theme = useTheme();
-    const [isLoading, setLoading] = useState(true);
+    const [isLoading, setLoading] = useState({});
 
     const [provinceCounter, setProvinceCount] = useState(0);
     const [individualCount, setIndividualCount] = useState(undefined);
@@ -131,16 +131,33 @@ function Summary() {
         }
     }
 
-    function fetchClinical() {
-        fetchClinicalCompleteness().then((data) => {
-            setNumClinicalComplete(data.numClinicalComplete);
+    function finishEndpoint(endpoint) {
+        setLoading((old) => {
+            const newObj = { ...old };
+            newObj[endpoint] = false;
+            console.log(newObj);
+            return newObj;
         });
     }
 
+    function fetchClinical() {
+        fetchClinicalCompleteness()
+            .then((data) => {
+                setNumClinicalComplete(data.numClinicalComplete);
+            })
+            .finally(() => {
+                finishEndpoint('clinical');
+            });
+    }
+
     function fetchGenomic() {
-        fetchGenomicCompleteness().then((numCompleteGenomic) => {
-            setNumGenomicComplete(numCompleteGenomic);
-        });
+        fetchGenomicCompleteness()
+            .then((numCompleteGenomic) => {
+                setNumGenomicComplete(numCompleteGenomic);
+            })
+            .finally(() => {
+                finishEndpoint('genomic');
+            });
     }
 
     useEffect(() => {
@@ -155,18 +172,20 @@ function Summary() {
                 .catch((error) => {
                     // pass
                     console.log('Error fetching data : ', error);
+                })
+                .finally(() => {
+                    finishEndpoint(endpoint);
                 });
         }
 
-        fetchData('/individual_count')
-            .then(() => fetchData('/primary_site_count'))
-            .then(() => fetchData('/cohort_count'))
-            .then(() => fetchData('/patients_per_cohort'))
-            .then(() => fetchData('/treatment_type_count'))
-            .then(() => fetchData('/diagnosis_age_count'))
-            .then(() => fetchGenomic())
-            .then(() => fetchClinical())
-            .finally(() => setLoading(false));
+        fetchData('/individual_count');
+        fetchData('/primary_site_count');
+        fetchData('/cohort_count');
+        fetchData('/patients_per_cohort');
+        fetchData('/treatment_type_count');
+        fetchData('/diagnosis_age_count');
+        fetchGenomic();
+        fetchClinical();
     }, []);
 
     return (
@@ -204,7 +223,7 @@ function Summary() {
             )}
             <Grid item xs={12} sm={12} md={6} lg={3}>
                 <SmallCountCard
-                    isLoading={isLoading}
+                    isLoading={isLoading['/individual_count']}
                     title="Number of Patients"
                     count={individualCount?.individual_count || 0}
                     primary
@@ -214,6 +233,7 @@ function Summary() {
             </Grid>
             <Grid item xs={12} sm={12} md={6} lg={3}>
                 <SmallCountCard
+                    isLoading={isLoading['/individual_count']}
                     title="Cohorts"
                     count={cohortCount?.cohort_count || 0}
                     icon={<Hive fontSize="inherit" />}
@@ -222,7 +242,7 @@ function Summary() {
             </Grid>
             <Grid item xs={12} sm={12} md={6} lg={3}>
                 <SmallCountCard
-                    isLoading={isLoading}
+                    isLoading={isLoading['/individual_count']}
                     title="Provinces"
                     count={provinceCounter || 0}
                     icon={<Public fontSize="inherit" />}
@@ -238,7 +258,7 @@ function Summary() {
                     dataObject={diagnosisAgeCount || {}}
                     dataVis=""
                     height="400px; auto"
-                    loading={diagnosisAgeCount === undefined}
+                    loading={isLoading['/diagnosis_age_count']}
                     orderAlphabetically
                     chartType="bar"
                     dropDown={false}
@@ -251,7 +271,7 @@ function Summary() {
                     dataVis=""
                     chartType="bar"
                     height="400px; auto"
-                    loading={treatmentTypeCount === undefined}
+                    loading={isLoading['/treatment_type_count']}
                     orderByFrequency
                     cutoff={10}
                 />
@@ -264,7 +284,7 @@ function Summary() {
                     chartType="bar"
                     height="400px; auto"
                     dropDown={false}
-                    loading={primarySiteCount === undefined}
+                    loading={isLoading['/primary_site_count']}
                     orderByFrequency
                     cutoff={10}
                 />
@@ -277,7 +297,7 @@ function Summary() {
                     chartType="bar"
                     height="400px; auto"
                     dropDown={false}
-                    loading={patientsPerCohort === undefined}
+                    loading={isLoading['/patients_per_cohort']}
                     orderByFrequency
                     cutoff={10}
                 />
@@ -290,7 +310,7 @@ function Summary() {
                     chartType="bar"
                     height="400px; auto"
                     dropDown={false}
-                    loading={numClinicalComplete === undefined}
+                    loading={isLoading.clinical}
                     orderByFrequency
                     cutoff={10}
                 />
@@ -303,7 +323,7 @@ function Summary() {
                     chartType="bar"
                     height="400px; auto"
                     dropDown={false}
-                    loading={numGenomicComplete === undefined}
+                    loading={isLoading.genomic}
                     orderByFrequency
                     cutoff={10}
                 />

--- a/src/views/summary/summary.js
+++ b/src/views/summary/summary.js
@@ -185,6 +185,7 @@ function Summary() {
         fetchData('/diagnosis_age_count');
         fetchGenomic();
         fetchClinical();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     return (

--- a/src/views/summary/summary.js
+++ b/src/views/summary/summary.js
@@ -135,7 +135,6 @@ function Summary() {
         setLoading((old) => {
             const newObj = { ...old };
             newObj[endpoint] = false;
-            console.log(newObj);
             return newObj;
         });
     }


### PR DESCRIPTION
## Ticket(s)

- [DIG-1786](https://candig.atlassian.net/browse/DIG-1786)
- [DIG-1787](https://candig.atlassian.net/browse/DIG-1787)

## Description

- This fixes up both tickets at once -- making loading the endpoints an asynchronous thing (now that we have better asynchronous support w/ gunicorn), and also switching isLoading to be a dict that tracks progress per-endpoint.

## Expected Behaviour

- All endpoints are called at once / isLoading works per endpoint (e.g. if say completeness takes forever, it doesn't affect the loading status of the rest)

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-1786]: https://candig.atlassian.net/browse/DIG-1786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DIG-1787]: https://candig.atlassian.net/browse/DIG-1787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ