### PR TITLE
DIG-1766: Update data portal to use new model 3.1 endpoints

### DIFF
--- a/src/views/clinicalGenomic/widgets/patientSidebar.js
+++ b/src/views/clinicalGenomic/widgets/patientSidebar.js
@@ -96,18 +96,19 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtFirs
                     obj[key] !== null &&
                     obj[key] !== undefined &&
                     obj[key] !== '' &&
+                    !key.endsWith('_not_available') &&
                     (!(typeof obj[key] === 'object') || (typeof obj[key] === 'object' && 'month_interval' in obj[key]))
                 );
             });
 
-            let value = key;
+            let value = key.toLowerCase();
             if (key === 'date_of_diagnosis') {
                 value = `Age at Diagnosis`;
-            } else if (key.endsWith('_start_date')) {
+            } else if (key.endsWith('start_date') || key === 'test_date') {
                 value = `Diagnosis_to_${key}`;
                 startDate = key;
-            } else if (key.endsWith('_end_date')) {
-                value = key.split('_end_date')[0];
+            } else if (key.endsWith('end_date')) {
+                value = key.split('end_date')[0].replace(/_+$/, '');
                 value = `${value.trim()} Duration`;
                 endDate = key;
             } else if (key.startsWith('date_of_')) {
@@ -189,6 +190,11 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtFirs
                     row[column.field] = ageAtFirstDiagnosis + Math.floor(obj[column.field].month_interval / 12);
                 } else {
                     row[column.field] = Array.isArray(obj[column.field]) ? obj[column.field].join(', ') : obj[column.field]; // Add spaces to arrays
+                }
+
+                // The boolean in FIELD_not_available can override whatever the actual value is
+                if (obj[`${column.field}_not_available`]) {
+                    row[column.field] = 'Not available';
                 }
             });
 


### PR DESCRIPTION
## Ticket(s)

- [DIG-1766](https://candig.atlassian.net/browse/DIG-1766)

## Description

Single donor view fixup changes for model 3: 

- Not Available field handling 
- Test date and Systemic Therapies columns being mishandled

## Screenshots (if appropriate)

### Before PR

![image](https://github.com/user-attachments/assets/425d03cb-6754-4dc0-ad1c-1f5db7fa8ee7)
![image](https://github.com/user-attachments/assets/cd1b2822-12c5-42ae-9fe6-bbef9c1492d2)


### After PR

![image](https://github.com/user-attachments/assets/0609fa4c-8023-4ac3-8436-eb5ed4ebfc9e)
![image](https://github.com/user-attachments/assets/b3ef38dc-ece8-4a9e-a8fd-c6a539b56f31)

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-1766]: https://candig.atlassian.net/browse/DIG-1766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ