### PR TITLE
Summary page: Set initial loading state to true

### DIFF
--- a/src/views/summary/summary.js
+++ b/src/views/summary/summary.js
@@ -18,7 +18,16 @@ import { useSidebarWriterContext } from 'layout/MainLayout/Sidebar/SidebarContex
 
 function Summary() {
     const theme = useTheme();
-    const [isLoading, setLoading] = useState({});
+    const [isLoading, setLoading] = useState({
+        '/individual_count': true,
+        '/primary_site_count': true,
+        '/cohort_count': true,
+        '/patients_per_cohort': true,
+        '/treatment_type_count': true,
+        '/diagnosis_age_count': true,
+        clinical: true,
+        genomic: true
+    });
 
     const [provinceCounter, setProvinceCount] = useState(0);
     const [individualCount, setIndividualCount] = useState(undefined);


### PR DESCRIPTION
## Description
@SonQBChau  playwright tests for the summary page caught isLoading never being triggered. This addition changes the default value to true instead of undefined

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
