### PR TITLE
FIxup various warnings on the summary page

### DIFF
--- a/src/ui-component/cards/SmallCountCard.js
+++ b/src/ui-component/cards/SmallCountCard.js
@@ -26,7 +26,7 @@ const classes = {
 // ===========================|| INDIVIDUALS - SMALL COUNT CARD ||=========================== //
 
 function SmallCountCard({ isLoading, title, count, icon, color }) {
-    const events = useSelector((state) => state);
+    const customization = useSelector((state) => state.customization);
 
     // TODO jss-to-styled codemod: The Fragment root was replaced by div. Change the tag if needed.
     const Root = styled('div')(({ theme }) => ({
@@ -98,7 +98,7 @@ function SmallCountCard({ isLoading, title, count, icon, color }) {
             ) : (
                 <MainCard
                     border
-                    sx={{ borderRadius: events.customization.borderRadius * 0.25 }}
+                    sx={{ borderRadius: customization.borderRadius * 0.25 }}
                     className={classes.card}
                     contentClass={classes.content}
                 >

--- a/src/views/summary/CustomOfflineChart.js
+++ b/src/views/summary/CustomOfflineChart.js
@@ -12,6 +12,7 @@ import { useSelector } from 'react-redux';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import NoDataToDisplay from 'highcharts/modules/no-data-to-display';
+import highchartsAccessibility from 'highcharts/modules/accessibility';
 import { IconTrash } from '@tabler/icons-react';
 
 // Custon Components and constants
@@ -31,26 +32,25 @@ window.Highcharts = Highcharts;
  * @param {array} dataObject
  */
 
-function CustomOfflineChart(props) {
-    const {
-        chartType,
-        data,
-        index,
-        height,
-        dataVis,
-        dataObject,
-        dropDown,
-        onRemoveChart,
-        edit,
-        loading,
-        orderByFrequency,
-        orderAlphabetically,
-        cutoff,
-        grayscale,
-        trimByDefault,
-        onChangeDataVisChartType,
-        onChangeDataVisData
-    } = props;
+function CustomOfflineChart({
+    chartType,
+    data,
+    index,
+    height = '200px; auto',
+    dataVis,
+    dataObject,
+    dropDown,
+    onRemoveChart,
+    edit,
+    loading,
+    orderByFrequency,
+    orderAlphabetically,
+    cutoff,
+    grayscale,
+    trimByDefault,
+    onChangeDataVisChartType,
+    onChangeDataVisData
+}) {
     const theme = useTheme();
 
     // State management
@@ -61,6 +61,7 @@ function CustomOfflineChart(props) {
     const chartRef = createRef();
 
     NoDataToDisplay(Highcharts);
+    highchartsAccessibility(Highcharts);
 
     const [chartOptions, setChartOptions] = useState({
         credits: {
@@ -128,6 +129,10 @@ function CustomOfflineChart(props) {
 
                         // Case 3: an object whose keys are cohorts and whose values are numbers
                         return Object.values(datum).some((val) => typeof val === 'string' && val.startsWith('<'));
+                    }
+
+                    if (typeof datum === 'number') {
+                        return false;
                     }
 
                     console.log(`Could not parse input to hasCensoredData: ${datum}`);
@@ -542,10 +547,6 @@ CustomOfflineChart.propTypes = {
     trimByDefault: PropTypes.bool,
     onChangeDataVisChartType: PropTypes.func,
     onChangeDataVisData: PropTypes.func
-};
-
-CustomOfflineChart.defaultProps = {
-    height: '200px; auto'
 };
 
 export default CustomOfflineChart;


### PR DESCRIPTION
## Description

- This fixes the warnings that were being output on the summary page

## Expected Behaviour

- When you load the summary page, nothing should show up in the console

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
