### PR TITLE
DIG-1820 / DIG-1832: Redscreen errors on prod

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -9,10 +9,11 @@
 export function aggregateObj(stat, aggregateObj, aggregator = (object, key) => object[key]) {
     const count = { ...aggregateObj };
     Object.keys(stat).forEach((key) => {
+        const value = parseInt(aggregator(stat, key), 10);
         if (key in count) {
-            count[key] += aggregator(stat, key);
+            count[key] += value;
         } else {
-            count[key] = aggregator(stat, key);
+            count[key] = value;
         }
     });
     return count;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -9,11 +9,10 @@
 export function aggregateObj(stat, aggregateObj, aggregator = (object, key) => object[key]) {
     const count = { ...aggregateObj };
     Object.keys(stat).forEach((key) => {
-        const value = parseInt(aggregator(stat, key), 10);
         if (key in count) {
-            count[key] += value;
+            count[key] += aggregator(stat, key);
         } else {
-            count[key] = value;
+            count[key] = aggregator(stat, key);
         }
     });
     return count;

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -127,12 +127,14 @@ function SearchHandler({ setLoading }) {
                     // Reorder the data, and fill out the patients per cohort
                     const clinicalData = {};
                     data.forEach((site) => {
-                        clinicalData[site.location.name] = site?.results;
+                        if ('results' in site) {
+                            clinicalData[site.location.name] = site?.results;
+                        }
                     });
 
                     const genomicData = data
                         .map((site) =>
-                            site.results.genomic?.map((caseData) => {
+                            site?.results?.genomic?.map((caseData) => {
                                 caseData.location = site.location;
                                 return caseData;
                             })

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -446,7 +446,7 @@ function Sidebar() {
             filter: {
                 node: [readerContext?.programs?.map((loc) => loc.location.name) || []], // Set your default nodes
                 exclude_cohorts: [
-                    readerContext?.programs?.map((loc) => loc?.results?.items.map((cohort) => cohort.program_id)).flat(1) || []
+                    readerContext?.programs?.map((loc) => loc?.results?.items?.map((cohort) => cohort.program_id)).flat(1) || []
                 ], // Set cohorts to empty array or whichever default value you want
                 query: {}
             }
@@ -465,7 +465,7 @@ function Sidebar() {
     // Parse out what we need:
     const sites = readerContext?.programs?.map((loc) => loc.location.name) || [];
     const cohorts = readerContext?.federation?.map((loc) => loc.results?.map((cohort) => cohort.program_id) || [])?.flat(1) || [];
-    const authorizedCohorts = readerContext?.programs?.flatMap((loc) => loc?.results?.items.map((cohort) => cohort.program_id)) || [];
+    const authorizedCohorts = readerContext?.programs?.flatMap((loc) => loc?.results?.items?.map((cohort) => cohort.program_id)) || [];
     const treatmentTypes = ExtractSidebarElements('treatment_types');
     const tumourPrimarySites = ExtractSidebarElements('tumour_primary_sites');
     const systemicTherapyDrugNames = ExtractSidebarElements('drug_names');

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -464,7 +464,7 @@ function Sidebar() {
 
     // Parse out what we need:
     const sites = readerContext?.programs?.map((loc) => loc.location.name) || [];
-    const cohorts = readerContext?.federation?.map((loc) => loc.results.map((cohort) => cohort.program_id))?.flat(1) || [] || [];
+    const cohorts = readerContext?.federation?.map((loc) => loc.results?.map((cohort) => cohort.program_id) || [])?.flat(1) || [];
     const authorizedCohorts = readerContext?.programs?.flatMap((loc) => loc?.results?.items.map((cohort) => cohort.program_id)) || [];
     const treatmentTypes = ExtractSidebarElements('treatment_types');
     const tumourPrimarySites = ExtractSidebarElements('tumour_primary_sites');

--- a/src/views/summary/summary.js
+++ b/src/views/summary/summary.js
@@ -53,7 +53,7 @@ function Summary() {
 
     /* Aggregated count of federated data */
     function federationStatCount(data, endpoint) {
-        const candigDataSouceCollection = {};
+        const candigDataSourceCollection = {};
 
         if (data && Array.isArray(data)) {
             // Fake Server with same URL
@@ -72,12 +72,12 @@ function Summary() {
                     case '/individual_count':
                         setIndividualCount((oldIndividualCount) => aggregateObj(stat.results, oldIndividualCount));
                         if (stat.location) {
-                            if (!(stat.location['province-code'] in candigDataSouceCollection)) {
-                                candigDataSouceCollection[stat.location['province-code']] = 0;
+                            if (!(stat.location['province-code'] in candigDataSourceCollection)) {
+                                candigDataSourceCollection[stat.location['province-code']] = 0;
                             }
-                            candigDataSouceCollection[stat.location['province-code']] += parseInt(stat.results.individual_count, 10);
+                            candigDataSourceCollection[stat.location['province-code']] += parseInt(stat.results.individual_count, 10);
 
-                            setCanDigDataSource(candigDataSouceCollection);
+                            setCanDigDataSource(candigDataSourceCollection);
                         }
 
                         break;

--- a/src/views/summary/summary.js
+++ b/src/views/summary/summary.js
@@ -61,10 +61,8 @@ function Summary() {
             // data[0].location[1] = 'Ontario';
             // data[0].location[2] = 'ca-on';
 
-            let count = 0;
             data?.forEach((stat) => {
                 // Federation aggregate count of stats
-                count += 1;
                 if (!stat.results) {
                     // Something went wrong
                     return;

--- a/src/views/summary/summary.js
+++ b/src/views/summary/summary.js
@@ -79,9 +79,7 @@ function Summary() {
                             }
                             candigDataSouceCollection[stat.location['province-code']] += parseInt(stat.results.individual_count, 10);
 
-                            if (count === data.length) {
-                                setCanDigDataSource(candigDataSouceCollection);
-                            }
+                            setCanDigDataSource(candigDataSouceCollection);
                         }
 
                         break;


### PR DESCRIPTION
## Ticket(s)

- [DIG-1820](https://candig.atlassian.net/browse/DIG-1820)
- [DIG-1832](https://candig.atlassian.net/browse/DIG-1832)

## Description

- This should fix two issues, though I could only test one of them:
1. Data Portal doesn't continue if a single federated node fails -- this was found by logging in as one user who had no authorization to BC. Since BC was on an old version of Query, it would crash out with a 500 error if the user did not have authorization to any cohorts. The 500 would then prevent Data Portal from continuing to go with the rest of its results
2. `.map()` errors. Was not able to test this

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [x] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-1820]: https://candig.atlassian.net/browse/DIG-1820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DIG-1832]: https://candig.atlassian.net/browse/DIG-1832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ