### PR TITLE
Clean up warnings on the data portal

### DIFF
--- a/src/views/clinicalGenomic/clinicalGenomicSearch.js
+++ b/src/views/clinicalGenomic/clinicalGenomicSearch.js
@@ -23,7 +23,8 @@ const classes = {
     noSidebarOffset: `${PREFIX}-noSidebarOffset`,
     headerSpacing: `${PREFIX}-headerSpacing`,
     anchor: `${PREFIX}-anchor`,
-    navigationLink: `${PREFIX}-navigationLink`
+    navigationLink: `${PREFIX}-navigationLink`,
+    mainContent: `${PREFIX}-mainContent`
 };
 
 // TODO jss-to-styled codemod: The Fragment root was replaced by div. Change the tag if needed.
@@ -61,6 +62,10 @@ const Root = styled('div')(({ _ }) => ({
     [`& .${classes.navigationLink}`]: {
         float: 'right',
         textAlign: 'right'
+    },
+
+    [`& .${classes.mainContent}`]: {
+        padding: '16px !important'
     }
 }));
 
@@ -160,7 +165,7 @@ function ClinicalGenomicSearch() {
                                 key={section.id}
                                 border
                                 sx={{ borderRadius: customization.borderRadius * 0.25 }}
-                                contentClass={{ padding: '16px !important' }}
+                                contentClass={classes.mainContent}
                             >
                                 <SearchIndicator />
                             </StyledMainCard>

--- a/src/views/clinicalGenomic/widgets/patientCountSingle.js
+++ b/src/views/clinicalGenomic/widgets/patientCountSingle.js
@@ -87,7 +87,6 @@ function PatientCountSingle(props) {
     const totalPatients = SumCensoredTotals(Object.values(counts.totals)) || [0, 0];
     const patientsInSearch = SumCensoredTotals(Object.values(counts.counts)) || [0, 0];
     const numCohorts = Object.values(counts.totals)?.length || 0;
-    console.log(SITE, site);
     return (
         <StyledBox pr={2} sx={{ border: 1, borderRadius: 2, boxShadow: 2, borderColor: 'primary.main' }}>
             <Grid container justifyContent="center" alignItems="center" spacing={2} className={classes.container}>


### PR DESCRIPTION
## Ticket(s)
N/A

## Description

- This fixes up a few warnings:
1. A warning around contentClass being an object instead of a string
2. Console log on the search page that was for debugging

## Expected Behaviour

- Less warnings on the search page

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
