### PR TITLE
Remove filter text

### DIFF
--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -561,7 +561,7 @@ function Sidebar() {
             </Tabs>
             <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
                 <Button className={classes.button} onClick={() => resetButton()}>
-                    Reset Filters
+                    Reset
                 </Button>
                 <Button className={classes.button} onClick={triggerSearch}>
                     Search


### PR DESCRIPTION
## Ticket(s)
[DIG-1865: Reset Filter Overflow](https://candig.atlassian.net/browse/DIG-1865)

## Description
Overflowing text on the "Reset Filter" button was resolved by shortening the text to "Reset." However, we should improve the textbox behavior by using a flexbox layout with overflow handling to prevent it from exceeding the container's boundaries.

## Screenshots
![image](https://github.com/user-attachments/assets/3c613c06-2ab7-4ce9-9fe0-5f0f6bf6e037)


## To do/Tickets to be made before merging branch
- Change flexbox behaviour to prevent overflow text but wrap the buttons

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
