### PR TITLE
Fixup router selection

### DIFF
--- a/src/MenuList/NavGroup/index.js
+++ b/src/MenuList/NavGroup/index.js
@@ -1,4 +1,6 @@
 import PropTypes from 'prop-types';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 
 // mui
 import { styled } from '@mui/material/styles';
@@ -7,6 +9,7 @@ import { Divider, List, Typography } from '@mui/material';
 // project imports
 import NavItem from '../NavItem';
 import NavCollapse from '../NavCollapse';
+import { MENU_OPEN } from 'store/actions';
 
 const PREFIX = 'NavGroup';
 
@@ -35,6 +38,15 @@ const DividerRoot = styled(Divider)(({ theme }) => ({
 // ===========================|| SIDEBAR MENU LIST GROUP ||=========================== //
 
 function NavGroup({ item }) {
+    // Determine our path for the NavItems on page load
+    const dispatch = useDispatch();
+    useEffect(() => {
+        // Note that '/' is an alias of /summary
+        const id = window.location.pathname === '/' ? 'summary' : window.location.pathname.slice(1);
+        dispatch({ type: MENU_OPEN, id });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
     // menu list collapse & items
     const items = item.children.map((menu) => {
         switch (menu.type) {

--- a/src/layout/MainLayout/LogoSection/index.js
+++ b/src/layout/MainLayout/LogoSection/index.js
@@ -1,3 +1,4 @@
+import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 // mui
@@ -6,12 +7,15 @@ import { ButtonBase } from '@mui/material';
 // project imports
 import config from 'config';
 import Logo from 'ui-component/Logo';
+import { MENU_OPEN } from 'store/actions';
 
 // ===========================|| MAIN LOGO ||=========================== //
 
 function LogoSection() {
+    const dispatch = useDispatch();
+
     return (
-        <ButtonBase disableRipple component={Link} to={config.defaultPath}>
+        <ButtonBase disableRipple component={Link} to={config.defaultPath} onClick={() => dispatch({ type: MENU_OPEN, id: 'summary' })}>
             <Logo />
         </ButtonBase>
     );

--- a/src/menu-items/clinicalGenomicSearch.js
+++ b/src/menu-items/clinicalGenomicSearch.js
@@ -19,7 +19,7 @@ const clinicalGenomicSearch = {
     type: 'group',
     children: [
         {
-            id: 'Clinical & Genomic Search',
+            id: 'clinicalGenomicSearch',
             title: 'Clinical & Genomic Search',
             type: 'item',
             url: `${basename}/clinicalGenomicSearch `,

--- a/src/menu-items/completenessStats.js
+++ b/src/menu-items/completenessStats.js
@@ -19,7 +19,7 @@ const completenessStats = {
     type: 'group',
     children: [
         {
-            id: 'Completeness Stats',
+            id: 'completeness',
             title: 'Completeness Stats',
             type: 'item',
             url: `${basename}/completeness `,


### PR DESCRIPTION
## Ticket(s)

- [DIG-1866](https://candig.atlassian.net/browse/DIG-1866)

## Description

- This fixes the behaviour of the top bar. In the future, it might be more accurate to have each NavItem instead read the window.location.pathname to figure out if they are selected, instead of relying on `useSelector` hooks.

## Screenshots (if appropriate)

### After PR

[Screencast from 2024-11-19 11-29-36.webm](https://github.com/user-attachments/assets/f39e4d1f-85fc-4529-96c2-aa1d44414ea0)

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-1866]: https://candig.atlassian.net/browse/DIG-1866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ