### PR TITLE
Cohort to Program naming

### DIFF
--- a/src/store/constant.js
+++ b/src/store/constant.js
@@ -37,7 +37,7 @@ export const primarySiteCount = {
     'Tonsil C09': 50
 };
 
-export const cohortByNode = {
+export const programByNode = {
     BCGSC: {
         POG: 50
     },
@@ -84,7 +84,7 @@ export const fullClinicalData = {
 
 export const PRIMARY_SITES = ['Breast', 'Trachea', 'Panceas'];
 
-export const COHORTS = ['POG', 'Inspire', 'Biocan', 'Biodiva', 'Compass', 'Palms', 'IO-Alines'];
+export const PROGRAMS = ['POG', 'Inspire', 'Biocan', 'Biodiva', 'Compass', 'Palms', 'IO-Alines'];
 
 export const CLIN_METADATA = [
     'patients',
@@ -135,8 +135,8 @@ export const DataVisualizationChartInfo = {
         xAxis: 'Primary Site',
         yAxis: 'Number of Primary Sites'
     },
-    patients_per_cohort: {
-        title: 'Distribution of Cohort by Node',
+    patients_per_program: {
+        title: 'Distribution of Program by Node',
         xAxis: 'Site',
         yAxis: 'Number of Patients'
     },
@@ -152,7 +152,7 @@ export const DataVisualizationChartInfo = {
     }
 };
 export const validCharts = ['bar', 'line', 'scatter', 'column'];
-export const validStackedCharts = ['patients_per_cohort', 'full_clinical_data', 'full_genomic_data'];
+export const validStackedCharts = ['patients_per_program', 'full_clinical_data', 'full_genomic_data'];
 
 // Highcharts Map requires a specific set of codes for provinces
 // and territories, as represented by hcProvCodes below.

--- a/src/ui-component/ingest/ClinicalIngest.js
+++ b/src/ui-component/ingest/ClinicalIngest.js
@@ -45,7 +45,7 @@ const Root = styled('div')({
 function ClinicalIngest({ setTab, fileUpload, clinicalData }) {
     // setTab should be a function that sets the tab to the genomic ingest page
 
-    const [authorizedCohorts, setAuthorizedCohorts] = useState([]);
+    const [authorizedPrograms, setAuthorizedPrograms] = useState([]);
 
     useEffect(() => {
         function fetchPrograms() {
@@ -56,13 +56,13 @@ function ClinicalIngest({ setTab, fileUpload, clinicalData }) {
                         const fields = [];
                         Object.keys(programs).forEach((program) => {
                             const field = [
-                                makeField('Cohort', program),
+                                makeField('Program', program),
                                 makeField('Clinical Patients', programs[program].toString()),
                                 makeField('Read Access', 'Unknown')
                             ];
                             fields.push(field);
                         });
-                        setAuthorizedCohorts(fields);
+                        setAuthorizedPrograms(fields);
                     });
                 })
                 .catch((error) => console.log(error));
@@ -75,11 +75,11 @@ function ClinicalIngest({ setTab, fileUpload, clinicalData }) {
             <Grid container direction="column" spacing={4}>
                 <Grid item>
                     <Typography align="left" className={classes.titleText}>
-                        <b>Your authorized cohorts</b>
+                        <b>Your authorized programs</b>
                     </Typography>
-                    {authorizedCohorts.length > 0 ? (
+                    {authorizedPrograms.length > 0 ? (
                         <Grid direction="row" spacing={3} container>
-                            {authorizedCohorts.map((fields, index) => (
+                            {authorizedPrograms.map((fields, index) => (
                                 <Grid item xs={5} key={index}>
                                     <DataRow rowWidth="100%" itemSize="0.9em" fields={fields} />
                                 </Grid>
@@ -87,14 +87,14 @@ function ClinicalIngest({ setTab, fileUpload, clinicalData }) {
                         </Grid>
                     ) : (
                         <Typography align="left" className={classes.bodyText}>
-                            No cohorts found.
+                            No Programs found.
                         </Typography>
                     )}
                 </Grid>
                 <Grid item sx={{ width: '100%' }}>
                     <div>
                         <Typography align="left" className={classes.titleText}>
-                            <b>Choose a cohort for validation</b>
+                            <b>Choose a program for validation</b>
                         </Typography>
                         <Grid container sx={{ marginTop: '0.5em', marginLeft: '1em' }} direction="row" alignItems="center" spacing={2}>
                             <Grid item>
@@ -121,7 +121,7 @@ function ClinicalIngest({ setTab, fileUpload, clinicalData }) {
                             rowWidth="100%"
                             itemSize="0.9em"
                             fields={[
-                                makeField('Cohort', clinicalData.donors[0].program_id),
+                                makeField('Program', clinicalData.donors[0].program_id),
                                 makeField('Clinical Patients', clinicalData.donors.length),
                                 makeField('Read Access', '1')
                             ]}

--- a/src/ui-component/ingest/GenomicIngest.js
+++ b/src/ui-component/ingest/GenomicIngest.js
@@ -41,8 +41,8 @@ const Root = styled('div')({
 function GenomicIngest({ beginIngest, fileUpload, clinicalData, genomicData }) {
     const [ingestButtonEnabled, setIngestButtonEnabled] = useState(false);
 
-    const cohort = [
-        makeField('Cohort', clinicalData.donors[0].program_id),
+    const program = [
+        makeField('Program', clinicalData.donors[0].program_id),
         makeField('Clinical Patients', clinicalData.donors.length),
         makeField('Read Access', '1')
     ];
@@ -54,9 +54,9 @@ function GenomicIngest({ beginIngest, fileUpload, clinicalData, genomicData }) {
             <Grid container direction="column" sx={{ flexGrow: 1 }} spacing={4}>
                 <Grid item>
                     <Typography align="left" className={classes.titleText}>
-                        <b>Cohort for ingestion</b>
+                        <b>Program for ingestion</b>
                     </Typography>
-                    <DataRow rowWidth="100%" itemSize="0.9em" fields={cohort} />
+                    <DataRow rowWidth="100%" itemSize="0.9em" fields={program} />
                 </Grid>
                 <Grid item width="100%">
                     <Typography align="left" className={classes.titleText}>

--- a/src/views/clinicalGenomic/clinicalGenomicSearch.js
+++ b/src/views/clinicalGenomic/clinicalGenomicSearch.js
@@ -95,9 +95,9 @@ const StyledMainCard = styled(MainCard)((_) => ({
 
 const sections = [
     {
-        id: 'cohorts summary',
+        id: 'Programs summary',
         header: undefined,
-        component: <AuthorizationSections title="All Cohorts" />
+        component: <AuthorizationSections title="All Programs" />
     },
     {
         id: 'counts',
@@ -110,9 +110,9 @@ const sections = [
         component: <DataVisualization />
     },
     {
-        id: 'authorized cohorts',
+        id: 'authorized programs',
         header: undefined,
-        component: <AuthorizationSections title="Authorized Cohorts" />
+        component: <AuthorizationSections title="Authorized Programs" />
     },
     {
         id: 'clinical',

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -26,7 +26,7 @@ function SearchHandler({ setLoading }) {
                 .then((data) => {
                     writer((old) => ({ ...old, sidebar: data }));
                 })
-                .then(() => fetchFederationStat('/patients_per_cohort'))
+                .then(() => fetchFederationStat('/patients_per_program'))
                 .then((data) => {
                     writer((old) => ({ ...old, federation: data }));
                 })
@@ -88,10 +88,10 @@ function SearchHandler({ setLoading }) {
                         age_at_diagnosis: CollateSummary(data, 'age_at_diagnosis'),
                         treatment_type_count: CollateSummary(data, 'treatment_type_count'),
                         primary_site_count: CollateSummary(data, 'primary_site_count'),
-                        patients_per_cohort: {}
+                        patients_per_program: {}
                     };
                     data.forEach((site) => {
-                        discoveryCounts.patients_per_cohort[site.location.name] = site.results?.patients_per_cohort;
+                        discoveryCounts.patients_per_program[site.location.name] = site.results?.patients_per_program;
                     });
 
                     writer((old) => ({ ...old, counts: discoveryCounts }));
@@ -124,7 +124,7 @@ function SearchHandler({ setLoading }) {
                     if (reader.filter?.node) {
                         data = data.filter((site) => !reader.filter.node.includes(site.location.name));
                     }
-                    // Reorder the data, and fill out the patients per cohort
+                    // Reorder the data, and fill out the patients per program
                     const clinicalData = {};
                     data.forEach((site) => {
                         if ('results' in site) {
@@ -162,12 +162,12 @@ function SearchHandler({ setLoading }) {
 
     // Query 3: when the selected donor changes, re-query the server
     useEffect(() => {
-        if (!reader.donorID || !reader.cohort) {
+        if (!reader.donorID || !reader.program) {
             return;
         }
         setLoading(true);
 
-        const url = `v3/authorized/donor_with_clinical_data/program/${reader.cohort}/donor/${reader.donorID}`;
+        const url = `v3/authorized/donor_with_clinical_data/program/${reader.program}/donor/${reader.donorID}`;
         trackPromise(
             fetchFederation(url, 'katsu')
                 .then((data) => {

--- a/src/views/clinicalGenomic/widgets/dataVisualization.js
+++ b/src/views/clinicalGenomic/widgets/dataVisualization.js
@@ -75,7 +75,7 @@ function DataVisualization() {
     };
 
     const dataVis = {
-        patients_per_cohort: handleCensoring('patients_per_cohort', (site, _) => site, true) || {},
+        patients_per_program: handleCensoring('patients_per_program', (site, _) => site, true) || {},
         diagnosis_age_count: handleCensoring('age_at_diagnosis', (_, age) => age.replace(/ Years$/, '')) || {},
         treatment_type_count: handleCensoring('treatment_type_count') || {},
         primary_site_count: handleCensoring('primary_site_count') || {}
@@ -93,7 +93,7 @@ function DataVisualization() {
     const [dataValue, setDataValue] = useState(
         localStorage.getItem('dataVisData') && JSON.parse(localStorage.getItem('dataVisData'))?.[0]
             ? JSON.parse(localStorage.getItem('dataVisData'))[0]
-            : 'patients_per_cohort'
+            : 'patients_per_program'
     );
     const [chartType, setChartType] = useState(
         localStorage.getItem('dataVisChartType') && JSON.parse(localStorage.getItem('dataVisChartType'))?.[0]

--- a/src/views/clinicalGenomic/widgets/genomicData.js
+++ b/src/views/clinicalGenomic/widgets/genomicData.js
@@ -55,7 +55,7 @@ function GenomicData() {
     const columns = [
         { field: 'location', headerName: 'Node', minWidth: 120, sortable: false, filterable: false },
         { field: 'donor_id', headerName: 'Donor ID', minWidth: 150, sortable: false, filterable: false },
-        { field: 'program_id', headerName: 'Cohort ID', minWidth: 150, sortable: false, filterable: false },
+        { field: 'program_id', headerName: 'Program ID', minWidth: 150, sortable: false, filterable: false },
         { field: 'position', headerName: 'Position', minWidth: 150, sortable: false, filterable: false },
         { field: 'tumour_normal_designation', headerName: 'Tumour/Normal', minWidth: 200, sortable: false, filterable: false },
         { field: 'submitter_specimen_id', headerName: 'Sample Registration ID', minWidth: 300, sortable: false, filterable: false },

--- a/src/views/clinicalGenomic/widgets/patientCountSingle.js
+++ b/src/views/clinicalGenomic/widgets/patientCountSingle.js
@@ -66,18 +66,18 @@ function PatientCountSingle(props) {
 
     const SumCensoredTotals = (countsArray) =>
         countsArray.reduce(
-            (partialSum, cohortTotal) => {
-                if (typeof cohortTotal === 'object') {
-                    if (cohortTotal.patients_count.startsWith('<')) {
-                        return [partialSum[0], partialSum[1] + parseInt(cohortTotal.patients_count.substring(1), 10)];
+            (partialSum, programTotal) => {
+                if (typeof programTotal === 'object') {
+                    if (programTotal.patients_count.startsWith('<')) {
+                        return [partialSum[0], partialSum[1] + parseInt(programTotal.patients_count.substring(1), 10)];
                     }
-                    const toAdd = parseInt(cohortTotal.patients_count, 10);
+                    const toAdd = parseInt(programTotal.patients_count, 10);
                     return [partialSum[0] + toAdd, partialSum[1] + toAdd];
                 }
-                if (typeof cohortTotal === 'string' && cohortTotal.startsWith('<')) {
-                    return [partialSum[0], partialSum[1] + parseInt(cohortTotal.substring(1), 10)];
+                if (typeof programTotal === 'string' && programTotal.startsWith('<')) {
+                    return [partialSum[0], partialSum[1] + parseInt(programTotal.substring(1), 10)];
                 }
-                return [partialSum[0] + parseInt(cohortTotal, 10), partialSum[1] + parseInt(cohortTotal, 10)];
+                return [partialSum[0] + parseInt(programTotal, 10), partialSum[1] + parseInt(programTotal, 10)];
             },
             [0, 0]
         );
@@ -86,7 +86,7 @@ function PatientCountSingle(props) {
 
     const totalPatients = SumCensoredTotals(Object.values(counts.totals)) || [0, 0];
     const patientsInSearch = SumCensoredTotals(Object.values(counts.counts)) || [0, 0];
-    const numCohorts = Object.values(counts.totals)?.length || 0;
+    const numPrograms = Object.values(counts.totals)?.length || 0;
     return (
         <StyledBox pr={2} sx={{ border: 1, borderRadius: 2, boxShadow: 2, borderColor: 'primary.main' }}>
             <Grid container justifyContent="center" alignItems="center" spacing={2} className={classes.container}>
@@ -111,12 +111,12 @@ function PatientCountSingle(props) {
                 <Divider flexItem orientation="vertical" className={classes.divider} />
                 <Grid item xs={2}>
                     <Typography align="center" className={classes.patientEntry}>
-                        {numCohorts}
+                        {numPrograms}
                     </Typography>
                 </Grid>
                 <Divider flexItem orientation="vertical" className={classes.divider} />
                 <Grid item className={classes.button} pr={-2}>
-                    {numCohorts > 1 ? (
+                    {numPrograms > 1 ? (
                         <Button
                             onClick={(_) => setExpanded((old) => !old)}
                             variant="contained"
@@ -134,23 +134,23 @@ function PatientCountSingle(props) {
             </Grid>
 
             {expanded
-                ? counts.totals.map((cohort) => {
-                      const locked = !counts.unlockedPrograms?.some((programID) => programID === cohort.program_id);
+                ? counts.totals.map((program) => {
+                      const locked = !counts.unlockedPrograms?.some((programID) => programID === program.program_id);
                       return (
                           <Grid
                               container
                               justifyContent="center"
                               alignItems="center"
                               spacing={2}
-                              key={cohort.program_id}
+                              key={program.program_id}
                               className={classes.container}
                           >
                               <Grid item xs={2}>
                                   <Typography variant="h5" align="center" className={classes.patientEntry}>
                                       <b className={classes.patientEntry}>
-                                          {cohort.program_id}
+                                          {program.program_id}
                                           {locked && (
-                                              <Tooltip title="Unauthorized Cohort" placement="right">
+                                              <Tooltip title="Unauthorized Program" placement="right">
                                                   <LockOutlinedIcon className={classes.lockIcon} />
                                               </Tooltip>
                                           )}
@@ -160,13 +160,13 @@ function PatientCountSingle(props) {
                               <Divider flexItem orientation="vertical" className={classes.divider} />
                               <Grid item xs={2}>
                                   <Typography align="center" className={classes.patientEntry}>
-                                      {counts.counts?.[cohort.program_id] || 0}
+                                      {counts.counts?.[program.program_id] || 0}
                                   </Typography>
                               </Grid>
                               <Divider flexItem orientation="vertical" className={classes.divider} />
                               <Grid item xs={2}>
                                   <Typography align="center" className={classes.patientEntry}>
-                                      {cohort.patients_count || 0}
+                                      {program.patients_count || 0}
                                   </Typography>
                               </Grid>
                               <Divider flexItem orientation="vertical" className={classes.divider} />

--- a/src/views/clinicalGenomic/widgets/patientCounts.js
+++ b/src/views/clinicalGenomic/widgets/patientCounts.js
@@ -27,15 +27,15 @@ function PatientCounts() {
     const context = useSearchResultsReaderContext();
     const sites = context?.federation;
     const programs = context?.programs;
-    const discoveryCounts = context?.counts?.patients_per_cohort;
+    const discoveryCounts = context?.counts?.patients_per_program;
     const clinicalCounts = context?.clinical;
 
-    // Generate the map of site->cohort->numbers
+    // Generate the map of site->program->numbers
     let siteData = [];
     if (Array.isArray(sites)) {
         siteData = sites.map((entry) => {
             const counts = discoveryCounts?.[entry.location.name] || {};
-            const realCounts = clinicalCounts?.[entry.location.name]?.summary?.patients_per_cohort || {};
+            const realCounts = clinicalCounts?.[entry.location.name]?.summary?.patients_per_program || {};
             let unlockedPrograms = [];
             // Fill up the programs using the summary counts
             if (Array.isArray(programs)) {
@@ -80,7 +80,7 @@ function PatientCounts() {
                     </Grid>
                     <Grid item xs={2}>
                         <Typography variant="h5" className={`${PREFIX}-header`}>
-                            Total Cohorts
+                            Total Programs
                         </Typography>
                     </Grid>
                     <Grid item xs={1} ml="auto" className={`${PREFIX}-button`}>

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -121,7 +121,8 @@ SidebarGroup.propTypes = {
 };
 
 function StyledCheckboxList(props) {
-    const { isExclusion, groupName, isFilterList, onWrite, options, authorizedCohorts, useAutoComplete, hide, checked, setChecked } = props;
+    const { isExclusion, groupName, isFilterList, onWrite, options, authorizedPrograms, useAutoComplete, hide, checked, setChecked } =
+        props;
 
     if (hide) {
         return null;
@@ -222,8 +223,8 @@ function StyledCheckboxList(props) {
                 label={
                     <div className={classes.lockContainer}>
                         {option}
-                        {groupName === 'exclude_cohorts' && authorizedCohorts && !authorizedCohorts.includes(option) && (
-                            <Tooltip title="Unauthorized Cohort" placement="right">
+                        {groupName === 'exclude_programs' && authorizedPrograms && !authorizedPrograms.includes(option) && (
+                            <Tooltip title="Unauthorized Program" placement="right">
                                 <LockOutlinedIcon className={classes.lockIcon} />
                             </Tooltip>
                         )}
@@ -259,7 +260,7 @@ function StyledCheckboxList(props) {
 StyledCheckboxList.propTypes = {
     isExclusion: PropTypes.bool,
     groupName: PropTypes.string,
-    authorizedCohorts: PropTypes.array,
+    authorizedPrograms: PropTypes.array,
     hide: PropTypes.bool,
     isDonorList: PropTypes.bool,
     isFilterList: PropTypes.bool,
@@ -418,7 +419,7 @@ function Sidebar() {
 
     // Clinical Data
     const [selectedNodes, setSelectedNodes] = useState({});
-    const [selectedCohorts, setSelectedCohorts] = useState({});
+    const [selectedPrograms, setSelectedPrograms] = useState({});
     const [selectedTreatment, setSelectedTreatment] = useState({});
     const [selectedPrimarySite, setSelectedPrimarySite] = useState({});
     const [selectedSystemicTherapy, setSelectedSystemicTherapy] = useState({});
@@ -440,14 +441,14 @@ function Sidebar() {
                 },
                 reqNum: old.reqNum + 1
             }));
-        } else if (readerContext.clear === 'cohorts') {
-            setSelectedCohorts({});
+        } else if (readerContext.clear === 'programs') {
+            setSelectedPrograms({});
             writerContext((old) => ({
                 ...old,
                 filter: {
                     ...old.filter,
-                    exclude_cohorts: [
-                        readerContext?.programs?.map((loc) => loc?.results?.items?.map((cohort) => cohort.program_id)).flat(1) || []
+                    exclude_programs: [
+                        readerContext?.programs?.map((loc) => loc?.results?.items?.map((program) => program.program_id)).flat(1) || []
                     ]
                 },
                 reqNum: old.reqNum + 1
@@ -496,7 +497,7 @@ function Sidebar() {
     function resetButton() {
         // Reset state variables for checkboxes and dropdowns
         setSelectedNodes({});
-        setSelectedCohorts({});
+        setSelectedPrograms({});
 
         // Genomic
         setSelectedGenes('');
@@ -509,14 +510,14 @@ function Sidebar() {
         setSelectedPrimarySite({});
         setSelectedSystemicTherapy({});
 
-        // Set context writer to include only nodes and cohorts
+        // Set context writer to include only nodes and programs
         writerContext({
-            // Set nodes and cohorts in the filter
+            // Set nodes and programs in the filter
             filter: {
                 node: [readerContext?.programs?.map((loc) => loc.location.name) || []], // Set your default nodes
-                exclude_cohorts: [
-                    readerContext?.programs?.map((loc) => loc?.results?.items?.map((cohort) => cohort.program_id)).flat(1) || []
-                ], // Set cohorts to empty array or whichever default value you want
+                exclude_programs: [
+                    readerContext?.programs?.map((loc) => loc?.results?.items?.map((program) => program.program_id)).flat(1) || []
+                ], // Set programs to empty array or whichever default value you want
                 query: {}
             }
         });
@@ -533,8 +534,8 @@ function Sidebar() {
 
     // Parse out what we need:
     const sites = readerContext?.programs?.map((loc) => loc.location.name) || [];
-    const cohorts = readerContext?.federation?.map((loc) => loc.results?.map((cohort) => cohort.program_id) || [])?.flat(1) || [];
-    const authorizedCohorts = readerContext?.programs?.flatMap((loc) => loc?.results?.items?.map((cohort) => cohort.program_id)) || [];
+    const programs = readerContext?.federation?.map((loc) => loc.results?.map((program) => program.program_id) || [])?.flat(1) || [];
+    const authorizedPrograms = readerContext?.programs?.flatMap((loc) => loc?.results?.items?.map((program) => program.program_id)) || [];
     const treatmentTypes = ExtractSidebarElements('treatment_types');
     const tumourPrimarySites = ExtractSidebarElements('tumour_primary_sites');
     const systemicTherapyDrugNames = ExtractSidebarElements('drug_names');
@@ -578,15 +579,15 @@ function Sidebar() {
                     setChecked={setSelectedNodes}
                 />
             </SidebarGroup>
-            <SidebarGroup name="Cohort">
+            <SidebarGroup name="Program">
                 <StyledCheckboxList
-                    options={cohorts}
-                    authorizedCohorts={authorizedCohorts}
+                    options={programs}
+                    authorizedPrograms={authorizedPrograms}
                     onWrite={writerContext}
-                    groupName="exclude_cohorts"
+                    groupName="exclude_programs"
                     isExclusion
-                    checked={selectedCohorts}
-                    setChecked={setSelectedCohorts}
+                    checked={selectedPrograms}
+                    setChecked={setSelectedPrograms}
                 />
             </SidebarGroup>
             <GenomicsGroup

--- a/src/views/completeness/fieldLevelCompletenessGraph.jsx
+++ b/src/views/completeness/fieldLevelCompletenessGraph.jsx
@@ -59,7 +59,7 @@ const Root = styled(Box)(({ _ }) => ({
 
 function FieldLevelCompletenessGraph(props) {
     const { data, loading, title } = props;
-    const [filter, setFilter] = useState('All cohorts');
+    const [filter, setFilter] = useState('All programs');
     const theme = useTheme();
     const chartRef = createRef();
     const events = useSelector((state) => state);
@@ -78,24 +78,24 @@ function FieldLevelCompletenessGraph(props) {
 
     // TODO: Filter fields here
     const fields = {};
-    const allCohorts = ['All cohorts'];
+    const allPrograms = ['All programs'];
     if (data) {
         Object.values(data).forEach((site) => {
-            const cohorts = site.results?.programs;
-            if (!cohorts) {
+            const programs = site.results?.programs;
+            if (!programs) {
                 return;
             }
 
             // Convert each one into a singular field
             // Category -> Field name -> { missing & total }
-            cohorts.forEach((cohort) => {
-                const concatName = `${site.location.name} - ${cohort.program_id}`;
-                allCohorts.push(concatName);
-                if (concatName !== filter && filter !== 'All cohorts') {
+            programs.forEach((program) => {
+                const concatName = `${site.location.name} - ${program.program_id}`;
+                allPrograms.push(concatName);
+                if (concatName !== filter && filter !== 'All programs') {
                     return;
                 }
 
-                const theseFields = cohort?.metadata?.required_but_missing;
+                const theseFields = program?.metadata?.required_but_missing;
                 Object.keys(theseFields).forEach((fieldCategory) => {
                     Object.keys(theseFields[fieldCategory]).forEach((fieldName) => {
                         const concatenatedName = `${fieldCategory}/${fieldName}`;
@@ -196,9 +196,9 @@ function FieldLevelCompletenessGraph(props) {
                     <div className={classes.spacer} />
                     <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
                         <Select value={filter} onChange={(event) => setFilter(event.target.value)} className={classes.siteSelection}>
-                            {allCohorts.map((cohort) => (
-                                <MenuItem value={cohort} key={cohort}>
-                                    {cohort}
+                            {allPrograms.map((program) => (
+                                <MenuItem value={program} key={program}>
+                                    {program}
                                 </MenuItem>
                             ))}
                         </Select>

--- a/src/views/summary/CustomOfflineChart.js
+++ b/src/views/summary/CustomOfflineChart.js
@@ -113,7 +113,7 @@ function CustomOfflineChart({
                     // datum is either going to be one of three things:
                     // 1. an array of objects
                     // 2. an object which whose keys are indexes and whose values are objects with <var>_count and <var>_name
-                    // 3. an object whose keys are cohorts and whose values are numbers
+                    // 3. an object whose keys are programs and whose values are numbers
                     // (Why the return value is formatted this way I have no idea)
 
                     // Case 1: an array of objects
@@ -127,7 +127,7 @@ function CustomOfflineChart({
                             return isObjectCensored(datum);
                         }
 
-                        // Case 3: an object whose keys are cohorts and whose values are numbers
+                        // Case 3: an object whose keys are programs and whose values are numbers
                         return Object.values(datum).some((val) => typeof val === 'string' && val.startsWith('<'));
                     }
 
@@ -184,11 +184,11 @@ function CustomOfflineChart({
 
                 Object.keys(thisData).forEach((key, i) => {
                     categories.push(key);
-                    Object.keys(thisData[key]).forEach((cohort) => {
-                        if (!data.has(cohort)) {
-                            data.set(cohort, new Array(Object.keys(thisData).length).fill(0));
+                    Object.keys(thisData[key]).forEach((program) => {
+                        if (!data.has(program)) {
+                            data.set(program, new Array(Object.keys(thisData).length).fill(0));
                         }
-                        data.get(cohort).splice(i, 1, thisData[key][cohort]);
+                        data.get(program).splice(i, 1, thisData[key][program]);
                     });
 
                     // Order & truncate the categories by the data

--- a/src/views/summary/summary.js
+++ b/src/views/summary/summary.js
@@ -21,8 +21,8 @@ function Summary() {
     const [isLoading, setLoading] = useState({
         '/individual_count': true,
         '/primary_site_count': true,
-        '/cohort_count': true,
-        '/patients_per_cohort': true,
+        '/program_count': true,
+        '/patients_per_program': true,
         '/treatment_type_count': true,
         '/diagnosis_age_count': true,
         clinical: true,
@@ -33,8 +33,8 @@ function Summary() {
     const [individualCount, setIndividualCount] = useState(undefined);
     const [primarySiteCount, setPrimarySiteCount] = useState(undefined);
     const [treatmentTypeCount, setTreatmentTypeCount] = useState(undefined);
-    const [cohortCount, setCohortCount] = useState(undefined);
-    const [patientsPerCohort, setPatientsPerCohort] = useState(undefined);
+    const [programCount, setProgramCount] = useState(undefined);
+    const [patientsPerProgram, setPatientsPerProgram] = useState(undefined);
     const [diagnosisAgeCount, setDiagnosisAgeCount] = useState(undefined);
     const [numClinicalComplete, setNumClinicalComplete] = useState(undefined);
     const [numGenomicComplete, setNumGenomicComplete] = useState(undefined);
@@ -81,12 +81,12 @@ function Summary() {
                         }
 
                         break;
-                    case '/cohort_count':
-                        setCohortCount((oldCohortCount) => aggregateObj(stat.results, oldCohortCount));
+                    case '/program_count':
+                        setProgramCount((oldProgramCount) => aggregateObj(stat.results, oldProgramCount));
                         break;
-                    case '/patients_per_cohort':
-                        setPatientsPerCohort((oldPatientsPerCohort) =>
-                            aggregateObjStack(stat, oldPatientsPerCohort, (stat, _) => invertkatsu(stat.results))
+                    case '/patients_per_program':
+                        setPatientsPerProgram((oldPatientsPerProgram) =>
+                            aggregateObjStack(stat, oldPatientsPerProgram, (stat, _) => invertkatsu(stat.results))
                         );
                         break;
                     case '/primary_site_count':
@@ -184,8 +184,8 @@ function Summary() {
 
         fetchData('/individual_count');
         fetchData('/primary_site_count');
-        fetchData('/cohort_count');
-        fetchData('/patients_per_cohort');
+        fetchData('/program_count');
+        fetchData('/patients_per_program');
         fetchData('/treatment_type_count');
         fetchData('/diagnosis_age_count');
         fetchGenomic();
@@ -239,8 +239,8 @@ function Summary() {
             <Grid item xs={12} sm={12} md={6} lg={3}>
                 <SmallCountCard
                     isLoading={isLoading['/individual_count']}
-                    title="Cohorts"
-                    count={cohortCount?.cohort_count || 0}
+                    title="Programs"
+                    count={programCount?.program_count || 0}
                     icon={<Hive fontSize="inherit" />}
                     color={theme.palette.secondary.main}
                 />
@@ -296,13 +296,13 @@ function Summary() {
             </Grid>
             <Grid item xs={12} sm={12} md={6} lg={3}>
                 <CustomOfflineChart
-                    dataObject={patientsPerCohort || {}}
-                    data="patients_per_cohort"
+                    dataObject={patientsPerProgram || {}}
+                    data="patients_per_program"
                     dataVis=""
                     chartType="bar"
                     height="400px; auto"
                     dropDown={false}
-                    loading={isLoading['/patients_per_cohort']}
+                    loading={isLoading['/patients_per_program']}
                     orderByFrequency
                     cutoff={10}
                 />


### PR DESCRIPTION
## Ticket(s)
- [Change Cohort to Program - parent ticket](https://candig.atlassian.net/browse/DIG-1522)
- [Change Cohort to Program - data-portal](https://candig.atlassian.net/browse/DIG-1867)


## Description
This PR makes it so that the data-portal uses program instead of cohort and works with the other microservices for the following PRs

- https://github.com/CanDIG/CanDIGv2/pull/875
- https://github.com/CanDIG/candigv2-ingest/pull/139
- https://github.com/CanDIG/htsget_app/pull/341
- https://github.com/CanDIG/katsu/pull/274
- https://github.com/CanDIG/candig-opa/pull/73
- https://github.com/CanDIG/candigv2-query/pull/62

## Expected Behaviour
- The portal should work as normal with cohort replaced with program 


## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [x] My change requires a change to the documentation (runbook and playwright)
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
