### PR TITLE
Fix an error that happens when navigating to the second page of results

### DIFF
--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -139,7 +139,11 @@ function ClinicalView() {
 
     const HandlePageChange = (newModel) => {
         if (newModel.page !== queryReader.query?.page) {
-            writerContext((old) => ({ ...old, query: { ...old.query, page: newModel.page, page_size: newModel.pageSize } }));
+            writerContext((old) => ({
+                ...old,
+                query: { ...old.query, page: newModel.page, page_size: newModel.pageSize },
+                reqNum: old.reqNum + 1
+            }));
         }
     };
 

--- a/src/views/clinicalGenomic/widgets/searchExplainer.js
+++ b/src/views/clinicalGenomic/widgets/searchExplainer.js
@@ -35,8 +35,9 @@ function SearchExplainer() {
 
     // Decompose the query into its roots: what are we searching on?
     if (query !== undefined) {
+        const ignoredKeys = ['page', 'page_size']; // These are never included in the explanation
         Object.keys(query).forEach((key) => {
-            if (key !== undefined && query[key] !== undefined) {
+            if (key !== undefined && query[key] !== undefined && !ignoredKeys.includes(key)) {
                 const onDelete = () => {
                     writer((old) => ({ ...old, clear: key }));
                 };


### PR DESCRIPTION
## Description

- The search page errors out when navigating to the second page of results. Regression caused by two PRs: #188 and #186

## Expected Behaviour

- You should be able to go to the second page of results

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
