### PR TITLE
DIG-1514: An invalid chart in CustomOfflineCharts.js causes the searchpage to whitescreen.

### DIFF
--- a/src/views/clinicalGenomic/widgets/dataVisualization.js
+++ b/src/views/clinicalGenomic/widgets/dataVisualization.js
@@ -44,7 +44,7 @@ const DEFAULT_CHART_DEFINITIONS = [
     }
 ];
 
-const LOCAL_VARIABLE_KEY = 'chartDefinitions';
+export const LOCAL_VARIABLE_KEY = 'chartDefinitions';
 
 function DataVisualization() {
     // Hooks
@@ -99,6 +99,17 @@ function DataVisualization() {
         return newDataObj;
     };
 
+    const removeInvalidCharts = (chartDefinitions) => {
+        const retVal = [];
+        for (let i = 0; i < chartDefinitions.length; i += 1) {
+            if (VALID_CHART_TYPES.includes(chartDefinitions[i].chartType) && typeof chartDefinitions[i].trim === 'boolean') {
+                retVal.push(chartDefinitions[i]);
+            }
+        }
+
+        return retVal;
+    };
+
     const dataVis = {
         patients_per_program: handleCensoring('patients_per_program', (site, _) => site, true) || {},
         diagnosis_age_count: handleCensoring('age_at_diagnosis', (_, age) => age.replace(/ Years$/, '')) || {},
@@ -113,7 +124,9 @@ function DataVisualization() {
 
     // LocalStorage
     const [chartDefinitions, setChartDefinitions] = useState(
-        localStorage.getItem(LOCAL_VARIABLE_KEY) ? JSON.parse(localStorage.getItem(LOCAL_VARIABLE_KEY)) : DEFAULT_CHART_DEFINITIONS
+        localStorage.getItem(LOCAL_VARIABLE_KEY)
+            ? removeInvalidCharts(JSON.parse(localStorage.getItem(LOCAL_VARIABLE_KEY)))
+            : DEFAULT_CHART_DEFINITIONS
     );
     const [newDataKey, setNewDataKey] = useState('patients_per_program');
     const [newChartType, setNewChartType] = useState('bar');
@@ -122,7 +135,7 @@ function DataVisualization() {
     useEffect(() => {
         const invalidChartIndexes = [];
         for (let i = 0; i < chartDefinitions.length; i += 1) {
-            if (!VALID_CHART_TYPES.includes(chartDefinitions[i])) {
+            if (!VALID_CHART_TYPES.includes(chartDefinitions[i].chartType)) {
                 invalidChartIndexes.push(i);
             }
         }

--- a/src/views/clinicalGenomic/widgets/dataVisualization.js
+++ b/src/views/clinicalGenomic/widgets/dataVisualization.js
@@ -14,7 +14,7 @@ import Button from '@mui/material/Button';
 import { IconEdit, IconX, IconPlus } from '@tabler/icons-react';
 
 // Custom Components and context
-import CustomOfflineChart, { VALID_CHART_TYPES } from 'views/summary/CustomOfflineChart';
+import CustomOfflineChart, { VALID_CHART_TYPES, VISUALIZATION_LOCAL_STORAGE_KEY } from 'views/summary/CustomOfflineChart';
 import { useSearchResultsReaderContext } from '../SearchResultsContext';
 
 // Constants
@@ -43,8 +43,6 @@ const DEFAULT_CHART_DEFINITIONS = [
         trim: false
     }
 ];
-
-export const LOCAL_VARIABLE_KEY = 'chartDefinitions';
 
 function DataVisualization() {
     // Hooks
@@ -124,8 +122,8 @@ function DataVisualization() {
 
     // LocalStorage
     const [chartDefinitions, setChartDefinitions] = useState(
-        localStorage.getItem(LOCAL_VARIABLE_KEY)
-            ? removeInvalidCharts(JSON.parse(localStorage.getItem(LOCAL_VARIABLE_KEY)))
+        localStorage.getItem(VISUALIZATION_LOCAL_STORAGE_KEY)
+            ? removeInvalidCharts(JSON.parse(localStorage.getItem(VISUALIZATION_LOCAL_STORAGE_KEY)))
             : DEFAULT_CHART_DEFINITIONS
     );
     const [newDataKey, setNewDataKey] = useState('patients_per_program');
@@ -146,7 +144,7 @@ function DataVisualization() {
                 invalidChartIndexes.forEach((index, numRemoved) => {
                     newChartDefinitions.slice(index - numRemoved);
                 });
-                localStorage.setItem(LOCAL_VARIABLE_KEY, JSON.stringify(newChartDefinitions), { expires: 365 });
+                localStorage.setItem(VISUALIZATION_LOCAL_STORAGE_KEY, JSON.stringify(newChartDefinitions), { expires: 365 });
                 return newChartDefinitions;
             });
         }
@@ -155,7 +153,7 @@ function DataVisualization() {
     // Intial localStorage setting if there are none
     useEffect(() => {
         if (!localStorage.getItem('LOCAL_VARIABLE_KEY')) {
-            localStorage.setItem(LOCAL_VARIABLE_KEY, JSON.stringify(chartDefinitions), { expires: 365 });
+            localStorage.setItem(VISUALIZATION_LOCAL_STORAGE_KEY, JSON.stringify(chartDefinitions), { expires: 365 });
         }
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -167,7 +165,7 @@ function DataVisualization() {
         setChartDefinitions((old) => {
             const newChartDefinitions = old.slice();
             newChartDefinitions[index][key] = newVal;
-            localStorage.setItem(LOCAL_VARIABLE_KEY, JSON.stringify(newChartDefinitions), { expires: 365 });
+            localStorage.setItem(VISUALIZATION_LOCAL_STORAGE_KEY, JSON.stringify(newChartDefinitions), { expires: 365 });
             return newChartDefinitions;
         });
     }
@@ -175,7 +173,7 @@ function DataVisualization() {
     function removeChart(index) {
         const newChartDefinitions = chartDefinitions.slice(0, index).concat(chartDefinitions.slice(index + 1));
         setChartDefinitions(newChartDefinitions);
-        localStorage.setItem(LOCAL_VARIABLE_KEY, JSON.stringify(newChartDefinitions), { expires: 365 });
+        localStorage.setItem(VISUALIZATION_LOCAL_STORAGE_KEY, JSON.stringify(newChartDefinitions), { expires: 365 });
     }
 
     function AddChart(data, chartType) {
@@ -187,7 +185,7 @@ function DataVisualization() {
                 chartType: validStackedCharts.includes(data) ? 'bar' : chartType,
                 trim: false
             });
-            localStorage.setItem(LOCAL_VARIABLE_KEY, JSON.stringify(newDefs), { expires: 365 });
+            localStorage.setItem(VISUALIZATION_LOCAL_STORAGE_KEY, JSON.stringify(newDefs), { expires: 365 });
             return newDefs;
         });
     }

--- a/src/views/clinicalGenomic/widgets/dataVisualization.js
+++ b/src/views/clinicalGenomic/widgets/dataVisualization.js
@@ -152,7 +152,7 @@ function DataVisualization() {
 
     // Intial localStorage setting if there are none
     useEffect(() => {
-        if (!localStorage.getItem('LOCAL_VARIABLE_KEY')) {
+        if (!localStorage.getItem(VISUALIZATION_LOCAL_STORAGE_KEY)) {
             localStorage.setItem(VISUALIZATION_LOCAL_STORAGE_KEY, JSON.stringify(chartDefinitions), { expires: 365 });
         }
     }, []); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/views/clinicalGenomic/widgets/dataVisualization.js
+++ b/src/views/clinicalGenomic/widgets/dataVisualization.js
@@ -171,9 +171,12 @@ function DataVisualization() {
     }
 
     function removeChart(index) {
-        const newChartDefinitions = chartDefinitions.slice(0, index).concat(chartDefinitions.slice(index + 1));
-        setChartDefinitions(newChartDefinitions);
-        localStorage.setItem(VISUALIZATION_LOCAL_STORAGE_KEY, JSON.stringify(newChartDefinitions), { expires: 365 });
+        setChartDefinitions((old) => {
+            const newChartDefinitions = old.slice(0, index).concat(old.slice(index + 1));
+            localStorage.setItem(VISUALIZATION_LOCAL_STORAGE_KEY, JSON.stringify(newChartDefinitions), { expires: 365 });
+            console.log(newChartDefinitions);
+            return newChartDefinitions;
+        });
     }
 
     function AddChart(data, chartType) {
@@ -241,32 +244,6 @@ function DataVisualization() {
         );
     }
 
-    function returndataVisData() {
-        const data = chartDefinitions.map((item, index) => (
-            <Grid item xs={12} sm={12} md={6} lg={3} xl={3} key={index}>
-                <CustomOfflineChart
-                    dataObject=""
-                    dataVis={dataVis}
-                    data={item.data}
-                    index={index}
-                    chartType={item.chartType}
-                    height="400px; auto"
-                    dropDown
-                    onRemoveChart={() => removeChart(index)}
-                    edit={edit}
-                    orderByFrequency={item.data !== 'diagnosis_age_count'}
-                    orderAlphabetically={item.data === 'diagnosis_age_count'}
-                    trimByDefault={item.trim}
-                    onChangeDataVisChartType={(newType) => setDataVisEntry(index, 'chartType', newType)}
-                    onChangeDataVisData={(newData) => setDataVisEntry(index, 'data', newData)}
-                    loading={dataVis[item.data] === undefined}
-                />
-            </Grid>
-        ));
-
-        return data;
-    }
-
     return (
         <Box
             mr={1}
@@ -299,7 +276,30 @@ function DataVisualization() {
                     Data Visualization
                 </Typography>
                 <Grid container spacing={1} alignItems="center" justifyContent="center">
-                    {returndataVisData()}
+                    {chartDefinitions.map((item, index) => {
+                        console.log(item);
+                        return (
+                            <Grid item xs={12} sm={12} md={6} lg={3} xl={3} key={JSON.stringify(item)}>
+                                <CustomOfflineChart
+                                    dataObject=""
+                                    dataVis={dataVis}
+                                    data={item.data}
+                                    index={index}
+                                    chartType={item.chartType}
+                                    height="400px; auto"
+                                    dropDown
+                                    onRemoveChart={() => removeChart(index)}
+                                    edit={edit}
+                                    orderByFrequency={item.data !== 'diagnosis_age_count'}
+                                    orderAlphabetically={item.data === 'diagnosis_age_count'}
+                                    trimByDefault={item.trim}
+                                    onChangeDataVisChartType={(newType) => setDataVisEntry(index, 'chartType', newType)}
+                                    onChangeDataVisData={(newData) => setDataVisEntry(index, 'data', newData)}
+                                    loading={dataVis[item.data] === undefined}
+                                />
+                            </Grid>
+                        );
+                    })}
                 </Grid>
             </Grid>
             {edit && (

--- a/src/views/clinicalGenomic/widgets/dataVisualization.js
+++ b/src/views/clinicalGenomic/widgets/dataVisualization.js
@@ -133,16 +133,22 @@ function DataVisualization() {
     useEffect(() => {
         const invalidChartIndexes = [];
         for (let i = 0; i < chartDefinitions.length; i += 1) {
+            // If this is not a valid chart type, remove it
             if (!VALID_CHART_TYPES.includes(chartDefinitions[i].chartType)) {
+                invalidChartIndexes.push(i);
+            }
+            // If the data has loaded, but does not exist, then we also remove it
+            else if (!Object.keys(dataVis).includes(chartDefinitions[i].data)) {
                 invalidChartIndexes.push(i);
             }
         }
 
         if (invalidChartIndexes.length > 0) {
             setChartDefinitions((old) => {
-                const newChartDefinitions = old.slice();
+                let newChartDefinitions = old.slice();
                 invalidChartIndexes.forEach((index, numRemoved) => {
-                    newChartDefinitions.slice(index - numRemoved);
+                    const indexToRemove = index - numRemoved;
+                    newChartDefinitions = newChartDefinitions.slice(0, indexToRemove).concat(old.slice(indexToRemove + 1));
                 });
                 localStorage.setItem(VISUALIZATION_LOCAL_STORAGE_KEY, JSON.stringify(newChartDefinitions), { expires: 365 });
                 return newChartDefinitions;
@@ -174,7 +180,6 @@ function DataVisualization() {
         setChartDefinitions((old) => {
             const newChartDefinitions = old.slice(0, index).concat(old.slice(index + 1));
             localStorage.setItem(VISUALIZATION_LOCAL_STORAGE_KEY, JSON.stringify(newChartDefinitions), { expires: 365 });
-            console.log(newChartDefinitions);
             return newChartDefinitions;
         });
     }
@@ -276,30 +281,27 @@ function DataVisualization() {
                     Data Visualization
                 </Typography>
                 <Grid container spacing={1} alignItems="center" justifyContent="center">
-                    {chartDefinitions.map((item, index) => {
-                        console.log(item);
-                        return (
-                            <Grid item xs={12} sm={12} md={6} lg={3} xl={3} key={JSON.stringify(item)}>
-                                <CustomOfflineChart
-                                    dataObject=""
-                                    dataVis={dataVis}
-                                    data={item.data}
-                                    index={index}
-                                    chartType={item.chartType}
-                                    height="400px; auto"
-                                    dropDown
-                                    onRemoveChart={() => removeChart(index)}
-                                    edit={edit}
-                                    orderByFrequency={item.data !== 'diagnosis_age_count'}
-                                    orderAlphabetically={item.data === 'diagnosis_age_count'}
-                                    trimByDefault={item.trim}
-                                    onChangeDataVisChartType={(newType) => setDataVisEntry(index, 'chartType', newType)}
-                                    onChangeDataVisData={(newData) => setDataVisEntry(index, 'data', newData)}
-                                    loading={dataVis[item.data] === undefined}
-                                />
-                            </Grid>
-                        );
-                    })}
+                    {chartDefinitions.map((item, index) => (
+                        <Grid item xs={12} sm={12} md={6} lg={3} xl={3} key={JSON.stringify(item)}>
+                            <CustomOfflineChart
+                                dataObject=""
+                                dataVis={dataVis}
+                                data={item.data}
+                                index={index}
+                                chartType={item.chartType}
+                                height="400px; auto"
+                                dropDown
+                                onRemoveChart={() => removeChart(index)}
+                                edit={edit}
+                                orderByFrequency={item.data !== 'diagnosis_age_count'}
+                                orderAlphabetically={item.data === 'diagnosis_age_count'}
+                                trimByDefault={item.trim}
+                                onChangeDataVisChartType={(newType) => setDataVisEntry(index, 'chartType', newType)}
+                                onChangeDataVisData={(newData) => setDataVisEntry(index, 'data', newData)}
+                                loading={dataVis[item.data] === undefined}
+                            />
+                        </Grid>
+                    ))}
                 </Grid>
             </Grid>
             {edit && (

--- a/src/views/summary/CustomOfflineChart.js
+++ b/src/views/summary/CustomOfflineChart.js
@@ -23,6 +23,9 @@ import config from 'config';
 
 window.Highcharts = Highcharts;
 
+// Used to ensure that we are not parsed an invalid chart type
+export const VALID_CHART_TYPES = [];
+
 /*
  * Component for offline chart
  * @param {string} chartType

--- a/src/views/summary/CustomOfflineChart.js
+++ b/src/views/summary/CustomOfflineChart.js
@@ -20,11 +20,12 @@ import MainCard from 'ui-component/cards/MainCard';
 import { DataVisualizationChartInfo, validCharts, validStackedCharts } from 'store/constant';
 import { HAS_CENSORED_DATA_MARKER } from 'utils/utils';
 import config from 'config';
+import { LOCAL_VARIABLE_KEY } from 'views/clinicalGenomic/widgets/dataVisualization';
 
 window.Highcharts = Highcharts;
 
-// Used to ensure that we are not parsed an invalid chart type
-export const VALID_CHART_TYPES = [];
+// Used to ensure that we are not passed an invalid chart type
+export const VALID_CHART_TYPES = ['bar', 'line', 'column', 'scatter', 'pie'];
 
 /*
  * Component for offline chart
@@ -390,25 +391,11 @@ function CustomOfflineChart({
         theme.palette.tertiary
     ]);
 
-    function setLocalStorageDataVisChart(event) {
+    function setLocalStorageDataVis(event, key) {
         // Set LocalStorage for Data Visualization Chart Type
-        const dataVisChart = JSON.parse(localStorage.getItem('dataVisChartType'));
-        dataVisChart[index] = event.target.value;
-        localStorage.setItem('dataVisChartType', JSON.stringify(dataVisChart), { expires: 365 });
-    }
-
-    function setLocalStorageDataVisData(event) {
-        // Set LocalStorage for Data Visualization Data
-        const dataVisData = JSON.parse(localStorage.getItem('dataVisData'));
-        dataVisData[index] = event.target.value;
-        localStorage.setItem('dataVisData', JSON.stringify(dataVisData), { expires: 365 });
-    }
-
-    function setLocalStorageDataVisTrim(value) {
-        // Set LocalStorage for Data Visualization Trim status
-        const dataVisTrim = JSON.parse(localStorage.getItem('dataVisTrim'));
-        dataVisTrim[index] = value;
-        localStorage.setItem('dataVisTrim', JSON.stringify(dataVisTrim), { expires: 365 });
+        const dataVisChart = JSON.parse(localStorage.getItem(LOCAL_VARIABLE_KEY));
+        dataVisChart[index][key] = event.target.value;
+        localStorage.setItem(LOCAL_VARIABLE_KEY, JSON.stringify(dataVisChart), { expires: 365 });
     }
 
     /* eslint-disable jsx-a11y/no-onchange */
@@ -462,7 +449,7 @@ function CustomOfflineChart({
                                     onChange={(event) => {
                                         setChartData(event.target.value);
                                         onChangeDataVisData(event.target.value);
-                                        setLocalStorageDataVisData(event);
+                                        setLocalStorageDataVis(event, 'data');
                                     }}
                                 >
                                     {Object.keys(dataVis).map((key) => (
@@ -484,7 +471,7 @@ function CustomOfflineChart({
                                         onChange={(event) => {
                                             setChart(event.target.value);
                                             onChangeDataVisChartType(event.target.value);
-                                            setLocalStorageDataVisChart(event);
+                                            setLocalStorageDataVis(event, 'chartType');
                                         }}
                                     >
                                         <option value="bar">Stacked Bar</option>
@@ -500,7 +487,7 @@ function CustomOfflineChart({
                                         onChange={(event) => {
                                             setChart(event.target.value);
                                             onChangeDataVisChartType(event.target.value);
-                                            setLocalStorageDataVisChart(event);
+                                            setLocalStorageDataVis(event, 'chartType');
                                         }}
                                     >
                                         <option value="bar">Bar</option>
@@ -517,7 +504,7 @@ function CustomOfflineChart({
                                         type="checkbox"
                                         id="trim"
                                         onChange={() => {
-                                            setLocalStorageDataVisTrim(!trim);
+                                            setLocalStorageDataVis(!trim, 'trim');
                                             setTrim((old) => !old);
                                         }}
                                         checked={trim}

--- a/src/views/summary/CustomOfflineChart.js
+++ b/src/views/summary/CustomOfflineChart.js
@@ -394,9 +394,9 @@ function CustomOfflineChart({
 
     function setLocalStorageDataVis(event, key) {
         // Set LocalStorage for Data Visualization Chart Type
-        const dataVisChart = JSON.parse(localStorage.getItem(LOCAL_VARIABLE_KEY));
+        const dataVisChart = JSON.parse(localStorage.getItem(VISUALIZATION_LOCAL_STORAGE_KEY));
         dataVisChart[index][key] = event.target.value;
-        localStorage.setItem(LOCAL_VARIABLE_KEY, JSON.stringify(dataVisChart), { expires: 365 });
+        localStorage.setItem(VISUALIZATION_LOCAL_STORAGE_KEY, JSON.stringify(dataVisChart), { expires: 365 });
     }
 
     /* eslint-disable jsx-a11y/no-onchange */

--- a/src/views/summary/CustomOfflineChart.js
+++ b/src/views/summary/CustomOfflineChart.js
@@ -384,6 +384,7 @@ function CustomOfflineChart({
         dataObject,
         grayscale,
         height,
+        index,
         orderAlphabetically,
         orderByFrequency,
         theme.palette.grey,

--- a/src/views/summary/CustomOfflineChart.js
+++ b/src/views/summary/CustomOfflineChart.js
@@ -20,12 +20,13 @@ import MainCard from 'ui-component/cards/MainCard';
 import { DataVisualizationChartInfo, validCharts, validStackedCharts } from 'store/constant';
 import { HAS_CENSORED_DATA_MARKER } from 'utils/utils';
 import config from 'config';
-import { LOCAL_VARIABLE_KEY } from 'views/clinicalGenomic/widgets/dataVisualization';
 
 window.Highcharts = Highcharts;
 
 // Used to ensure that we are not passed an invalid chart type
 export const VALID_CHART_TYPES = ['bar', 'line', 'column', 'scatter', 'pie'];
+// Defined here in order to prevent a circular dependancy
+export const VISUALIZATION_LOCAL_STORAGE_KEY = 'chartDefinitions';
 
 /*
  * Component for offline chart


### PR DESCRIPTION
## Ticket(s)

- https://candig.atlassian.net/browse/DIG-1514

## Description

- This fixes an issue where an erroneous localstorage would cause the searchpage to whitescreen. This also involves a refactor of the entire `dataVisualization.js` component, as it was a bit unwieldy to work with.

## Expected Behaviour

- No changes should be visible, although if you corrupt your localStorage into having an invalid chart type it should fix itself automatically.

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
