### PR TITLE
bugfix: Nodes and cohorts should be linked in the sidebar

### DIFF
--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -154,6 +154,16 @@ function StyledCheckboxList(props) {
             ids = [ids];
         }
 
+        const cohortMap = {};
+        sites.forEach((site) => {
+            site.results.forEach((result) => {
+                if (!cohortMap[result.program_id]) {
+                    cohortMap[result.program_id] = new Set();
+                }
+                cohortMap[result.program_id].add(site.location.name);
+            });
+        });
+
         if (isExclusion ? !isChecked : isChecked) {
             setChecked((_) => {
                 const retVal = {};
@@ -171,10 +181,16 @@ function StyledCheckboxList(props) {
                         const programIds = sites
                             .filter((item) => ids.includes(item.location.name)) // Check if location.name is in ids array
                             .flatMap((item) => item.results.map((result) => result.program_id)); // Extract program_id
-                        retVal.query.exclude_programs = programIds.join('|');
+                        const validProgramIds = programIds.filter((programId) => {
+                            const associatedNodes = cohortMap[programId] || new Set();
+                            console.log('associatedNodes', associatedNodes);
+                            console.log('checked', checked);
+                            return Array.from(associatedNodes).every((node) => !(node in checked));
+                        });
+                        retVal.query.exclude_programs = validProgramIds.join('|');
                         setSelectedPrograms((old) => {
                             const newPrograms = { ...old };
-                            programIds.forEach((id) => {
+                            validProgramIds.forEach((id) => {
                                 newPrograms[id] = true;
                             });
                             return newPrograms;

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -121,8 +121,23 @@ SidebarGroup.propTypes = {
 };
 
 function StyledCheckboxList(props) {
-    const { isExclusion, groupName, isFilterList, onWrite, options, authorizedPrograms, useAutoComplete, hide, checked, setChecked } =
-        props;
+    const {
+        isExclusion,
+        groupName,
+        isFilterList,
+        onWrite,
+        options,
+        authorizedPrograms,
+        useAutoComplete,
+        hide,
+        selectedPrograms,
+        setSelectedPrograms,
+        checked,
+        setChecked
+    } = props;
+
+    const context = useSearchResultsReaderContext();
+    const sites = context?.federation;
 
     if (hide) {
         return null;
@@ -149,10 +164,22 @@ function StyledCheckboxList(props) {
             });
             onWrite((old) => {
                 const retVal = { donorLists: {}, filter: {}, query: {}, ...old };
-
                 // The following appends ourselves to the write context under 'query': {group: [|-delimited-list]} or 'donorList': {group: [|-delimited-list]}
                 if (isFilterList) {
                     retVal.filter[groupName] = ids;
+                    if (groupName === 'node') {
+                        const programIds = sites
+                            .filter((item) => ids.includes(item.location.name)) // Check if location.name is in ids array
+                            .flatMap((item) => item.results.map((result) => result.program_id)); // Extract program_id
+                        retVal.query.exclude_programs = programIds.join('|');
+                        setSelectedPrograms((old) => {
+                            const newPrograms = { ...old };
+                            programIds.forEach((id) => {
+                                newPrograms[id] = true;
+                            });
+                            return newPrograms;
+                        });
+                    }
                 } else if (ids.length > 0) {
                     retVal.query[groupName] = ids.join('|');
                 }
@@ -172,6 +199,23 @@ function StyledCheckboxList(props) {
                     const newList = Object.fromEntries(Object.entries(retVal.filter).filter(([name, _]) => name !== groupName));
                     newList[groupName] = ids;
                     retVal.filter = newList;
+                    if (groupName === 'node') {
+                        const currentPrograms = { ...selectedPrograms };
+                        Object.keys(selectedPrograms).forEach((id) => {
+                            if (currentPrograms[id]) {
+                                delete currentPrograms[id];
+                            }
+                        });
+                        if (currentPrograms && Object.keys(currentPrograms).length > 0) {
+                            retVal.query.exclude_programs = Object.keys(currentPrograms)
+                                .filter((id) => currentPrograms[id])
+                                .join('|');
+                        } else {
+                            delete retVal.query.exclude_programs;
+                            retVal.query = {};
+                        }
+                        setSelectedPrograms(currentPrograms);
+                    }
                 } else {
                     const newList = Object.fromEntries(Object.entries(retVal.query).filter(([name, _]) => name !== groupName));
                     if (ids.length > 0) {
@@ -575,6 +619,8 @@ function Sidebar() {
                     groupName="node"
                     isFilterList
                     isExclusion
+                    selectedPrograms={selectedPrograms}
+                    setSelectedPrograms={setSelectedPrograms}
                     checked={selectedNodes}
                     setChecked={setSelectedNodes}
                 />

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -312,6 +312,8 @@ StyledCheckboxList.propTypes = {
     onWrite: PropTypes.func,
     options: PropTypes.array,
     useAutoComplete: PropTypes.bool,
+    setSelectedPrograms: PropTypes.func,
+    selectedPrograms: PropTypes.object,
     setChecked: PropTypes.func,
     checked: PropTypes.object
 };

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -183,8 +183,6 @@ function StyledCheckboxList(props) {
                             .flatMap((item) => item.results.map((result) => result.program_id)); // Extract program_id
                         const validProgramIds = programIds.filter((programId) => {
                             const associatedNodes = cohortMap[programId] || new Set();
-                            console.log('associatedNodes', associatedNodes);
-                            console.log('checked', checked);
                             return Array.from(associatedNodes).every((node) => !(node in checked));
                         });
                         retVal.query.exclude_programs = validProgramIds.join('|');


### PR DESCRIPTION
## Ticket(s)
[DIG-1829](https://candig.atlassian.net/browse/DIG-1829)

## Description
When unselecting a node in the sidebar, its associated programs remain selected. This change ensures that selecting or unselecting a node also updates the selection of its associated programs.

## Expected Behaviour
- Unselecting a node will unselect its associated programs.
- Selecting a node will select its associated programs.

![chrome_cX89oQwf3U](https://github.com/user-attachments/assets/79fe033d-27e8-4859-8409-8ccc00ec14fd)

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-1829]: https://candig.atlassian.net/browse/DIG-1829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ