### PR TITLE
Add changes to the new authx endpoints

### DIFF
--- a/src/views/pages/authentication/AuthCheck.js
+++ b/src/views/pages/authentication/AuthCheck.js
@@ -17,32 +17,42 @@ function AuthCheck(props) {
         reqNum: 0
     });
 
+    const setAuthCheckValue = (prop, value) => {
+        setAuthCheckState((old) => {
+            const retVal = { ...old };
+            retVal[prop] = value;
+            return retVal;
+        });
+    };
+
     // Fire off the authorization check
     useEffect(() => {
-        fetch(`${INGEST_URL}/user/me/authorize`)
+        setAuthCheckValue('loading', true);
+        fetch(`${INGEST_URL}/user/me`)
             .then((request) => {
                 if (request.ok) {
-                    return request.json();
+                    setAuthCheckValue('authorized', true);
+                    return undefined;
                 }
-                throw new Error(`${request.status}: ${request.statusText}`);
-            })
-            .then((data) => {
-                setAuthCheckState((old) => {
-                    const retVal = { ...old };
-                    retVal.pending = data.results === 'Pending';
-                    retVal.authorized = Array.isArray(data.results);
-                    return retVal;
-                });
+                setAuthCheckValue('authorized', false);
+
+                // Request not ok: double check to see if we're pending
+                return fetch(`${INGEST_URL}/user/pending/me`)
+                    .then((request) => {
+                        if (request.ok) {
+                            return request.text();
+                        }
+                        throw new Error(request.error);
+                    })
+                    .then((text) => {
+                        setAuthCheckValue('pending', text.trim() === 'true');
+                    });
             })
             .catch((error) => {
                 console.log(error);
             })
             .finally(() => {
-                setAuthCheckState((old) => {
-                    const retVal = { ...old };
-                    retVal.loading = false;
-                    return retVal;
-                });
+                setAuthCheckValue('loading', false);
             });
     }, [authCheckState.reqNum]);
 


### PR DESCRIPTION
## Ticket(s)

- DIG-1887/1890/1892/1897

## Description

- [This PR](https://github.com/CanDIG/CanDIGv2/pull/938) changes how the ingest endpoints for the auth check work, and should be updated.

## Expected Behaviour

- Using this version of the portal will still work with the attached PR

## Related Issues (if appropriate)

- https://github.com/CanDIG/candigv2-authx/pull/40 
- https://github.com/CanDIG/candigv2-ingest/pull/151
- https://github.com/CanDIG/CanDIGv2/pull/938

## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
