### PR TITLE
Allow users to grab a list of nodes without auth

### DIFF
--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -593,7 +593,7 @@ function Sidebar() {
     };
 
     // Parse out what we need:
-    const sites = readerContext?.programs?.map((loc) => loc.location.name) || [];
+    const sites = readerContext?.federation?.map((loc) => loc.location.name) || [];
     const programs = readerContext?.federation?.map((loc) => loc.results?.map((program) => program.program_id) || [])?.flat(1) || [];
     const authorizedPrograms = readerContext?.programs?.flatMap((loc) => loc?.results?.items?.map((program) => program.program_id)) || [];
     const treatmentTypes = ExtractSidebarElements('treatment_types');


### PR DESCRIPTION
## Description

- Currently there's a bug where a user can be 500'd on a federated system and have their requests fail to load up anything on requesting katsu `v3/authorized/programs`. That is a separate issue, but since it's an authorized endpoint we shouldn't be using it anyway for determining which nodes exist (we can use the much more open `discovery/` endpoint instead).

## Screenshots (if appropriate)

### Before PR
![image](https://github.com/user-attachments/assets/2880868a-ff12-4e37-842e-69c665b94a6b)

### After PR
![image](https://github.com/user-attachments/assets/b30f49b0-6cb9-4612-93dd-ed2c01568bcb)

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [x] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
