### PR TITLE
Change discovery to auth

### DIFF
--- a/src/store/api.js
+++ b/src/store/api.js
@@ -30,15 +30,18 @@ export function fetchOrRelogin(...args) {
     });
 }
 
-export function fetchFederationStat(endpoint) {
+/*
+Generic querying for federation
+*/
+export function fetchFederation(path, service, payload) {
     return fetchOrRelogin(`${federation}/fanout`, {
         method: 'post',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
             method: 'GET',
-            path: `v3/discovery/overview${endpoint}`,
-            payload: {},
-            service: 'katsu'
+            path,
+            payload: payload || {},
+            service
         })
     })
         .then((response) => {
@@ -53,26 +56,23 @@ export function fetchFederationStat(endpoint) {
         });
 }
 
-/*
-Generic querying for federation
-*/
-export function fetchFederation(path, service) {
-    return fetchOrRelogin(`${federation}/fanout`, {
-        method: 'post',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            method: 'GET',
-            path,
-            payload: {},
-            service
-        })
-    })
-        .then((response) => {
-            if (response.ok) {
-                return response.json();
-            }
-            return [];
-        })
+/**
+ * Fetch federated sub-services by querying the Query microservice.
+ *
+ * @param {string} targetPath - The specific path within the target service to request data from
+ * @param {string} [targetService='katsu'] - The target service being queried (default: 'katsu')
+ * @param {string} [endpoint='discovery] - The endpoint used for the federation request (default: 'discovery')
+ * @param {string} [service='query'] - The service handling the request (default: 'query')
+ * @returns {Promise<Object|string>} A promise that resolves to the response data or 'error' if the request fails
+ */
+export function fetchFederatedSubServices(targetPath, targetService = 'katsu', endpoint = 'discovery', service = 'query') {
+    const payload = {
+        targetService,
+        targetPath
+    };
+
+    return fetchFederation(endpoint, service, payload)
+        .then((data) => data)
         .catch((error) => {
             console.log(`Error: ${error}`);
             return 'error';

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { trackPromise } from 'react-promise-tracker';
 
 import { useSearchResultsWriterContext, useSearchQueryReaderContext } from '../SearchResultsContext';
-import { fetchFederationStat, fetchFederation, query } from 'store/api';
+import { fetchFederation, query, fetchFederatedSubServices } from 'store/api';
 
 // NB: I assign to lastPromise a bunch to keep track of whether or not we need to chain promises together
 // However, the linter really dislikes this, and assumes I want to put everything inside one useEffect?
@@ -22,11 +22,11 @@ function SearchHandler({ setLoading }) {
     useEffect(() => {
         setLoading(true);
         lastPromise = trackPromise(
-            fetchFederation('v3/discovery/sidebar_list', 'katsu')
+            fetchFederatedSubServices(`v3/discovery/sidebar_list`)
                 .then((data) => {
                     writer((old) => ({ ...old, sidebar: data }));
                 })
-                .then(() => fetchFederationStat('/patients_per_program'))
+                .then(() => fetchFederatedSubServices('v3/discovery/overview/patients_per_program'))
                 .then((data) => {
                     writer((old) => ({ ...old, federation: data }));
                 })

--- a/src/views/summary/summary.js
+++ b/src/views/summary/summary.js
@@ -8,7 +8,7 @@ import CustomOfflineChart from 'views/summary/CustomOfflineChart';
 import TreatingCentreMap from 'views/summary/TreatingCentreMap';
 
 // project imports
-import { fetchClinicalCompleteness, fetchFederationStat, fetchGenomicCompleteness } from 'store/api';
+import { fetchClinicalCompleteness, fetchFederatedSubServices, fetchGenomicCompleteness } from 'store/api';
 import { aggregateObj, aggregateKatsuObj, aggregateObjStack, invertkatsu } from 'utils/utils';
 
 // assets
@@ -166,7 +166,7 @@ function Summary() {
 
     useEffect(() => {
         function fetchData(endpoint) {
-            return fetchFederationStat(endpoint)
+            return fetchFederatedSubServices(`v3/discovery/overview${endpoint}`)
                 .then((data) => {
                     federationStatCount(data, endpoint);
                     if (endpoint === '/individual_count') {
@@ -174,20 +174,20 @@ function Summary() {
                     }
                 })
                 .catch((error) => {
-                    // pass
-                    console.log('Error fetching data : ', error);
+                    console.log('Error fetching data:', error);
                 })
                 .finally(() => {
                     finishEndpoint(endpoint);
                 });
         }
-
-        fetchData('/individual_count');
-        fetchData('/primary_site_count');
-        fetchData('/program_count');
-        fetchData('/patients_per_program');
-        fetchData('/treatment_type_count');
-        fetchData('/diagnosis_age_count');
+        [
+            '/individual_count',
+            '/primary_site_count',
+            '/program_count',
+            '/patients_per_program',
+            '/treatment_type_count',
+            '/diagnosis_age_count'
+        ].forEach(fetchData);
         fetchGenomic();
         fetchClinical();
         // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Ticket(s)
[Data portal call query for Discovery Calls](https://candig.atlassian.net/browse/DIG-1936)

## Description
This PR implements changes to the discovery endpoints, enabling calls through the fetchFederatedSubServices function to access the Query microservices for Katsu services' discovery endpoints, implementing authentication on discovery.

## Expected Behaviour
Data portal should be working as it was prior to the auth change. 

## Related Issues (if appropriate)
- [CanDIGv2](https://github.com/CanDIG/CanDIGv2/pull/968)
- [Query PR needed alongside data-portal](https://github.com/CanDIG/candigv2-query/pull/68)


## Merge with
- [Query PR](https://github.com/CanDIG/candigv2-query/pull/68)

## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
