### PR TITLE
Replace the two small graphs with a field level completeness graph

### DIFF
--- a/src/views/completeness/fieldLevelCompletenessGraph.jsx
+++ b/src/views/completeness/fieldLevelCompletenessGraph.jsx
@@ -43,7 +43,7 @@ const Root = styled(Box)(({ _ }) => ({
         display: 'inline-flex',
         flexDirection: 'row-reverse',
         marginLeft: 'auto',
-        fontSize: '1.4em',
+        fontSize: '1.3em',
         fontWeight: 'normal',
         fontFamily: 'Helvetica, Arial, sans-serif' // Taken from HighCharts
     },
@@ -199,8 +199,17 @@ function FieldLevelCompletenessGraph(props) {
                 <div className={classes.titleBar}>
                     <Typography className={classes.title}>{title}</Typography>
                     <div className={classes.spacer} />
-                    <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
-                        <Select value={filter} onChange={(event) => setFilter(event.target.value)} className={classes.siteSelection}>
+                    <FormControl sx={{ m: 1, p: 0, minWidth: 120 }} size="small">
+                        <Select
+                            value={filter}
+                            onChange={(event) => setFilter(event.target.value)}
+                            className={classes.siteSelection}
+                            sx={{
+                                '& .MuiSelect-select': {
+                                    padding: '4px 8px !important'
+                                }
+                            }}
+                        >
                             {allPrograms.map((program) => (
                                 <MenuItem value={program} key={program}>
                                     {program}

--- a/src/views/summary/summary.js
+++ b/src/views/summary/summary.js
@@ -8,13 +8,14 @@ import CustomOfflineChart from 'views/summary/CustomOfflineChart';
 import TreatingCentreMap from 'views/summary/TreatingCentreMap';
 
 // project imports
-import { fetchClinicalCompleteness, fetchFederatedSubServices, fetchGenomicCompleteness } from 'store/api';
+import { fetchClinicalCompleteness, fetchFederatedSubServices } from 'store/api';
 import { aggregateObj, aggregateKatsuObj, aggregateObjStack, invertkatsu } from 'utils/utils';
 
 // assets
 import { Hive, CheckCircleOutline, WarningAmber, Person, Public } from '@mui/icons-material';
 
 import { useSidebarWriterContext } from 'layout/MainLayout/Sidebar/SidebarContext';
+import FieldLevelCompletenessGraph from '../completeness/fieldLevelCompletenessGraph';
 
 function Summary() {
     const theme = useTheme();
@@ -36,8 +37,8 @@ function Summary() {
     const [programCount, setProgramCount] = useState(undefined);
     const [patientsPerProgram, setPatientsPerProgram] = useState(undefined);
     const [diagnosisAgeCount, setDiagnosisAgeCount] = useState(undefined);
-    const [numClinicalComplete, setNumClinicalComplete] = useState(undefined);
-    const [numGenomicComplete, setNumGenomicComplete] = useState(undefined);
+    const [clinicalComplete, setClinicalComplete] = useState([]);
+
     const [connectionError, setConnectionError] = useState(0);
     const [sites, setSites] = useState(0);
     const [totalSites, setTotalSites] = useState(0);
@@ -144,26 +145,6 @@ function Summary() {
         });
     }
 
-    function fetchClinical() {
-        fetchClinicalCompleteness()
-            .then((data) => {
-                setNumClinicalComplete(data.numClinicalComplete);
-            })
-            .finally(() => {
-                finishEndpoint('clinical');
-            });
-    }
-
-    function fetchGenomic() {
-        fetchGenomicCompleteness()
-            .then((numCompleteGenomic) => {
-                setNumGenomicComplete(numCompleteGenomic);
-            })
-            .finally(() => {
-                finishEndpoint('genomic');
-            });
-    }
-
     useEffect(() => {
         function fetchData(endpoint) {
             return fetchFederatedSubServices(`v3/discovery/overview${endpoint}`)
@@ -188,8 +169,9 @@ function Summary() {
             '/treatment_type_count',
             '/diagnosis_age_count'
         ].forEach(fetchData);
-        fetchGenomic();
-        fetchClinical();
+        fetchClinicalCompleteness().then((data) => {
+            setClinicalComplete(data.data);
+        });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -307,31 +289,8 @@ function Summary() {
                     cutoff={10}
                 />
             </Grid>
-            <Grid item xs={12} sm={12} md={6} lg={3}>
-                <CustomOfflineChart
-                    dataObject={numClinicalComplete || {}}
-                    data="full_clinical_data"
-                    dataVis=""
-                    chartType="bar"
-                    height="400px; auto"
-                    dropDown={false}
-                    loading={isLoading.clinical}
-                    orderByFrequency
-                    cutoff={10}
-                />
-            </Grid>
-            <Grid item xs={12} sm={12} md={6} lg={3}>
-                <CustomOfflineChart
-                    dataObject={numGenomicComplete || {}}
-                    data="full_genomic_data"
-                    dataVis=""
-                    chartType="bar"
-                    height="400px; auto"
-                    dropDown={false}
-                    loading={isLoading.genomic}
-                    orderByFrequency
-                    cutoff={10}
-                />
+            <Grid item xs={12} sm={12} md={6} lg={6}>
+                <FieldLevelCompletenessGraph data={clinicalComplete} loading={clinicalComplete.length === 0} title="Field Level Completeness" />
             </Grid>
         </Grid>
     );

--- a/src/views/summary/summary.js
+++ b/src/views/summary/summary.js
@@ -290,7 +290,11 @@ function Summary() {
                 />
             </Grid>
             <Grid item xs={12} sm={12} md={6} lg={6}>
-                <FieldLevelCompletenessGraph data={clinicalComplete} loading={clinicalComplete.length === 0} title="Field Level Completeness" />
+                <FieldLevelCompletenessGraph
+                    data={clinicalComplete}
+                    loading={clinicalComplete.length === 0}
+                    title="Field Level Completeness"
+                />
             </Grid>
         </Grid>
     );


### PR DESCRIPTION
## Description

- Replaces the two small graphs on the summary page with the field level completeness graph

## Screenshots (if appropriate)

### Before PR
![image](https://github.com/user-attachments/assets/8ae15b8b-ac1c-4a98-b4c5-0b2677d15832)

### After PR
![image](https://github.com/user-attachments/assets/ba2763a3-4b95-4fcd-bd57-a609cb39f2ca)

## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
