### PR TITLE
DIG-2021: new query result format

### DIFF
--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -101,7 +101,8 @@ function ClinicalView() {
         {
             field: 'submitter_donor_id',
             headerName: 'Donor ID',
-            minWidth: 220,
+            minWidth: 250,
+            flex: 1,
             sortable: false,
             renderCell: (params) => (
                 <Tooltip title="Open Patient View" placement="right">
@@ -129,12 +130,12 @@ function ClinicalView() {
                 </Tooltip>
             )
         },
-        { field: 'location', headerName: 'Location', minWidth: 220, sortable: false },
-        { field: 'program_id', headerName: 'Program ID', minWidth: 220, sortable: false },
-        { field: 'sex_at_birth', headerName: 'Sex At Birth', minWidth: 170, sortable: false },
-        { field: 'deceased', headerName: 'Deceased', minWidth: 170, sortable: false },
-        { field: 'date_of_birth', headerName: 'Age at First Diagnosis', minWidth: 200, sortable: false },
-        { field: 'date_of_death', headerName: 'Age at Death', minWidth: 220, sortable: false }
+        { field: 'location', headerName: 'Location', minWidth: 125, flex: 1, sortable: false },
+        { field: 'program_id', headerName: 'Program ID', minWidth: 170, flex: 1, sortable: false },
+        { field: 'sex_at_birth', headerName: 'Sex At Birth', minWidth: 170, flex: 1, sortable: false },
+        { field: 'deceased', headerName: 'Deceased', minWidth: 170, flex: 1, sortable: false },
+        { field: 'date_of_birth', headerName: 'Age at First Diagnosis', minWidth: 170, flex: 1, sortable: false },
+        { field: 'date_of_death', headerName: 'Age at Death', minWidth: 170, flex: 1, sortable: false }
     ];
 
     const HandlePageChange = (newModel) => {

--- a/src/views/clinicalGenomic/widgets/genomicData.js
+++ b/src/views/clinicalGenomic/widgets/genomicData.js
@@ -53,12 +53,12 @@ function GenomicData() {
 
     // JSON on bottom now const screenWidth = desktopResolution ? '48%' : '100%';
     const columns = [
-        { field: 'location', headerName: 'Node', minWidth: 120, sortable: false, filterable: false },
-        { field: 'donor_id', headerName: 'Donor ID', minWidth: 150, sortable: false, filterable: false },
-        { field: 'program_id', headerName: 'Program ID', minWidth: 150, sortable: false, filterable: false },
-        { field: 'variant_count', headerName: 'Estimated Variants', minWidth: 150, sortable: false, filterable: false },
-        { field: 'tumour_normal_designation', headerName: 'Tumour/Normal', minWidth: 200, sortable: false, filterable: false },
-        { field: 'submitter_sample_id', headerName: 'Sample Registration ID', minWidth: 300, sortable: false, filterable: false }
+        { field: 'donor_id', headerName: 'Donor ID', minWidth: 220, flex: 1, sortable: false, filterable: false },
+        { field: 'location', headerName: 'Location', minWidth: 150, flex: 1, sortable: false, filterable: false },
+        { field: 'program_id', headerName: 'Program ID', minWidth: 170, flex: 1, sortable: false, filterable: false },
+        { field: 'variant_count', headerName: 'Estimated Variants', minWidth: 150, flex: 1, sortable: false, filterable: false },
+        { field: 'tumour_normal_designation', headerName: 'Tumour/Normal', minWidth: 200, flex: 1, sortable: false, filterable: false },
+        { field: 'submitter_sample_id', headerName: 'Sample Registration ID', minWidth: 300, flex: 1, sortable: false, filterable: false }
     ];
 
     const queryParams = query?.gene || query?.chrom;

--- a/src/views/clinicalGenomic/widgets/genomicData.js
+++ b/src/views/clinicalGenomic/widgets/genomicData.js
@@ -32,11 +32,11 @@ function GenomicData() {
                     // Make sure each row has an ID
                     const retVal = { ...patient };
                     retVal.id = index;
-                    retVal.genotypeLabel = patient.genotype.value;
-                    if (patient.genotype.secondaryAlleleIds) {
-                        retVal.genotypeLabel += ` (${patient.genotype.secondaryAlleleIds[0]})`;
-                    }
-                    retVal.zygosityLabel = patient.genotype.zygosity?.label || '';
+                    // retVal.genotypeLabel = patient.genotype.value;
+                    // if (patient.genotype.secondaryAlleleIds) {
+                    //     retVal.genotypeLabel += ` (${patient.genotype.secondaryAlleleIds[0]})`;
+                    // }
+                    // retVal.zygosityLabel = patient.genotype.zygosity?.label || '';
                     retVal.location = patient.location.name;
 
                     // TODO: Fix the below with the actual normal ID
@@ -56,11 +56,9 @@ function GenomicData() {
         { field: 'location', headerName: 'Node', minWidth: 120, sortable: false, filterable: false },
         { field: 'donor_id', headerName: 'Donor ID', minWidth: 150, sortable: false, filterable: false },
         { field: 'program_id', headerName: 'Program ID', minWidth: 150, sortable: false, filterable: false },
-        { field: 'position', headerName: 'Position', minWidth: 150, sortable: false, filterable: false },
+        { field: 'variant_count', headerName: 'Estimated Variants', minWidth: 150, sortable: false, filterable: false },
         { field: 'tumour_normal_designation', headerName: 'Tumour/Normal', minWidth: 200, sortable: false, filterable: false },
-        { field: 'submitter_specimen_id', headerName: 'Sample Registration ID', minWidth: 300, sortable: false, filterable: false },
-        { field: 'genotypeLabel', headerName: 'Genotype', minWidth: 300, sortable: false, filterable: false },
-        { field: 'zygosityLabel', headerName: 'Zygosity', minWidth: 200, sortable: false, filterable: false }
+        { field: 'submitter_sample_id', headerName: 'Sample Registration ID', minWidth: 300, sortable: false, filterable: false }
     ];
 
     const queryParams = query?.gene || query?.chrom;


### PR DESCRIPTION
## Ticket(s)

- DIG-2021

## Description

- Updated the genomic results table to display the estimated variant count instead of detailed info about the actual variants, since quick search doesn't give us that level of specificity.

Depends on https://github.com/CanDIG/htsget_app/pull/357 and https://github.com/CanDIG/candigv2-query/pull/71. 

You can test this for user1@test.ca with the gene SLC2A5.