### PR TITLE
DHDPS-310: Store both the access and the refresh token in the cookie, and use either as needed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ const root = createRoot(container);
 root.render(
     <Provider store={store}>
         <SearchResultsProvider>
-            <BrowserRouter>
+            <BrowserRouter forceRefresh>
                 <App />
             </BrowserRouter>
         </SearchResultsProvider>

--- a/src/layout/MainLayout/Header/ProfileSection/apiTokenbutton.jsx
+++ b/src/layout/MainLayout/Header/ProfileSection/apiTokenbutton.jsx
@@ -35,7 +35,7 @@ function APITokenButton(props) {
             if ('error' in data) {
                 setError(data.error);
             } else {
-                setToken(data.token);
+                setToken(data.token.split('|')[0]);
                 setTokenHidden(false);
             }
         });

--- a/src/layout/MainLayout/Header/index.js
+++ b/src/layout/MainLayout/Header/index.js
@@ -74,7 +74,6 @@ function Header({ handleLeftDrawerToggle }) {
             {/* header search */}
             {/* <SearchSection theme="light" />  Currently not needed */}
             <StyledGrow className={classes.grow} />
-            <StyledGrow className={classes.grow} />
 
             {/* notification & profile */}
             {/* <NotificationSection /> */}

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -5,29 +5,40 @@ export const htsget = process.env.REACT_APP_HTSGET_SERVER;
 export const INGEST_URL = process.env.REACT_APP_INGEST_SERVER;
 
 export function reloginCheck() {
-    return fetch('/query/whoami').then((response) => {
-        if (response.status === 401) {
-            // The user's token has expired, and they need to refresh the page
-            window.location.replace('/');
-            throw new Error("User's token has expired, they must refresh");
-        } else {
-            // Wasn't a permission denied -- continue processing
-            return true;
-        }
-    });
+    return fetch('/portal/favicon.ico')
+        .then((response) => {
+            console.log(`Relogin check performed. Statuz: ${response.status}`);
+            if (response.status === 401) {
+                // The user's token has expired, and they need to refresh the page
+                window.location.reload();
+                throw new Error("User's token has expired, they must refresh");
+            } else {
+                // Wasn't a permission denied -- continue processing
+                return true;
+            }
+        })
+        .catch((error) => {
+            console.log(error);
+            window.location.reload();
+        });
 }
 
 export function fetchOrRelogin(...args) {
-    return fetch(...args).then((response) => {
-        if (response.status === 401) {
-            // The user's token has expired, and they need to refresh the page
-            window.location.replace('/');
-            throw new Error("User's token has expired, they must refresh");
-        } else {
-            // Wasn't a permission denied -- continue processing
-            return response;
-        }
-    });
+    return fetch(...args)
+        .then((response) => {
+            if (response.status === 401) {
+                // The user's token has expired, and they need to refresh the page
+                window.location.reload();
+                throw new Error("User's token has expired, they must refresh");
+            } else {
+                // Wasn't a permission denied -- continue processing
+                return response;
+            }
+        })
+        .catch((error) => {
+            console.log(error);
+            window.location.reload();
+        });
 }
 
 /*

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -7,7 +7,6 @@ export const INGEST_URL = process.env.REACT_APP_INGEST_SERVER;
 export function reloginCheck() {
     return fetch('/portal/favicon.ico')
         .then((response) => {
-            console.log(`Relogin check performed. Statuz: ${response.status}`);
             if (response.status === 401) {
                 // The user's token has expired, and they need to refresh the page
                 window.location.reload();

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -23,21 +23,16 @@ export function reloginCheck() {
 }
 
 export function fetchOrRelogin(...args) {
-    return fetch(...args)
-        .then((response) => {
-            if (response.status === 401) {
-                // The user's token has expired, and they need to refresh the page
-                window.location.reload();
-                throw new Error("User's token has expired, they must refresh");
-            } else {
-                // Wasn't a permission denied -- continue processing
-                return response;
-            }
-        })
-        .catch((error) => {
-            console.log(error);
+    return fetch(...args).then((response) => {
+        if (response.status === 401) {
+            // The user's token has expired, and they need to refresh the page
             window.location.reload();
-        });
+            throw new Error("User's token has expired, they must refresh");
+        } else {
+            // Wasn't a permission denied -- continue processing
+            return response;
+        }
+    });
 }
 
 /*
@@ -188,7 +183,7 @@ export function fetchGenomicCompleteness() {
 export function fetchClinicalCompleteness() {
     return fetchFederation('discovery/programs', 'query').then((data) => {
         // Step 1: Determine the number of provinces
-        const provinces = data.map((site) => site?.location?.province);
+        const provinces = data?.map((site) => site?.location?.province);
         const uniqueProvinces = [...new Set(provinces)];
         const retVal = {};
         retVal.numProvinces = uniqueProvinces.length;

--- a/src/views/clinicalGenomic/widgets/patientCounts.js
+++ b/src/views/clinicalGenomic/widgets/patientCounts.js
@@ -89,7 +89,7 @@ function PatientCounts() {
                 </Grid>
             </Box>
             {/* Individual counts */}
-            {siteData.map((site) => (
+            {siteData?.map((site) => (
                 <React.Fragment key={site.location}>
                     <PatientCountSingle site={site.location} counts={site} />
                     <Box className={`${PREFIX}-spacing`} />

--- a/src/views/clinicalGenomic/widgets/timeline.js
+++ b/src/views/clinicalGenomic/widgets/timeline.js
@@ -94,7 +94,7 @@ function Timeline({ data, onEventClick }) {
 
         const generateSeriesDataPrimaryDiagnosis = (data, namePrefix, y, colour, date, name, id) =>
             Array.isArray(data)
-                ? data.map((item) => ({
+                ? data?.map((item) => ({
                       x: formatDate(item?.[date]),
                       y,
                       name: `${namePrefix}${item?.[id]}`,

--- a/src/views/completeness/fieldLevelCompletenessGraph.jsx
+++ b/src/views/completeness/fieldLevelCompletenessGraph.jsx
@@ -9,12 +9,15 @@ import PropTypes from 'prop-types';
 
 // project imports
 import Highcharts from 'highcharts/highstock';
+import HighchartsAccessibility from 'highcharts/modules/accessibility';
 import HighchartsReact from 'highcharts-react-official';
 import NoDataToDisplay from 'highcharts/modules/no-data-to-display';
 
 // assets
 import MainCard from 'ui-component/cards/MainCard';
 import { useTheme } from '@mui/system';
+
+HighchartsAccessibility(Highcharts);
 
 window.Highcharts = Highcharts;
 
@@ -62,7 +65,7 @@ function FieldLevelCompletenessGraph(props) {
     const [filter, setFilter] = useState('All programs');
     const theme = useTheme();
     const chartRef = createRef();
-    const events = useSelector((state) => state);
+    const customization = useSelector((state) => state.customization);
 
     NoDataToDisplay(Highcharts);
 
@@ -195,7 +198,7 @@ function FieldLevelCompletenessGraph(props) {
     // Determine what we can do with the data
     return (
         <Root sx={{ position: 'relative' }}>
-            <MainCard sx={{ borderRadius: events.customization.borderRadius * 0.25, height: '440px; auto' }}>
+            <MainCard sx={{ borderRadius: customization.borderRadius * 0.25, height: '440px; auto' }}>
                 <div className={classes.titleBar}>
                     <Typography className={classes.title}>{title}</Typography>
                     <div className={classes.spacer} />

--- a/src/views/summary/summary.js
+++ b/src/views/summary/summary.js
@@ -112,7 +112,7 @@ function Summary() {
 
         // Set Site Count/Provinces
         if (data) {
-            setProvinceCount(new Set(data.map((loc) => loc.location.province)).size);
+            setProvinceCount(new Set(data?.map((loc) => loc.location.province)).size);
         }
 
         // Count Node Status


### PR DESCRIPTION
## Ticket(s)

- https://github.com/CanDIG/CanDIGv2/pull/1052
- This is related to a DHDP ticket, but is functionality that we probably want in our base URL as well.

## Description

- This compounds on the work from https://github.com/CanDIG/CanDIGv2/pull/1052 and adjusts the frontend to:
1. Split out the token properly in the Get API Token button
2. Refresh properly when the refresh token becomes invalid

- This also fixes up an issue with some console warnings being thrown by the field level completeness graph. 

## Expected Behaviour

- Set the token lifetimes as below in Keycloak's admin page at /auth/admin/master/console/ under Candig (top left) and then Realm Settings:
- 
![image](https://github.com/user-attachments/assets/e6338ed2-1e5d-4cd6-bd45-61780eda2790)
![image](https://github.com/user-attachments/assets/1811b90b-76cf-496a-bbb9-d093b364eb7a)
- Sign into the frontend
- Wait a while for your tokens to expire
- Go to another page
- No more red screen, instead you are booted back to the login screen (because your login session has expired)

In addition, if you set the access token lifetime to be short but the refresh token lifetime to be long, you can see your access token refresh itself.

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
