### PR TITLE
Prevent the age data from getting erroneously deleted on rerender

### DIFF
--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -61,6 +61,7 @@ function ClinicalView() {
             delete patient.date_of_birth;
             delete patient.date_of_death;
         }
+        return patient;
     }
 
     // Function to process search results
@@ -76,8 +77,7 @@ function ClinicalView() {
                 .map((patient, index) => {
                     patient.id = index;
                     patient.deceased = !!patient.date_of_death;
-                    calculateAge(patient);
-                    return patient;
+                    return calculateAge({...patient});
                 });
         }
 

--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -77,7 +77,7 @@ function ClinicalView() {
                 .map((patient, index) => {
                     patient.id = index;
                     patient.deceased = !!patient.date_of_death;
-                    return calculateAge({...patient});
+                    return calculateAge({ ...patient });
                 });
         }
 


### PR DESCRIPTION
## Description

- The first page of search results on the clinical genomic search page were getting their ages deleted, as that page rerenders the search page multiple times and there was a non-pure function deleting data between renders.

## Expected Behaviour

- The first page of search results should now show ages properly, without needing to navigate back and forth

## Screenshots (if appropriate)

### Before PR
![image](https://github.com/user-attachments/assets/bcd81723-2107-4856-ad94-8b86f0aecbf4)

### After PR
![image](https://github.com/user-attachments/assets/0aff02f6-a2ad-422e-9007-e611425e9511)


## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
