### PR TITLE
Change sidebar sections to autocompletes

### DIFF
--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -264,7 +264,7 @@ function StyledCheckboxList(props) {
                     {option}
                 </li>
             )}
-            renderInput={(params) => <TextField {...params} label={groupName} />}
+            renderInput={(params) => <TextField {...params} label={groupName === 'exclude_programs' ? 'Programs' : groupName} />}
             renderTags={(tagValue, getTagProps) =>
                 tagValue.map((option, index) => <Chip {...getTagProps({ index })} key={option} label={option} />)
             }
@@ -628,11 +628,12 @@ function Sidebar() {
                     Search
                 </Button>
             </div>
-            <SidebarGroup name="Node">
+            <SidebarGroup name="Nodes">
                 <StyledCheckboxList
                     options={sites}
                     onWrite={writerContext}
                     groupName="node"
+                    useAutoComplete={sites.length >= 5}
                     isFilterList
                     isExclusion
                     selectedPrograms={selectedPrograms}
@@ -641,12 +642,13 @@ function Sidebar() {
                     setChecked={setSelectedNodes}
                 />
             </SidebarGroup>
-            <SidebarGroup name="Program">
+            <SidebarGroup name="Programs">
                 <StyledCheckboxList
                     options={programs}
                     authorizedPrograms={authorizedPrograms}
                     onWrite={writerContext}
                     groupName="exclude_programs"
+                    useAutoComplete={programs.length >= 5}
                     isExclusion
                     checked={selectedPrograms}
                     setChecked={setSelectedPrograms}
@@ -666,7 +668,7 @@ function Sidebar() {
                 setStartPos={setStartPos}
                 setEndPos={setEndPos}
             />
-            <SidebarGroup name="Treatment" hide={hideClinical}>
+            <SidebarGroup name="Treatments" hide={hideClinical}>
                 <StyledCheckboxList
                     options={treatmentTypes}
                     onWrite={writerContext}
@@ -677,7 +679,7 @@ function Sidebar() {
                     setChecked={setSelectedTreatment}
                 />
             </SidebarGroup>
-            <SidebarGroup name="Tumour Primary Site" hide={hideClinical}>
+            <SidebarGroup name="Tumour Primary Sites" hide={hideClinical}>
                 <StyledCheckboxList
                     options={tumourPrimarySites}
                     onWrite={writerContext}


### PR DESCRIPTION
## Ticket(s)
[DIG-1983: Sidebar collapse dropdown ](https://candig.atlassian.net/browse/DIG-1983)
## Description
With other elements in the sidebar we collapse the values when there are more than 5, now we have >30 programs ingested. Change all sections of the sidebar to collapse when more than 5.  Programs and Nodes have been updated

## Screenshots 
![image](https://github.com/user-attachments/assets/31581d81-8d3f-4570-98c6-5f4958083e09)


## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
