### PR TITLE
Replace all instances of site.results. with a safe site?.results?. || {}

### DIFF
--- a/src/store/api.js
+++ b/src/store/api.js
@@ -166,9 +166,9 @@ export function fetchGenomicCompleteness() {
         const numCompleteGenomic = {};
         data.filter((site) => site.status === 200).forEach((site) => {
             numCompleteGenomic[site.location.name] = {};
-            Object.keys(site.results).forEach((program) => {
-                Object.keys(site.results[program]).forEach((type) => {
-                    numCompleteGenomic[site.location.name][`${program} (${type})`] = site.results[program][type];
+            Object.keys(site?.results || {}).forEach((program) => {
+                Object.keys(site?.results[program] || {}).forEach((type) => {
+                    numCompleteGenomic[site.location.name][`${program} (${type})`] = site?.results?.[program]?.[type];
                 });
             });
         });

--- a/src/ui-component/ingest/ClinicalIngest.js
+++ b/src/ui-component/ingest/ClinicalIngest.js
@@ -52,7 +52,7 @@ function ClinicalIngest({ setTab, fileUpload, clinicalData }) {
             return fetchFederation('v3/discovery/donors/', 'katsu')
                 .then((result) => {
                     result.forEach((site) => {
-                        const programs = site.results.discovery_donor;
+                        const programs = site?.results?.discovery_donor || {};
                         const fields = [];
                         Object.keys(programs).forEach((program) => {
                             const field = [

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -61,7 +61,7 @@ function SearchHandler({ setLoading }) {
         const CollateSummary = (data, statName) => {
             const summaryStat = {};
             data.forEach((site) => {
-                const thisStat = site.results?.[statName];
+                const thisStat = site?.results?.[statName];
                 if (!thisStat) {
                     return;
                 }
@@ -92,7 +92,7 @@ function SearchHandler({ setLoading }) {
                         patients_per_program: {}
                     };
                     data.forEach((site) => {
-                        discoveryCounts.patients_per_program[site.location.name] = site.results?.patients_per_program;
+                        discoveryCounts.patients_per_program[site.location.name] = site?.results?.patients_per_program;
                     });
 
                     writer((old) => ({ ...old, counts: discoveryCounts }));

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -155,8 +155,8 @@ function StyledCheckboxList(props) {
         }
 
         const cohortMap = {};
-        sites.forEach((site) => {
-            site.results.forEach((result) => {
+        sites?.forEach((site) => {
+            site?.results?.forEach((result) => {
                 if (!cohortMap[result.program_id]) {
                     cohortMap[result.program_id] = new Set();
                 }

--- a/src/views/completeness/fieldLevelCompletenessGraph.jsx
+++ b/src/views/completeness/fieldLevelCompletenessGraph.jsx
@@ -84,7 +84,7 @@ function FieldLevelCompletenessGraph(props) {
     const allPrograms = ['All programs'];
     if (data) {
         Object.values(data).forEach((site) => {
-            const programs = site.results?.programs;
+            const programs = site?.results?.programs;
             if (!programs) {
                 return;
             }


### PR DESCRIPTION
## Ticket(s)

- https://candig.atlassian.net/browse/DIG-2025

## Description

- Fixes all instances I could find of site.results

## Expected Behaviour

- No more red screen

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
