### PR TITLE
Fix the profile section being on a separate line in the DHDP version

### DIFF
--- a/src/layout/MainLayout/Header/index.js
+++ b/src/layout/MainLayout/Header/index.js
@@ -82,14 +82,14 @@ function Header({ handleLeftDrawerToggle }) {
                 <Box pl={2} sx={{ display: 'flex', flexDirection: 'row' }}>
                     <MenuList />
                 </Box>
+                <StyledGrow className={classes.grow} />
+                <ProfileSection />
             </StyledBox>
             {/* header search */}
             {/* <SearchSection theme="light" />  Currently not needed */}
-            <StyledGrow className={classes.grow} />
 
             {/* notification & profile */}
             {/* <NotificationSection /> */}
-            <ProfileSection />
         </>
     );
 }


### PR DESCRIPTION
## Ticket(s)

- https://tfri.atlassian.net/browse/DHDPS-451

## Description

- This moves the profile section button from being on a separate row, to being on the right side, as expected

## Screenshots (if appropriate)

### Before PR
<img width="2874" height="414" alt="image" src="https://github.com/user-attachments/assets/af53b86d-95a0-40d5-b253-749c253b7220" />


### After PR
<img width="1800" height="694" alt="image" src="https://github.com/user-attachments/assets/dfd11154-ebf4-4928-a797-49088662f87d" />

## To do/Tickets to be made before merging branch

-

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
