### PR TITLE
DHDPS-463: Explain to the user when there's no authorized data

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
             href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&family=Roboto:wght@400;500;700&display=swap&family=Catamaran:wght@400&display=swap"
             rel="stylesheet"
         />
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />
     </head>
 
     <body>

--- a/src/assets/scss/_themes-vars.module.scss
+++ b/src/assets/scss/_themes-vars.module.scss
@@ -2,10 +2,10 @@
 $paper: #ffffff;
 
 // primary
-$primaryLight: #D9E3E5;
+$primaryLight: #d9e3e5;
 $primary200: #90caf9;
-$primaryMain: #00434F;
-$primaryDark: #00434F;
+$primaryMain: #00434f;
+$primaryDark: #00434f;
 $primary800: #0a407d;
 
 // secondary

--- a/src/views/clinicalGenomic/widgets/clinicalData.js
+++ b/src/views/clinicalGenomic/widgets/clinicalData.js
@@ -18,8 +18,11 @@ function ClinicalView() {
     // Mobile
     const [desktopResolution, setdesktopResolution] = React.useState(window.innerWidth > 1200);
     const searchResults = useSearchResultsReaderContext().clinical;
+    const countsResults = useSearchResultsReaderContext().counts;
     const writerContext = useSearchQueryWriterContext();
     const queryReader = useSearchQueryReaderContext();
+
+    const hasResults = countsResults?.patients_per_program && Object.values(countsResults?.patients_per_program).some((val) => val > 0);
 
     // Function to add location to each patient
     function addLocationToPatients(searchResults) {
@@ -161,6 +164,13 @@ function ClinicalView() {
         pageSize: queryReader.query?.pageSize || 10
     };
 
+    // Were there any results at all?
+    const noRowsOverlay = () => (
+        <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            {hasResults ? 'You do not have authorization to view Donor-level clinical data results from your search.' : 'No results'}
+        </div>
+    );
+
     return (
         <Box mr={1} ml={1} p={1} sx={{ border: 1, borderRadius: 2, boxShadow: 2, borderColor: theme.palette.primary[200] + 75 }}>
             <Typography pb={1} sx={{ color: config.isDHDP ? theme.palette.primary.main : 'black' }} variant="h4">
@@ -176,6 +186,9 @@ function ClinicalView() {
                     paginationModel={paginationModel}
                     onPaginationModelChange={HandlePageChange}
                     paginationMode="server"
+                    slots={{
+                        noRowsOverlay
+                    }}
                     hideFooterSelectedRowCount
                 />
             </div>

--- a/src/views/clinicalGenomic/widgets/genomicData.js
+++ b/src/views/clinicalGenomic/widgets/genomicData.js
@@ -18,7 +18,10 @@ function GenomicData() {
     const [desktopResolution, setdesktopResolution] = React.useState(window.innerWidth > 1200);
 
     const searchResults = useSearchResultsReaderContext().genomic;
+    const countsResults = useSearchResultsReaderContext().counts;
     const query = useSearchQueryReaderContext().query;
+
+    const hasResults = countsResults?.patients_per_program && Object.values(countsResults?.patients_per_program).some((val) => val > 0);
 
     // Flatten the search results so that we are filling in the rows
     let rows = [];
@@ -65,13 +68,35 @@ function GenomicData() {
     const queryParams = query?.gene || query?.chrom;
     const hasValidQuery = (query?.assembly && query?.chrom) || query?.gene;
 
+    let message = '';
+    if (!hasValidQuery) {
+        message = 'Perform a gene or coordinate search to view genomic variant data.';
+    } else if (hasResults) {
+        message = 'You do not have authorization to view Donor-level genomic data results from your search.';
+    } else {
+        message = 'No results';
+    }
+    // Were there any results at all?
+    const noRowsOverlay = () => (
+        <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>{message}</div>
+    );
+
     return (
         <Box mr={1} ml={1} p={1} sx={{ border: 1, borderRadius: 2, boxShadow: 2, borderColor: theme.palette.primary[200] + 75 }}>
             <Typography pb={1} sx={{ color: config.isDHDP ? theme.palette.primary.main : 'black' }} variant="h4">
                 {hasValidQuery ? `Genomic Variants: ${queryParams}` : 'Genomic Variants: Please query from the sidebar to populate'}
             </Typography>
             <div style={{ height: 510, width: '100%' }}>
-                <DataGrid rows={rows} columns={columns} pageSize={10} rowsPerPageOptions={[10]} hideFooterSelectedRowCount />
+                <DataGrid
+                    rows={rows}
+                    columns={columns}
+                    pageSize={10}
+                    rowsPerPageOptions={[10]}
+                    hideFooterSelectedRowCount
+                    slots={{
+                        noRowsOverlay
+                    }}
+                />
             </div>
         </Box>
     );

--- a/src/views/completeness/fieldLevelCompletenessGraph.jsx
+++ b/src/views/completeness/fieldLevelCompletenessGraph.jsx
@@ -183,7 +183,9 @@ function FieldLevelCompletenessGraph(props) {
                     const identifier = this.value.toString().split('/');
                     const field = identifier.slice(1).join('/').replaceAll('_', ' ');
                     let title = identifier[0][0].toUpperCase() + identifier[0].slice(1).toLowerCase();
-                    return config.isDHDP ? `<span style="text-transform:capitalize">${title}: ${field}</span>` : `<b>${title}:</b> <span style="text-transform:uppercase">${field}</span>`;
+                    return config.isDHDP
+                        ? `<span style="text-transform:capitalize">${title}: ${field}</span>`
+                        : `<b>${title}:</b> <span style="text-transform:uppercase">${field}</span>`;
                 }
                 /* eslint-enable */
             },


### PR DESCRIPTION
## Ticket(s)

- https://tfri.atlassian.net/browse/DHDPS-463

## Description

- If a user performs a search query and no donor-level data is returned due to no authorization, this adjusts the error message displayed for both the clinical and genomic results.

## Screenshots (if appropriate)

### Before PR
<img width="1477" height="565" alt="image" src="https://github.com/user-attachments/assets/1ad8ec39-b99c-421d-b072-576b6f33f786" />


### After PR
<img width="1477" height="565" alt="image" src="https://github.com/user-attachments/assets/fa118ea8-7565-4008-9ea5-1296ce0e7f48" />


## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
