### PR TITLE
DIG-2096: Adding DAC authorizations to users that have never logged in

### DIFF
--- a/src/views/pages/authentication/AuthCheck.js
+++ b/src/views/pages/authentication/AuthCheck.js
@@ -31,7 +31,13 @@ function AuthCheck(props) {
         fetch(`${INGEST_URL}/user/me`)
             .then((request) => {
                 if (request.ok) {
-                    setAuthCheckValue('authorized', true);
+                    return request.json();
+                }
+                return undefined;
+            })
+            .then((response) => {
+                if (typeof response !== 'undefined') {
+                    setAuthCheckValue('authorized', response.userinfo.is_candig_authorized);
                     return undefined;
                 }
                 setAuthCheckValue('authorized', false);


### PR DESCRIPTION
## Ticket(s)

- DIG-2096: Adding DAC authorizations to users that have never logged in

## Description

- Update the check for candig-authorization: not only should the endpoint return 200, the value of "is_candig_authorized" should be true.

## Expected Behaviour

- User that has not been candig-authorized should get the request-access screen; users that are authzed should go straight to summary.

## Related Issues (if appropriate)

-

## Screenshots (if appropriate)

### Before PR

### After PR

## To do/Tickets to be made before merging branch

-

## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
