### PR TITLE
Hotfix/federated pagination

### DIFF
--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -134,7 +134,7 @@ function SearchHandler({ setLoading }) {
                             })
                         )
                         .flat(1);
-                    console.log('Genomic Data:', genomicData);
+                    // console.log('Genomic Data:', genomicData);
                     writer((old) => ({ ...old, clinical: clinicalData, genomic: genomicData, loading: false }));
                 })
                 .catch((error) => {

--- a/src/views/clinicalGenomic/widgets/matchingPatients.js
+++ b/src/views/clinicalGenomic/widgets/matchingPatients.js
@@ -206,13 +206,11 @@ function MatchingPatientsView() {
     // Pagination
     const HandlePageChange = (newModel) => {
         if (newModel.page !== query.page) {
-            writerContext((old) => {
-                console.log('Old state in writerContext:', old);
-                return {
+            writerContext((old) => ({
                 ...old,
                 query: { ...old.query, page: newModel.page, page_size: newModel.pageSize },
                 reqNum: old.reqNum + 1
-            }});
+            }));
         }
     };
 
@@ -240,8 +238,6 @@ function MatchingPatientsView() {
               .reduce((partial, a) => partial + a, 0)
         : 0;
 
-    console.log('searchResultsClinical', searchResultsClinical);
-    console.log('rows', rows);
     return (
         <Box
             mr={1}

--- a/src/views/clinicalGenomic/widgets/matchingPatients.js
+++ b/src/views/clinicalGenomic/widgets/matchingPatients.js
@@ -114,7 +114,16 @@ function MatchingPatientsView() {
 
     // Patient Info Page click handler
     const handleRowClick = (row) => {
-        const url = `/patientView?patientId=${row.submitter_donor_id}&programId=${row.program_id}&location=${row.location}&submitterSampleId=${row.submitter_sample_id}&tumourNormalDesignation=${row.tumour_normal_designation}&variantCount=${row.variant_count}`;
+        // Find all rows for the same donor
+        const donorSamples = rows
+            .filter((r) => r.submitter_donor_id === row.submitter_donor_id)
+            .map((r) => r.submitter_sample_id)
+            .filter(Boolean); // remove null/undefined
+
+        // Join sample IDs into a comma-separated
+        const allSamples = donorSamples.join('|');
+        const url = `/patientView?patientId=${row.submitter_donor_id}&programId=${row.program_id}&location=${row.location}&submitterSampleIds=${allSamples}`;
+        
         window.open(url, '_blank');
     };
 
@@ -231,6 +240,13 @@ function MatchingPatientsView() {
         headingTextResults = `Clinical and Genomic results`;
     }
 
+    const totalRows = searchResultsClinical
+        ? Object.values(searchResultsClinical)
+              ?.filter((location) => typeof location !== 'undefined')
+              ?.map((site) => site.count)
+              .reduce((partial, a) => partial + a, 0)
+        : 0;
+
     return (
         <Box
             mr={1}
@@ -252,6 +268,7 @@ function MatchingPatientsView() {
                     getRowId={(row) => row.submitter_donor_id + (row.submitter_sample_id || '')}
                     rows={rows}
                     columns={columns}
+                    rowCount={totalRows}
                     pageSizeOptions={[10]}
                     onRowClick={(rowData) => handleRowClick(rowData.row)}
                     paginationModel={paginationModel}

--- a/src/views/clinicalGenomic/widgets/matchingPatients.js
+++ b/src/views/clinicalGenomic/widgets/matchingPatients.js
@@ -206,11 +206,13 @@ function MatchingPatientsView() {
     // Pagination
     const HandlePageChange = (newModel) => {
         if (newModel.page !== query.page) {
-            writerContext((old) => ({
+            writerContext((old) => {
+                console.log('Old state in writerContext:', old);
+                return {
                 ...old,
                 query: { ...old.query, page: newModel.page, page_size: newModel.pageSize },
                 reqNum: old.reqNum + 1
-            }));
+            }});
         }
     };
 
@@ -238,6 +240,8 @@ function MatchingPatientsView() {
               .reduce((partial, a) => partial + a, 0)
         : 0;
 
+    console.log('searchResultsClinical', searchResultsClinical);
+    console.log('rows', rows);
     return (
         <Box
             mr={1}
@@ -264,7 +268,7 @@ function MatchingPatientsView() {
                     onRowClick={(rowData) => handleRowClick(rowData.row)}
                     paginationModel={paginationModel}
                     onPaginationModelChange={HandlePageChange}
-                    paginationMode="client"
+                    paginationMode="server"
                     hideFooterSelectedRowCount
                 />
             </div>

--- a/src/views/clinicalGenomic/widgets/matchingPatients.js
+++ b/src/views/clinicalGenomic/widgets/matchingPatients.js
@@ -114,6 +114,10 @@ function MatchingPatientsView() {
 
     // Patient Info Page click handler
     const handleRowClick = (row) => {
+        if (!row?.submitter_donor_id) {
+            console.warn('Row data not loaded yet:', row);
+            return;
+        }
         const url = `/patientView?patientId=${row.submitter_donor_id}&programId=${row.program_id}&location=${row.location}&submitterSampleId=${row.submitter_sample_id}&tumourNormalDesignation=${row.tumour_normal_designation}&variantCount=${row.variant_count}`;
         window.open(url, '_blank');
     };
@@ -256,7 +260,8 @@ function MatchingPatientsView() {
             </Box>
             <div style={{ height: 680, width: '100%' }}>
                 <DataGrid
-                    getRowId={(row) => row.submitter_donor_id + (row.submitter_sample_id || '')}
+                    getRowId={(row) => `${row.submitter_donor_id}_${row.submitter_sample_id || ''}`}
+                    key={rows.length}
                     rows={rows}
                     columns={columns}
                     rowCount={totalRows}

--- a/src/views/clinicalGenomic/widgets/matchingPatients.js
+++ b/src/views/clinicalGenomic/widgets/matchingPatients.js
@@ -114,16 +114,7 @@ function MatchingPatientsView() {
 
     // Patient Info Page click handler
     const handleRowClick = (row) => {
-        // Find all rows for the same donor
-        const donorSamples = rows
-            .filter((r) => r.submitter_donor_id === row.submitter_donor_id)
-            .map((r) => r.submitter_sample_id)
-            .filter(Boolean); // remove null/undefined
-
-        // Join sample IDs into a comma-separated
-        const allSamples = donorSamples.join('|');
-        const url = `/patientView?patientId=${row.submitter_donor_id}&programId=${row.program_id}&location=${row.location}&submitterSampleIds=${allSamples}`;
-        
+        const url = `/patientView?patientId=${row.submitter_donor_id}&programId=${row.program_id}&location=${row.location}&submitterSampleId=${row.submitter_sample_id}&tumourNormalDesignation=${row.tumour_normal_designation}&variantCount=${row.variant_count}`;
         window.open(url, '_blank');
     };
 

--- a/src/views/clinicalGenomic/widgets/matchingPatients.js
+++ b/src/views/clinicalGenomic/widgets/matchingPatients.js
@@ -252,12 +252,11 @@ function MatchingPatientsView() {
                     getRowId={(row) => row.submitter_donor_id + (row.submitter_sample_id || '')}
                     rows={rows}
                     columns={columns}
-                    rowCount={rows.length}
                     pageSizeOptions={[10]}
                     onRowClick={(rowData) => handleRowClick(rowData.row)}
                     paginationModel={paginationModel}
                     onPaginationModelChange={HandlePageChange}
-                    paginationMode="server"
+                    paginationMode="client"
                     hideFooterSelectedRowCount
                 />
             </div>

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -208,6 +208,8 @@ function StyledCheckboxList(props) {
                 } else if (ids.length > 0) {
                     retVal.query[groupName] = ids.join('|');
                 }
+                retVal.query.page = 0;
+                retVal.query.page_size = old.query?.page_size || 10;
                 return retVal;
             });
         } else {
@@ -591,6 +593,8 @@ function Sidebar() {
                 delete retVal.query.gene;
                 delete retVal.query.assembly;
                 delete retVal.query.genomic_data_types;
+                retVal.query.page = 0;
+                retVal.query.page_size = old.query?.page_size || 10;
                 return retVal;
             });
         } else if (readerContext.clear === 'treatment') {


### PR DESCRIPTION
## Description
Pagination hotfix: rows.length → totalRows was missed when merging clinical and genomic tables. Needs testing on federated dev servers.

Patient ID URL bug: Switching to server-side pagination introduced a race condition where row data may not be fully loaded. Added a key to force reload of row data when it changes and prevent opening a new tab if the row is blank.

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
