### PR TITLE
Bugfix/unauth lock sidebar dropdown

### DIFF
--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -277,7 +277,7 @@ function StyledCheckboxList(props) {
             options={options}
             disableCloseOnSelect
             renderOption={(props, option, { selected }) => (
-                <li {...props} key={option} >
+                <li {...props} key={option}>
                     <div
                         style={{
                             display: 'flex',
@@ -306,21 +306,19 @@ function StyledCheckboxList(props) {
                             }}
                         >
                             {option}
-                            {groupName === 'exclude_programs' &&
-                                authorizedPrograms &&
-                                !authorizedPrograms.includes(option) && (
-                                    <Tooltip title="Unauthorized Program" placement="right">
-                                        <LockOutlinedIcon
-                                            sx={{
-                                                color: 'primary.main',
-                                                fontSize: '1.1rem',
-                                                verticalAlign: 'text-bottom',
-                                                position: 'relative',
-                                                top: '3px'
-                                            }}
-                                        />
-                                    </Tooltip>
-                                )}
+                            {groupName === 'exclude_programs' && authorizedPrograms && !authorizedPrograms.includes(option) && (
+                                <Tooltip title="Unauthorized Program" placement="right">
+                                    <LockOutlinedIcon
+                                        sx={{
+                                            color: 'primary.main',
+                                            fontSize: '1.1rem',
+                                            verticalAlign: 'text-bottom',
+                                            position: 'relative',
+                                            top: '3px'
+                                        }}
+                                    />
+                                </Tooltip>
+                            )}
                         </span>
                     </div>
                 </li>
@@ -763,7 +761,7 @@ function Sidebar() {
                     authorizedPrograms={authorizedPrograms}
                     onWrite={writerContext}
                     groupName="exclude_programs"
-                    useAutoComplete={programs.length >= 2}
+                    useAutoComplete={programs.length >= 5}
                     isExclusion
                     checked={selectedPrograms}
                     setChecked={setSelectedPrograms}

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -76,7 +76,9 @@ const Root = styled('div')(({ theme }) => ({
     [`& .${classes.lockContainer}`]: {
         display: 'flex',
         alignItems: 'center',
-        justifyContent: 'center'
+        justifyContent: 'flex-start',
+        gap: '4px',
+        width: '100%'
     }
 }));
 
@@ -275,15 +277,52 @@ function StyledCheckboxList(props) {
             options={options}
             disableCloseOnSelect
             renderOption={(props, option, { selected }) => (
-                <li {...props} key={option}>
-                    <Checkbox
-                        icon={icon}
-                        checkedIcon={checkedIcon}
-                        style={{ marginRight: 8 }}
-                        checked={isExclusion ? !selected : selected}
-                        value={option}
-                    />
-                    {option}
+                <li {...props} key={option} >
+                    <div
+                        style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            width: '100%'
+                        }}
+                    >
+                        <Checkbox
+                            icon={icon}
+                            checkedIcon={checkedIcon}
+                            sx={{
+                                paddingTop: 0,
+                                paddingBottom: 0,
+                                marginRight: 1
+                            }}
+                            checked={isExclusion ? !selected : selected}
+                            value={option}
+                        />
+
+                        <span
+                            style={{
+                                display: 'inline-flex',
+                                alignItems: 'baseline',
+                                gap: '4px',
+                                lineHeight: 1.2
+                            }}
+                        >
+                            {option}
+                            {groupName === 'exclude_programs' &&
+                                authorizedPrograms &&
+                                !authorizedPrograms.includes(option) && (
+                                    <Tooltip title="Unauthorized Program" placement="right">
+                                        <LockOutlinedIcon
+                                            sx={{
+                                                color: 'primary.main',
+                                                fontSize: '1.1rem',
+                                                verticalAlign: 'text-bottom',
+                                                position: 'relative',
+                                                top: '3px'
+                                            }}
+                                        />
+                                    </Tooltip>
+                                )}
+                        </span>
+                    </div>
                 </li>
             )}
             renderInput={(params) => <TextField {...params} label={groupName === 'exclude_programs' ? 'Programs' : groupName} />}
@@ -724,7 +763,7 @@ function Sidebar() {
                     authorizedPrograms={authorizedPrograms}
                     onWrite={writerContext}
                     groupName="exclude_programs"
-                    useAutoComplete={programs.length >= 5}
+                    useAutoComplete={programs.length >= 2}
                     isExclusion
                     checked={selectedPrograms}
                     setChecked={setSelectedPrograms}

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -76,9 +76,7 @@ const Root = styled('div')(({ theme }) => ({
     [`& .${classes.lockContainer}`]: {
         display: 'flex',
         alignItems: 'center',
-        justifyContent: 'flex-start',
-        gap: '4px',
-        width: '100%'
+        justifyContent: 'center'
     }
 }));
 


### PR DESCRIPTION
## Ticket(s)
[Sidebar Dropdown Locks for Programs](https://candig.atlassian.net/browse/DIG-2107l)

## Description
Before adding autocomplete to all sidebar sections, locks indicating unauthorized cohorts were visible only outside the autocomplete. This PR adds the locks into the autocomplete dropdown. Some inline styling was necessary due to MUI’s style overrides on spans, divs, and other elements.

## Screenshots (if appropriate)

### Before AutoComplete was added
<img width="336" height="513" alt="image" src="https://github.com/user-attachments/assets/5df192e3-f5f1-49ac-8a31-6fbe18091d68" />

### Before PR
<img width="323" height="633" alt="image" src="https://github.com/user-attachments/assets/9ab70f2f-dd7f-43eb-a28a-d185f9c2d38c" />

### After PR
<img width="281" height="470" alt="image" src="https://github.com/user-attachments/assets/b4b04b2a-f99c-47ca-8012-8a6c3ab8c3b2" />

### How the styling effects other autocompletes
<img width="288" height="547" alt="image" src="https://github.com/user-attachments/assets/fa807937-10a5-4bcf-b5e5-e28a1a337eb5" />


## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
