### PR TITLE
Fix node counts

### DIFF
--- a/src/views/completeness/completeness.jsx
+++ b/src/views/completeness/completeness.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 
 // mui
-// import { useTheme, makeStyles } from '@mui/styles';
 import Grid from '@mui/material/Grid';
 import useTheme from '@mui/system/useTheme';
 import SmallCountCard from 'ui-component/cards/SmallCountCard';
@@ -13,7 +12,6 @@ import { fetchClinicalCompleteness, fetchGenomicCompleteness } from 'store/api';
 // assets
 import { CheckCircleOutline, WarningAmber, Person } from '@mui/icons-material';
 
-// Test data
 import { useSidebarWriterContext } from 'layout/MainLayout/Sidebar/SidebarContext';
 import FieldLevelCompletenessGraph from './fieldLevelCompletenessGraph';
 
@@ -55,6 +53,10 @@ function Completeness() {
         });
     }, []);
 
+    // Compute totals for display
+    const totalNodes = numNodes;
+    const activeNodes = numNodes - numErrorNodes;
+
     return (
         <Grid container spacing={1}>
             {numErrorNodes > 0 ? (
@@ -63,7 +65,7 @@ function Completeness() {
                         <Grid item xs={6} pr={1}>
                             <SmallCountCard
                                 title="Nodes"
-                                count={`${numNodes}/${numNodes + numErrorNodes}`}
+                                count={`${activeNodes}/${totalNodes}`}
                                 icon={<CheckCircleOutline fontSize="inherit" />}
                                 color={theme.palette.secondary.main}
                             />
@@ -71,7 +73,7 @@ function Completeness() {
                         <Grid item xs={6}>
                             <SmallCountCard
                                 title="Connection Error"
-                                count={`${numErrorNodes}/${numNodes + numErrorNodes}`}
+                                count={`${numErrorNodes}/${totalNodes}`}
                                 icon={<WarningAmber fontSize="inherit" />}
                                 color={theme.palette.error.main}
                             />
@@ -83,12 +85,13 @@ function Completeness() {
                     <SmallCountCard
                         isLoading={isLoading}
                         title="Nodes"
-                        count={numNodes}
+                        count={activeNodes}
                         icon={<CheckCircleOutline fontSize="inherit" />}
                         color={theme.palette.secondary.main}
                     />
                 </Grid>
             )}
+
             <Grid item xs={12} sm={12} md={6} lg={3}>
                 <SmallCountCard
                     isLoading={isLoading}
@@ -99,6 +102,7 @@ function Completeness() {
                     color={theme.palette.primary.main}
                 />
             </Grid>
+
             <Grid item xs={12} sm={12} md={6} lg={3}>
                 <SmallCountCard
                     isLoading={isLoading}
@@ -109,6 +113,7 @@ function Completeness() {
                     color={theme.palette.secondary.main}
                 />
             </Grid>
+
             <Grid item xs={12} sm={12} md={6} lg={3}>
                 <SmallCountCard
                     isLoading={isLoading}
@@ -119,6 +124,7 @@ function Completeness() {
                     color={theme.palette.tertiary.main}
                 />
             </Grid>
+
             <Grid item xs={12} sm={12} md={6} lg={3}>
                 <CustomOfflineChart
                     dataObject={numClinicalComplete || {}}
@@ -132,6 +138,7 @@ function Completeness() {
                     cutoff={10}
                 />
             </Grid>
+
             <Grid item xs={12} sm={12} md={6} lg={3}>
                 <CustomOfflineChart
                     dataObject={numGenomicComplete || {}}
@@ -145,9 +152,7 @@ function Completeness() {
                     cutoff={10}
                 />
             </Grid>
-            {/* <Grid item xs={12} sm={12} md={6} lg={6}>
-                <MainCard>(Percentage complete graph)</MainCard>
-            </Grid> */}
+
             <Grid item xs={12} sm={12} md={6} lg={6}>
                 <FieldLevelCompletenessGraph data={clinicalComplete} loading={clinicalComplete.length === 0} title="Field Level" />
             </Grid>


### PR DESCRIPTION
## Ticket(s)
[Down Nodes on Completeness Page Count](https://candig.atlassian.net/browse/DIG-2137)

## Description
When the data-portal has a down node the completeness page shows one extra node in the count compared to the summary page which shows the correct count. There are only 4 nodes present on production but because UCal is down its showing as 5 on the portal

## Expected Behaviour
Show the proper node counts

## Screenshots

### Before PR
<img width="478" height="201" alt="image" src="https://github.com/user-attachments/assets/ae412e0d-5f3c-4d5d-802c-b9c28c1d265e" />

The counts should match up to the actual number of nodes on CanDIG.

### To do:
This should be tested on develop to verify it works with multiple nodes.

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
