### PR TITLE
Email tooltip popup

### DIFF
--- a/src/layout/MainLayout/Footer/index.js
+++ b/src/layout/MainLayout/Footer/index.js
@@ -147,15 +147,18 @@ function Footer(props) {
 
     function copyEmail(email) {
         try {
-            if (navigator.clipboard) {
-                navigator.clipboard
-                    .writeText(email)
+            if (!navigator.clipboard) {
+                const copyFn = navigator.clipboard?.writeText
+                    ? () => navigator.clipboard.writeText(email)
+                    : () => fallbackCopyTextToClipboard(email);
+
+                copyFn()
                     .then(() => {
-                        handleTooltipOpen();
+                        setOpen(false);
+                        setTimeout(() => setOpen(true), 10);
+                        setTimeout(() => setOpen(false), 2000);
                     })
-                    .catch(() => {
-                        fallbackCopyTextToClipboard(email);
-                    });
+                    .catch(() => fallbackCopyTextToClipboard(email));
             } else {
                 fallbackCopyTextToClipboard(email);
             }
@@ -222,34 +225,30 @@ function Footer(props) {
                             onClick={() => copyEmail('info@distributedgenomics.ca')}
                             onMouseOver={() => {
                                 document.body.style.cursor = 'pointer';
-                                return null;
                             }}
                             onMouseOut={() => {
                                 document.body.style.cursor = 'default';
-                                return null;
                             }}
                         >
                             <Tooltip
                                 title="Email Copied!"
                                 placement="right"
                                 style={{ ...linkFrame, cursor: 'pointer' }}
-                                PopperProps={{
-                                    disablePortal: true
-                                }}
-                                onClose={handleTooltipClose}
+                                PopperProps={{ disablePortal: true }}
                                 open={open}
+                                onClose={handleTooltipClose}
                                 disableFocusListener
                                 disableHoverListener
                                 disableTouchListener
                             >
-                                <>
+                                <Box sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}>
                                     <IconMail
                                         stroke={1.5}
                                         size="1.3rem"
                                         style={{ color: theme.palette.primary.main, marginRight: '0.5em' }}
                                     />
                                     <span style={linkText}>info@distributedgenomics.ca</span>
-                                </>
+                                </Box>
                             </Tooltip>
                         </ButtonBase>
                     </HelpContainer>

--- a/src/layout/MainLayout/Footer/index.js
+++ b/src/layout/MainLayout/Footer/index.js
@@ -233,7 +233,6 @@ function Footer(props) {
                             <Tooltip
                                 title="Email Copied!"
                                 placement="right"
-                                style={{ ...linkFrame, cursor: 'pointer' }}
                                 PopperProps={{ disablePortal: true }}
                                 open={open}
                                 onClose={handleTooltipClose}

--- a/src/layout/MainLayout/Footer/index.js
+++ b/src/layout/MainLayout/Footer/index.js
@@ -158,9 +158,9 @@ function Footer(props) {
                         setTimeout(() => setOpen(true), 10);
                         setTimeout(() => setOpen(false), 2000);
                     })
-                    .catch(() => fallbackCopyTextToClipboard(email));
-            } else {
-                fallbackCopyTextToClipboard(email);
+                    .catch(() => {
+                        fallbackCopyTextToClipboard(email);
+                    });
             }
         } catch (err) {
             console.error('Error copying email:', err);


### PR DESCRIPTION
## Ticket(s)
[Email Tooltip Popup](https://candig.atlassian.net/browse/DIG-2127)

## Description
There used to be a small popup saying “Email Copied!” when you clicked on the email link at the footer, which is currently absent. This stopped working because of a changed in MUI v5 which doesn't automatically reopen if the open state is already set. These changes correct that works on Chrome and Firefox.  

## Expected Behaviour
Email Copied! tool tip shows when you click on the email.

## Screenshots
<img width="612" height="114" alt="image" src="https://github.com/user-attachments/assets/adeb12e2-39ec-408a-94c2-e7f32d838818" />


## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
