### PR TITLE
Add Beacon search to the v3 version of the frontend

### DIFF
--- a/src/MenuList/NavGroup/index.js
+++ b/src/MenuList/NavGroup/index.js
@@ -42,7 +42,7 @@ function NavGroup({ item }) {
     const dispatch = useDispatch();
     useEffect(() => {
         // Note that '/' is an alias of /summary
-        const id = window.location.pathname === '/' ? 'summary' : window.location.pathname.slice(1);
+        const id = window.location.pathname === '/' ? 'clinicalGenomicSearch' : window.location.pathname.slice(1);
         dispatch({ type: MENU_OPEN, id });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);

--- a/src/layout/MainLayout/Header/ProfileSection/index.js
+++ b/src/layout/MainLayout/Header/ProfileSection/index.js
@@ -196,7 +196,7 @@ function ProfileSection() {
 
     // Grab the user key for the logged in user
     useEffect(() => {
-        fetch(`/query/whoami`)
+        fetch(`/candig-api/v1/whoami`)
             .then((response) => {
                 if (response.ok) {
                     return response.json();

--- a/src/layout/MainLayout/LogoSection/index.js
+++ b/src/layout/MainLayout/LogoSection/index.js
@@ -15,7 +15,12 @@ function LogoSection() {
     const dispatch = useDispatch();
 
     return (
-        <ButtonBase disableRipple component={Link} to={config.defaultPath} onClick={() => dispatch({ type: MENU_OPEN, id: 'summary' })}>
+        <ButtonBase
+            disableRipple
+            component={Link}
+            to={config.defaultPath}
+            onClick={() => dispatch({ type: MENU_OPEN, id: 'clinicalGenomicSearch' })}
+        >
             <Logo />
         </ButtonBase>
     );

--- a/src/menu-items/index.js
+++ b/src/menu-items/index.js
@@ -1,5 +1,5 @@
 import clinicalGenomicSearch from './clinicalGenomicSearch';
-import summary from './summary';
+// import summary from './summary';
 import completenessStats from './completenessStats';
 // import ingest from './ingest';
 
@@ -10,7 +10,7 @@ import completenessStats from './completenessStats';
 // ===========================|| MENU ITEMS ||=========================== //
 
 const menuItems = {
-    items: [summary, clinicalGenomicSearch, completenessStats /* , ingest, pages, utilities, other */]
+    items: [clinicalGenomicSearch, completenessStats /* summary, ingest, pages, utilities, other */]
 };
 
 export default menuItems;

--- a/src/routes/MainRoutes.js
+++ b/src/routes/MainRoutes.js
@@ -37,11 +37,11 @@ const MainRoutes = {
     children: [
         {
             path: `/`,
-            element: <Summary />
+            element: <ClinicalGenomicSearch />
         },
         {
             path: `${basename}/`,
-            element: <Summary />
+            element: <ClinicalGenomicSearch />
         },
         {
             path: `${basename}/summary`,

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -38,16 +38,21 @@ export function fetchOrRelogin(...args) {
 /*
 Generic querying for federation
 */
-export function fetchFederation(path, service, payload = {}, fetchMethod = fetchOrRelogin) {
+export function fetchFederation(path, service, abort = null, payload = {}, fetchMethod = fetchOrRelogin, method = 'GET') {
+    const requestbody = {
+        method,
+        path,
+        payload: payload || {},
+        service
+    };
+    if (abort != null) {
+        requestbody.signal = abort;
+    }
+
     return fetchMethod(`${federation}/fanout`, {
         method: 'post',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            method: 'GET',
-            path,
-            payload: payload || {},
-            service
-        })
+        body: JSON.stringify(requestbody)
     })
         .then((response) => {
             if (response.ok) {
@@ -227,4 +232,64 @@ export function fetchRefreshToken() {
             console.log('Error:', error);
             return error;
         });
+}
+
+/*
+ * CanDIG-API filtering_terms:
+ */
+export function fetchBeaconFilteringTerms() {
+    return fetchFederation('v1/beacon/datasets/filtering_terms', 'candig-api').then((data) => {
+        // We need to merge the results from each response
+        const allTerms = new Set();
+        data.forEach((site) => {
+            site?.results?.response?.filteringTerms?.forEach((item) => allTerms.add(item.id));
+        });
+        return allTerms;
+    });
+}
+
+// params.filters should be a list of objects
+// e.g. [{ "id": "SNOMED:33821000087103" }]
+export function queryBeacon(params, abort) {
+    // Transform the parameters into something that it'll understand
+    const params_filters = [];
+    // Grab out the page and page number
+    const page = params?.page;
+    const page_size = params?.page_size;
+
+    const NON_FILTER_PARAMS = ['page', 'page_size'];
+    const NON_ID_FILTERS = [];
+
+    if (typeof params !== 'undefined' && params !== null) {
+        Object.keys(params).forEach((param) => {
+            if (NON_FILTER_PARAMS.includes(param)) {
+                return;
+            }
+
+            const new_param = {};
+
+            if (!NON_ID_FILTERS.includes(param)) {
+                new_param.id = params[param];
+                // } else {
+                // Non-ID filters need to be applied as well -- how should I approach this?
+            }
+            params_filters.push(new_param);
+        });
+    }
+
+    // Construct the payload
+    const payload = {
+        meta: { apiVersion: 'v2.0.0' },
+        query: {
+            requestedGranularity: 'record',
+            filters: params_filters, // [{ "id": "SNOMED:33821000087103" }]
+            pagination: {
+                page,
+                pageSize: page_size
+                // "skip": ?
+            }
+        }
+    };
+
+    return fetchFederation('v1/beacon/persons', 'candig-api', abort, payload, fetchOrRelogin, 'POST');
 }

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -3,6 +3,7 @@
 export const federation = `${process.env.REACT_APP_FEDERATION_API_SERVER}/v1`;
 export const htsget = process.env.REACT_APP_HTSGET_SERVER;
 export const INGEST_URL = process.env.REACT_APP_INGEST_SERVER;
+export const API_URL = process.env.REACT_APP_API_SERVER;
 
 export function reloginCheck() {
     return fetch('/portal/favicon.ico')
@@ -250,7 +251,7 @@ export function fetchBeaconFilteringTerms() {
 
 // params.filters should be a list of objects
 // e.g. [{ "id": "SNOMED:33821000087103" }]
-export function queryBeacon(params, abort) {
+export function queryBeacon(params, abort = null) {
     // Transform the parameters into something that it'll understand
     const params_filters = [];
     // Grab out the page and page number

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -239,24 +239,17 @@ export function fetchRefreshToken() {
  * CanDIG-API filtering_terms:
  */
 export function fetchBeaconFilteringTerms() {
-    return fetchFederation('v1/beacon/datasets/filtering_terms', 'candig-api').then((data) => {
-        // We need to merge the results from each response
-        const allTerms = new Set();
-        data.forEach((site) => {
-            site?.results?.response?.filteringTerms?.forEach((item) => allTerms.add(item.id));
-        });
-        return allTerms;
-    });
+    return fetchFederation('v1/beacon/datasets/filtering_terms', 'candig-api');
 }
 
 // params.filters should be a list of objects
 // e.g. [{ "id": "SNOMED:33821000087103" }]
-export function queryBeacon(params, abort = null) {
+export function queryBeacon(params, filter_mapping, abort = null) {
     // Transform the parameters into something that it'll understand
     const params_filters = [];
     // Grab out the page and page number
-    const page = params?.page;
-    const page_size = params?.page_size;
+    const page = undefined; // params?.page;
+    const page_size = undefined; // params?.page_size;
 
     const NON_FILTER_PARAMS = ['page', 'page_size'];
     const NON_ID_FILTERS = [];
@@ -270,7 +263,7 @@ export function queryBeacon(params, abort = null) {
             const new_param = {};
 
             if (!NON_ID_FILTERS.includes(param)) {
-                new_param.id = params[param];
+                new_param.id = filter_mapping[params[param]];
                 // } else {
                 // Non-ID filters need to be applied as well -- how should I approach this?
             }

--- a/src/store/constant.js
+++ b/src/store/constant.js
@@ -125,6 +125,11 @@ export const DataVisualizationChartInfo = {
         xAxis: 'Age Range',
         yAxis: 'Number of Patients'
     },
+    drug_type_count: {
+        title: 'Drug Exposure Distribution',
+        xAxis: 'Drug Type',
+        yAxis: 'Number of Exposures With Drug'
+    },
     treatment_type_count: {
         title: 'Treatment Type Distribution',
         xAxis: 'Treatment Type',

--- a/src/views/clinicalGenomic/clinicalPatientView.js
+++ b/src/views/clinicalGenomic/clinicalPatientView.js
@@ -43,7 +43,6 @@ function ClinicalPatientView() {
         location,
         forceSelection
     );
-    console.log(topLevel);
     const ageAtFirstDiagnosis = topLevel.age_at_diagnosis;
     const dateOfBirth = data?.date_of_birth;
 

--- a/src/views/clinicalGenomic/clinicalPatientView.js
+++ b/src/views/clinicalGenomic/clinicalPatientView.js
@@ -43,7 +43,8 @@ function ClinicalPatientView() {
         location,
         forceSelection
     );
-    const ageAtFirstDiagnosis = topLevel.age_at_first_diagnosis;
+    console.log(topLevel);
+    const ageAtFirstDiagnosis = topLevel.age_at_diagnosis;
     const dateOfBirth = data?.date_of_birth;
 
     const handleEventClick = (category, array) => {

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -65,15 +65,12 @@ function FormatClinicalData(data) {
     return retVal;
 }
 
-// TODO: Currently I've gotten the patients counts working by editing patientCounts
-// I should instead use the below function to massage incoming data from the Beacon search
-// into a format that the frontend understands
 function FormatFederationData(data) {
     return data.map((site) => {
         const newResults = Object.keys(site?.results?.info?.patients_per_program).map((program) => ({
             patients_count: site?.results?.info?.patients_per_program[program],
             program_id: program
-        }))
+        }));
 
         return { ...site, results: newResults };
     });

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -4,14 +4,34 @@ import PropTypes from 'prop-types';
 import { trackPromise } from 'react-promise-tracker';
 
 import { useSearchResultsWriterContext, useSearchQueryReaderContext } from '../SearchResultsContext';
-import { fetchFederation, query, fetchFederatedSubServices } from 'store/api';
+import { fetchFederation, queryBeacon, fetchBeaconFilteringTerms } from 'store/api';
 import { isCensored } from 'utils/utils';
 
+// The old function to collate summary statistics from multiple sites together
+// Needs to be reworked to the new beacon format
+const CollateSummary = (data, statName) => {
+    const summaryStat = {};
+    data.forEach((site) => {
+        const thisStat = site?.results?.[statName];
+        if (!thisStat) return;
+
+        Object.keys(thisStat).forEach((key) => {
+            if (key in summaryStat && !isCensored(summaryStat[key])) {
+                if (!isCensored(thisStat[key])) {
+                    summaryStat[key] += thisStat[key];
+                }
+            } else {
+                summaryStat[key] = thisStat[key];
+            }
+        });
+    });
+    return summaryStat;
+};
+
+// This handles transforming queries in the SearchResultsContext to actual search queries
 // NB: I assign to lastPromise a bunch to keep track of whether or not we need to chain promises together
 // However, the linter really dislikes this, and assumes I want to put everything inside one useEffect?
 /* eslint-disable react-hooks/exhaustive-deps */
-
-// This handles transforming queries in the SearchResultsContext to actual search queries
 function SearchHandler({ setLoading }) {
     const reader = useSearchQueryReaderContext();
     const writer = useSearchResultsWriterContext();
@@ -23,7 +43,9 @@ function SearchHandler({ setLoading }) {
     useEffect(() => {
         setLoading(true);
         lastPromise = trackPromise(
-            fetchFederatedSubServices(`v3/discovery/sidebar_list`)
+            fetchBeaconFilteringTerms().then((data) => writer((old) => ({ ...old, filters: data }))),
+            'federation'
+            /* fetchFederatedSubServices(`v3/discovery/sidebar_list`)
                 .then((data) => writer((old) => ({ ...old, sidebar: data })))
                 .then(() => fetchFederatedSubServices('v3/discovery/overview/patients_per_program'))
                 .then((data) => writer((old) => ({ ...old, federation: data })))
@@ -33,40 +55,15 @@ function SearchHandler({ setLoading }) {
                 .then(() => fetch('/genomics/htsget/v1/genes'))
                 .then((response) => (response.ok ? response.json() : console.log(response)))
                 .then((data) => writer((old) => ({ ...old, genes: data?.results })))
-                .finally(() => setLoading(false)),
-            'federation'
+                .finally(() => setLoading(false)), */
         );
     }, []);
 
-    // Query 2: when the search query changes (but not the page number), re-query the discovery stats
+    /* // Query 2: when the search query changes including just the page number, re-query
     useEffect(() => {
         // First, abort any currently-running search promises
         summaryFetchAbort.current.abort('New request started');
         const newAbort = new AbortController();
-
-        const CollateSummary = (data, statName) => {
-            const summaryStat = {};
-            data.forEach((site) => {
-                const thisStat = site?.results?.[statName];
-                if (!thisStat) return;
-
-                Object.keys(thisStat).forEach((key) => {
-                    if (key in summaryStat && !isCensored(summaryStat[key])) {
-                        if (!isCensored(thisStat[key])) {
-                            summaryStat[key] += thisStat[key];
-                        }
-                    } else {
-                        summaryStat[key] = thisStat[key];
-                    }
-                });
-            });
-            return summaryStat;
-        };
-
-        // Prepare query excluding pagination
-        const { ...queryNoPageSize } = reader.query || {};
-        if ('page' in queryNoPageSize) delete queryNoPageSize.page;
-        if ('page_size' in queryNoPageSize) delete queryNoPageSize.page_size;
 
         // **Add genomic_data_types if it exists**
         if (reader.query?.genomic_data_types) {
@@ -74,8 +71,8 @@ function SearchHandler({ setLoading }) {
         }
 
         setLoading(true);
-        const discoveryPromise = () =>
-            query(queryNoPageSize, newAbort.signal, 'discovery/query')
+        const discoveryPromise = () => new Promise(() => {});
+        query(queryNoPageSize, newAbort.signal, 'discovery/query')
                 .then((data) => {
                     if (reader.filter?.node) {
                         data = data.filter((site) => !reader.filter.node.includes(site.location.name));
@@ -107,7 +104,7 @@ function SearchHandler({ setLoading }) {
         }
 
         summaryFetchAbort.current = newAbort;
-    }, [reader.reqNum]);
+    }, [reader.reqNum]); */
 
     // Query 3: when the search query changes, re-query the server
     useEffect(() => {
@@ -116,26 +113,9 @@ function SearchHandler({ setLoading }) {
         const newAbort = new AbortController();
 
         const donorQueryPromise = () =>
-            query(reader.query, newAbort.signal)
+            queryBeacon(reader.query, newAbort.signal)
                 .then((data) => {
-                    if (reader.filter?.node) {
-                        data = data.filter((site) => !reader.filter.node.includes(site.location.name));
-                    }
-                    // Reorder the data, and fill out the patients per program
-                    const clinicalData = {};
-                    data.forEach((site) => {
-                        if ('results' in site) clinicalData[site.location.name] = site?.results;
-                    });
-                    const genomicData = data
-                        .map((site) =>
-                            site?.results?.genomic?.map((caseData) => {
-                                caseData.location = site.location;
-                                return caseData;
-                            })
-                        )
-                        .flat(1);
-                    // console.log('Genomic Data:', genomicData);
-                    writer((old) => ({ ...old, clinical: clinicalData, genomic: genomicData, loading: false }));
+                    console.log(data);
                 })
                 .catch((error) => {
                     // Ignore abort errors
@@ -143,6 +123,28 @@ function SearchHandler({ setLoading }) {
                 })
                 .finally(() => setLoading(false));
 
+        /* Old code:
+            query(reader.query, newAbort.signal)
+            .then((data) => {
+                if (reader.filter?.node) {
+                    data = data.filter((site) => !reader.filter.node.includes(site.location.name));
+                }
+                // Reorder the data, and fill out the patients per program
+                const clinicalData = {};
+                data.forEach((site) => {
+                    if ('results' in site) clinicalData[site.location.name] = site?.results;
+                });
+                const genomicData = data
+                    .map((site) =>
+                        site?.results?.genomic?.map((caseData) => {
+                            caseData.location = site.location;
+                            return caseData;
+                        })
+                    )
+                    .flat(1);
+                // console.log('Genomic Data:', genomicData);
+                writer((old) => ({ ...old, clinical: clinicalData, genomic: genomicData, loading: false }));
+            }) */
         if (lastPromise === null) {
             lastPromise = donorQueryPromise();
         } else {
@@ -157,7 +159,7 @@ function SearchHandler({ setLoading }) {
         if (!reader.donorID || !reader.program) return;
         setLoading(true);
 
-        const url = `v3/authorized/donor_with_clinical_data/program/${reader.program}/donor/${reader.donorID}`;
+        /* const url = `v3/authorized/donor_with_clinical_data/program/${reader.program}/donor/${reader.donorID}`;
         trackPromise(
             fetchFederation(url, 'katsu')
                 .then((data) => {
@@ -165,7 +167,7 @@ function SearchHandler({ setLoading }) {
                 })
                 .finally(() => setLoading(false)),
             'donor'
-        );
+        ); */
     }, [JSON.stringify(reader.donorID)]);
     // We don't really implement a graphical component
     // NB: This might be a good reason to have this be a function call instead of what it currently is.

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { trackPromise } from 'react-promise-tracker';
@@ -77,15 +77,38 @@ function FormatFederationData(data) {
 }
 
 function FormatSidebarData(data) {
+    const RemoveNulls = (items) => items.filter((term) => term !== 'No value' && term !== 'No matching concept');
+
     return data.map((site) => {
         const newResults = {
-            treatment_types: Object.keys(site?.results?.info?.treatment_type_count || {}),
-            tumour_primary_sites: Object.keys(site?.results?.info?.primary_site_count || {}),
-            drug_names: Object.keys(site?.results?.info?.drug_type_count || {})
+            treatment_types: RemoveNulls(Object.keys(site?.results?.info?.treatment_type_count || {})),
+            tumour_primary_sites: RemoveNulls(Object.keys(site?.results?.info?.primary_site_count || {})),
+            drug_names: RemoveNulls(Object.keys(site?.results?.info?.drug_type_count || {}))
         };
 
         return { ...site, results: newResults };
     });
+}
+
+function FormatFilteringTerms(data) {
+    // We need to merge the results from each response
+    const allTerms = new Set();
+    data.forEach((site) => {
+        site?.results?.response?.filteringTerms?.forEach((item) => allTerms.add(item.id));
+    });
+    return allTerms;
+}
+
+function FormatFilters(data) {
+    const retVal = {};
+    data.forEach((site) => {
+        if (typeof site?.results?.response?.filteringTerms !== 'undefined') {
+            site.results.response.filteringTerms.forEach((term) => {
+                retVal[term.label] = term.id;
+            });
+        }
+    });
+    return retVal;
 }
 
 // This handles transforming queries in the SearchResultsContext to actual search queries
@@ -97,6 +120,7 @@ function SearchHandler({ setLoading }) {
     const writer = useSearchResultsWriterContext();
     const summaryFetchAbort = useRef(new AbortController());
     const clinicalFetchAbort = useRef(new AbortController());
+    const [filters, setFilters] = useState({});
 
     // Query 1: always have the federation sites and authorized programs query results available
     let lastPromise = null;
@@ -104,7 +128,10 @@ function SearchHandler({ setLoading }) {
         setLoading(true);
         lastPromise = trackPromise(
             fetchBeaconFilteringTerms()
-                .then((data) => writer((old) => ({ ...old, filters: data })))
+                .then((data) => {
+                    writer((old) => ({ ...old, filters: FormatFilteringTerms(data) }));
+                    setFilters((_) => FormatFilters(data));
+                })
                 .then(() => queryBeacon({ page_size: 1 }))
                 .then((data) =>
                     writer((old) => ({
@@ -182,8 +209,9 @@ function SearchHandler({ setLoading }) {
         clinicalFetchAbort.current.abort('New request started');
         const newAbort = new AbortController();
 
+        // TODO: incoming filters need to be converted to their internal IDs (which we have from the filtering_terms call earlier)
         const donorQueryPromise = () =>
-            queryBeacon(reader.query, newAbort.signal)
+            queryBeacon(reader.query, filters, newAbort.signal)
                 .then((data) => {
                     if (reader.filter?.node) {
                         data = data.filter((site) => !reader.filter.node.includes(site.location.name));
@@ -224,6 +252,7 @@ function SearchHandler({ setLoading }) {
                             });
 
                             // patients_per_program is added verbatim, instead of being collated together
+                            // TODO: The results need to be reformatted to the old style (see FormatFederationData)
                             if (typeof site?.results?.info?.patients_per_program !== 'undefined') {
                                 discoveryCounts.patients_per_program[site.location.name] = site.results.info.patients_per_program;
                             }

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -69,7 +69,14 @@ function FormatClinicalData(data) {
 // I should instead use the below function to massage incoming data from the Beacon search
 // into a format that the frontend understands
 function FormatFederationData(data) {
-    return data;
+    return data.map((site) => {
+        const newResults = Object.keys(site?.results?.info?.patients_per_program).map((program) => ({
+            patients_count: site?.results?.info?.patients_per_program[program],
+            program_id: program
+        }))
+
+        return { ...site, results: newResults };
+    });
 }
 
 function FormatSidebarData(data) {
@@ -78,7 +85,7 @@ function FormatSidebarData(data) {
             treatment_types: Object.keys(site?.results?.info?.treatment_type_count || {}),
             tumour_primary_sites: Object.keys(site?.results?.info?.primary_site_count || {}),
             drug_names: Object.keys(site?.results?.info?.drug_type_count || {})
-        }
+        };
 
         return { ...site, results: newResults };
     });
@@ -102,11 +109,13 @@ function SearchHandler({ setLoading }) {
             fetchBeaconFilteringTerms()
                 .then((data) => writer((old) => ({ ...old, filters: data })))
                 .then(() => queryBeacon({ page_size: 1 }))
-                .then((data) => writer((old) => ({
-                    ...old,
-                    federation: FormatFederationData(data),
-                    sidebar: FormatSidebarData(data)
-                })))
+                .then((data) =>
+                    writer((old) => ({
+                        ...old,
+                        federation: FormatFederationData(data),
+                        sidebar: FormatSidebarData(data)
+                    }))
+                )
                 .finally(() => setLoading(false)),
             'federation'
             /* fetchFederatedSubServices(`v3/discovery/sidebar_list`)

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -28,6 +28,13 @@ const CollateSummary = (data, statName) => {
     return summaryStat;
 };
 
+function ParseISO8601Year(text) {
+    if (typeof text !== 'string') return undefined;
+    const regex = /(\d+)Y/.exec(text);
+    if (!regex) return undefined;
+    return regex[1];
+}
+
 // Format incoming clinical data from Beacon into a form that the frontend expects
 // Is this actually the best way to go forwards? Or should I just be rewriting the frontend components
 function FormatClinicalData(data) {
@@ -39,6 +46,7 @@ function FormatClinicalData(data) {
     // _       deceased, gender, is_deceased, location, lost_to_followup_after_clinical_event_identifier,
     // _       lost_to_followup_reason, program_id, sex_at_birth, submitter_donor_id}]
     // }
+
     const retVal = {
         count: data.resultsCount,
         results: data.results.map((donor) => ({
@@ -48,11 +56,32 @@ function FormatClinicalData(data) {
             num_exposures: donor.exposures?.length || 0,
             num_interventions: donor.interventionsOrProcedures?.length || 0,
             num_measures: donor.measures?.length || 0,
+            // Need to figure out how to get the _first_ age of onset
+            age_at_diagnosis: ParseISO8601Year(donor.diseases?.[0]?.ageOfOnset?.iso8601duration) || undefined,
             num_treatments: donor.treatments?.length || 0
         }))
     };
 
     return retVal;
+}
+
+// TODO: Currently I've gotten the patients counts working by editing patientCounts
+// I should instead use the below function to massage incoming data from the Beacon search
+// into a format that the frontend understands
+function FormatFederationData(data) {
+    return data;
+}
+
+function FormatSidebarData(data) {
+    return data.map((site) => {
+        const newResults = {
+            treatment_types: Object.keys(site?.results?.info?.treatment_type_count || {}),
+            tumour_primary_sites: Object.keys(site?.results?.info?.primary_site_count || {}),
+            drug_names: Object.keys(site?.results?.info?.drug_type_count || {})
+        }
+
+        return { ...site, results: newResults };
+    });
 }
 
 // This handles transforming queries in the SearchResultsContext to actual search queries
@@ -70,7 +99,15 @@ function SearchHandler({ setLoading }) {
     useEffect(() => {
         setLoading(true);
         lastPromise = trackPromise(
-            fetchBeaconFilteringTerms().then((data) => writer((old) => ({ ...old, filters: data }))),
+            fetchBeaconFilteringTerms()
+                .then((data) => writer((old) => ({ ...old, filters: data })))
+                .then(() => queryBeacon({ page_size: 1 }))
+                .then((data) => writer((old) => ({
+                    ...old,
+                    federation: FormatFederationData(data),
+                    sidebar: FormatSidebarData(data)
+                })))
+                .finally(() => setLoading(false)),
             'federation'
             /* fetchFederatedSubServices(`v3/discovery/sidebar_list`)
                 .then((data) => writer((old) => ({ ...old, sidebar: data })))
@@ -180,7 +217,6 @@ function SearchHandler({ setLoading }) {
                                 });
                             });
 
-                            console.log(clinicalData);
                             // patients_per_program is added verbatim, instead of being collated together
                             if (typeof site?.results?.info?.patients_per_program !== 'undefined') {
                                 discoveryCounts.patients_per_program[site.location.name] = site.results.info.patients_per_program;

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -28,6 +28,33 @@ const CollateSummary = (data, statName) => {
     return summaryStat;
 };
 
+// Format incoming clinical data from Beacon into a form that the frontend expects
+// Is this actually the best way to go forwards? Or should I just be rewriting the frontend components
+function FormatClinicalData(data) {
+    // data: Object (site) => { exists, resultsCount, resultsHandover, setType, results:
+    // _     [{dataset_id, diseases, ethnicity, id, interventionsOrProcedures, location, measures, sex, treatments}]
+    // }
+    // return format: Object (site) => { count, genomic: [], results:
+    // _     [{cause_of_death, date_alive_after_lost_to_followup, date_of_birth, date_of_death, date_resolution,
+    // _       deceased, gender, is_deceased, location, lost_to_followup_after_clinical_event_identifier,
+    // _       lost_to_followup_reason, program_id, sex_at_birth, submitter_donor_id}]
+    // }
+    const retVal = {
+        count: data.resultsCount,
+        results: data.results.map((donor) => ({
+            program_id: donor.dataset_id,
+            submitter_donor_id: donor.id,
+            sex_at_birth: donor.sex?.label,
+            num_exposures: donor.exposures?.length || 0,
+            num_interventions: donor.interventionsOrProcedures?.length || 0,
+            num_measures: donor.measures?.length || 0,
+            num_treatments: donor.treatments?.length || 0
+        }))
+    };
+
+    return retVal;
+}
+
 // This handles transforming queries in the SearchResultsContext to actual search queries
 // NB: I assign to lastPromise a bunch to keep track of whether or not we need to chain promises together
 // However, the linter really dislikes this, and assumes I want to put everything inside one useEffect?
@@ -115,7 +142,69 @@ function SearchHandler({ setLoading }) {
         const donorQueryPromise = () =>
             queryBeacon(reader.query, newAbort.signal)
                 .then((data) => {
-                    console.log(data);
+                    if (reader.filter?.node) {
+                        data = data.filter((site) => !reader.filter.node.includes(site.location.name));
+                    }
+
+                    // Reorder the data, and fill out the patients per program
+                    const clinicalData = {};
+                    const DISCOVERY_FIELDS = ['primary_site_count', 'treatment_type_count', 'age_at_diagnosis', 'drug_type_count'];
+                    const discoveryCounts = { patients_per_program: {} }; // Note: patients_per_program handled differently
+                    DISCOVERY_FIELDS.forEach((field) => {
+                        discoveryCounts[field] = {};
+                    });
+
+                    data.forEach((site) => {
+                        if ('results' in site) {
+                            // Grab the clinical data
+                            const resultSets = site?.results?.response?.resultSets;
+                            if (resultSets.length > 1) {
+                                console.warn("More than one result set found, need to figure out what's going on");
+                                clinicalData[site.location.name] = FormatClinicalData(resultSets[0]);
+                            } else if (resultSets.length > 0) {
+                                clinicalData[site.location.name] = FormatClinicalData(resultSets[0]);
+                            }
+
+                            // Grab the discovery data as well
+                            DISCOVERY_FIELDS.forEach((field) => {
+                                if (typeof site?.results?.info?.[field] === 'undefined') {
+                                    return;
+                                }
+
+                                Object.keys(site.results?.info?.[field]).forEach((datum) => {
+                                    if (datum in discoveryCounts[field]) {
+                                        discoveryCounts[field][datum] += site.results.info[field][datum];
+                                    } else {
+                                        discoveryCounts[field][datum] = site.results.info[field][datum];
+                                    }
+                                });
+                            });
+
+                            console.log(clinicalData);
+                            // patients_per_program is added verbatim, instead of being collated together
+                            if (typeof site?.results?.info?.patients_per_program !== 'undefined') {
+                                discoveryCounts.patients_per_program[site.location.name] = site.results.info.patients_per_program;
+                            }
+                        }
+                    });
+                    const genomicData = data
+                        .map((site) =>
+                            site?.results?.genomic?.map((caseData) => {
+                                caseData.location = site.location;
+                                return caseData;
+                            })
+                        )
+                        .flat(1);
+
+                    writer((old) => ({
+                        ...old,
+                        clinical: clinicalData,
+                        genomic: genomicData,
+                        counts: discoveryCounts,
+                        // federation: discoveryCounts.patients_per_program,
+                        loading: false
+                    }));
+                    // console.log(data);
                 })
                 .catch((error) => {
                     // Ignore abort errors

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -64,7 +64,7 @@ function useClinicalPatientData(patientId, programId, location, forceSelection) 
                     // Filter patientData to create topLevel data excluding arrays, objects, and empty values
                     const filteredData = filterNestedObject(patientData);
 
-                    if (filteredData?.date_of_birth) {
+                    /* if (filteredData?.date_of_birth) {
                         if (filteredData.date_of_birth.day_interval) {
                             // Logic for 'day' resolution
                             if (filteredData?.date_of_death?.day_interval && filteredData?.date_of_birth?.day_interval) {
@@ -111,7 +111,8 @@ function useClinicalPatientData(patientId, programId, location, forceSelection) 
                         const remainingMonths = ageInMonths % 12;
                         filteredData.time_from_diagnosis_to_last_followup = `${years}y ${remainingMonths}m`;
                         delete filteredData.date_alive_after_lost_to_followup;
-                    }
+                    } */
+                    console.log(filteredData);
 
                     setTopLevel(filteredData);
                     setData(patientData);
@@ -123,7 +124,7 @@ function useClinicalPatientData(patientId, programId, location, forceSelection) 
                             setColumns={setColumns}
                             setTitle={setTitle}
                             forceSelection={forceSelection}
-                            ageAtFirstDiagnosis={filteredData.age_at_first_diagnosis}
+                            ageAtFirstDiagnosis={filteredData.age_at_diagnosis}
                         />
                     );
                 }

--- a/src/views/clinicalGenomic/useClinicalPatientData.js
+++ b/src/views/clinicalGenomic/useClinicalPatientData.js
@@ -112,7 +112,6 @@ function useClinicalPatientData(patientId, programId, location, forceSelection) 
                         filteredData.time_from_diagnosis_to_last_followup = `${years}y ${remainingMonths}m`;
                         delete filteredData.date_alive_after_lost_to_followup;
                     } */
-                    console.log(filteredData);
 
                     setTopLevel(filteredData);
                     setData(patientData);

--- a/src/views/clinicalGenomic/widgets/dataVisualization.js
+++ b/src/views/clinicalGenomic/widgets/dataVisualization.js
@@ -109,7 +109,7 @@ function DataVisualization() {
 
     const dataVis = {
         patients_per_program: handleCensoring('patients_per_program', (site, _) => site, true) || {},
-        // diagnosis_age_count: handleCensoring('age_at_diagnosis', (_, age) => age.replace(/ Years$/, '')) || {},
+        diagnosis_age_count: handleCensoring('age_at_diagnosis', (_, age) => age.replace(/ Years$/, '')) || {},
         drug_type_count: handleCensoring('drug_type_count') || {},
         treatment_type_count: handleCensoring('treatment_type_count') || {},
         primary_site_count: handleCensoring('primary_site_count') || {}

--- a/src/views/clinicalGenomic/widgets/dataVisualization.js
+++ b/src/views/clinicalGenomic/widgets/dataVisualization.js
@@ -28,7 +28,7 @@ const DEFAULT_CHART_DEFINITIONS = [
         trim: false
     },
     {
-        data: 'diagnosis_age_count',
+        data: 'drug_type_count',
         chartType: 'bar',
         trim: false
     },
@@ -75,7 +75,7 @@ function DataVisualization() {
             return newDataObj;
         }
 
-        // Check the clinical results to see if we can fill in any censored data with real ones
+        /* // Check the clinical results to see if we can fill in any censored data with real ones
         Object.entries(clinical).forEach(([siteName, site]) => {
             Object.keys(site.summary?.[dataKey]).forEach((key) => {
                 if (isObject) {
@@ -92,7 +92,7 @@ function DataVisualization() {
 
         if (hasCensoredData) {
             newDataObj[HAS_CENSORED_DATA_MARKER] = true;
-        }
+        } */
         return newDataObj;
     };
 
@@ -109,7 +109,8 @@ function DataVisualization() {
 
     const dataVis = {
         patients_per_program: handleCensoring('patients_per_program', (site, _) => site, true) || {},
-        diagnosis_age_count: handleCensoring('age_at_diagnosis', (_, age) => age.replace(/ Years$/, '')) || {},
+        // diagnosis_age_count: handleCensoring('age_at_diagnosis', (_, age) => age.replace(/ Years$/, '')) || {},
+        drug_type_count: handleCensoring('drug_type_count') || {},
         treatment_type_count: handleCensoring('treatment_type_count') || {},
         primary_site_count: handleCensoring('primary_site_count') || {}
     };

--- a/src/views/clinicalGenomic/widgets/matchingPatients.js
+++ b/src/views/clinicalGenomic/widgets/matchingPatients.js
@@ -139,12 +139,12 @@ function MatchingPatientsView() {
         ['program_id', 'Program ID', 150],
         ['sex_at_birth', 'Sex At Birth', 115],
         ['deceased', 'Deceased', 115],
-        // ['date_of_birth', 'Age at First Diagnosis', 160],
+        ['age_at_diagnosis', 'Age at First Diagnosis', 160]
         // ['date_of_death', 'Age at Death', 100]
-        ['num_exposures', 'Number of exposures', 160],
-        ['num_interventions', 'Number of interventions', 160],
-        ['num_measures', 'Number of measures', 160],
-        ['num_treatments', 'Number of treatments', 160]
+        // ['num_exposures', 'Number of exposures', 160],
+        // ['num_interventions', 'Number of interventions', 160],
+        // ['num_measures', 'Number of measures', 160],
+        // ['num_treatments', 'Number of treatments', 160]
     ];
 
     const genomicFields = [

--- a/src/views/clinicalGenomic/widgets/matchingPatients.js
+++ b/src/views/clinicalGenomic/widgets/matchingPatients.js
@@ -139,8 +139,12 @@ function MatchingPatientsView() {
         ['program_id', 'Program ID', 150],
         ['sex_at_birth', 'Sex At Birth', 115],
         ['deceased', 'Deceased', 115],
-        ['date_of_birth', 'Age at First Diagnosis', 160],
-        ['date_of_death', 'Age at Death', 100]
+        // ['date_of_birth', 'Age at First Diagnosis', 160],
+        // ['date_of_death', 'Age at Death', 100]
+        ['num_exposures', 'Number of exposures', 160],
+        ['num_interventions', 'Number of interventions', 160],
+        ['num_measures', 'Number of measures', 160],
+        ['num_treatments', 'Number of treatments', 160]
     ];
 
     const genomicFields = [

--- a/src/views/clinicalGenomic/widgets/patientCountSingle.js
+++ b/src/views/clinicalGenomic/widgets/patientCountSingle.js
@@ -84,7 +84,6 @@ function PatientCountSingle(props) {
 
     const PrintCensoredCounts = (totals) => (totals[0] === totals[1] ? totals[0] : `${totals[0]}-${totals[1]}`);
 
-    console.log(counts.totals);
     const totalPatients = SumCensoredTotals(Object.values(counts.totals)) || [0, 0];
     const patientsInSearch = SumCensoredTotals(Object.values(counts.counts)) || [0, 0];
     const numPrograms = Object.values(counts.totals)?.length || 0;

--- a/src/views/clinicalGenomic/widgets/patientCountSingle.js
+++ b/src/views/clinicalGenomic/widgets/patientCountSingle.js
@@ -68,7 +68,7 @@ function PatientCountSingle(props) {
         countsArray.reduce(
             (partialSum, programTotal) => {
                 if (typeof programTotal === 'object') {
-                    if (programTotal.patients_count.startsWith('<')) {
+                    if (typeof programTotal.patients_count === 'string' && programTotal.patients_count.startsWith('<')) {
                         return [partialSum[0], partialSum[1] + parseInt(programTotal.patients_count.substring(1), 10)];
                     }
                     const toAdd = parseInt(programTotal.patients_count, 10);
@@ -84,6 +84,7 @@ function PatientCountSingle(props) {
 
     const PrintCensoredCounts = (totals) => (totals[0] === totals[1] ? totals[0] : `${totals[0]}-${totals[1]}`);
 
+    console.log(counts.totals);
     const totalPatients = SumCensoredTotals(Object.values(counts.totals)) || [0, 0];
     const patientsInSearch = SumCensoredTotals(Object.values(counts.counts)) || [0, 0];
     const numPrograms = Object.values(counts.totals)?.length || 0;

--- a/src/views/clinicalGenomic/widgets/patientCounts.js
+++ b/src/views/clinicalGenomic/widgets/patientCounts.js
@@ -34,8 +34,6 @@ function PatientCounts() {
     let siteData = [];
     if (Array.isArray(sites)) {
         siteData = sites.map((entry) => {
-            console.log("entry");
-            console.log(entry);
             const counts = discoveryCounts?.[entry.location.name] || {};
             const realCounts = clinicalCounts?.[entry.location.name]?.summary?.patients_per_program || {};
             let unlockedPrograms = [];
@@ -58,18 +56,6 @@ function PatientCounts() {
                 totals: entry?.results || {},
                 unlockedPrograms
             };
-
-            /* const totalCounts = Object.keys(entry?.results?.info?.patients_per_program).map((program) => ({
-                patients_count: entry?.results?.info?.patients_per_program[program],
-                program_id: program
-            }));
-
-            return {
-                location: entry.location.name,
-                counts: entry?.results?.info?.patients_per_program, // finalCounts,
-                totals: totalCounts, // entry?.results || {},
-                unlockedPrograms: [] // unlockedPrograms
-            }; */
         });
     }
 

--- a/src/views/clinicalGenomic/widgets/patientCounts.js
+++ b/src/views/clinicalGenomic/widgets/patientCounts.js
@@ -34,7 +34,7 @@ function PatientCounts() {
     let siteData = [];
     if (Array.isArray(sites)) {
         siteData = sites.map((entry) => {
-            const counts = discoveryCounts?.[entry.location.name] || {};
+            /* const counts = discoveryCounts?.[entry.location.name] || {};
             const realCounts = clinicalCounts?.[entry.location.name]?.summary?.patients_per_program || {};
             let unlockedPrograms = [];
             // Fill up the programs using the summary counts
@@ -49,13 +49,18 @@ function PatientCounts() {
                 finalCounts[program] = program in realCounts ? realCounts[program] : counts[program];
             });
 
-            // Where possible, also use the real counts
+            // Where possible, also use the real counts */
+
+            const totalCounts = Object.keys(entry?.results?.info?.patients_per_program).map((program) => ({
+                patients_count: entry?.results?.info?.patients_per_program[program],
+                program_id: program
+            }));
 
             return {
                 location: entry.location.name,
-                counts: finalCounts,
-                totals: entry?.results || {},
-                unlockedPrograms
+                counts: entry?.results?.info?.patients_per_program, // finalCounts,
+                totals: totalCounts, // entry?.results || {},
+                unlockedPrograms: [] // unlockedPrograms
             };
         });
     }

--- a/src/views/clinicalGenomic/widgets/patientCounts.js
+++ b/src/views/clinicalGenomic/widgets/patientCounts.js
@@ -34,7 +34,9 @@ function PatientCounts() {
     let siteData = [];
     if (Array.isArray(sites)) {
         siteData = sites.map((entry) => {
-            /* const counts = discoveryCounts?.[entry.location.name] || {};
+            console.log("entry");
+            console.log(entry);
+            const counts = discoveryCounts?.[entry.location.name] || {};
             const realCounts = clinicalCounts?.[entry.location.name]?.summary?.patients_per_program || {};
             let unlockedPrograms = [];
             // Fill up the programs using the summary counts
@@ -49,9 +51,15 @@ function PatientCounts() {
                 finalCounts[program] = program in realCounts ? realCounts[program] : counts[program];
             });
 
-            // Where possible, also use the real counts */
+            // Where possible, also use the real counts
+            return {
+                location: entry.location.name,
+                counts: finalCounts,
+                totals: entry?.results || {},
+                unlockedPrograms
+            };
 
-            const totalCounts = Object.keys(entry?.results?.info?.patients_per_program).map((program) => ({
+            /* const totalCounts = Object.keys(entry?.results?.info?.patients_per_program).map((program) => ({
                 patients_count: entry?.results?.info?.patients_per_program[program],
                 program_id: program
             }));
@@ -61,7 +69,7 @@ function PatientCounts() {
                 counts: entry?.results?.info?.patients_per_program, // finalCounts,
                 totals: totalCounts, // entry?.results || {},
                 unlockedPrograms: [] // unlockedPrograms
-            };
+            }; */
         });
     }
 

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -670,7 +670,7 @@ function Sidebar() {
 
     // Parse out what we need:
     const sites = readerContext?.federation?.map((loc) => loc.location.name) || [];
-    const programs = readerContext?.federation?.map((loc) => Object.keys(loc.results?.patients_per_program) || [])?.flat(1) || [];
+    const programs = readerContext?.federation?.map((loc) => loc.results?.map((program) => program.program_id) || [])?.flat(1) || [];
     const authorizedPrograms = readerContext?.programs?.flatMap((loc) => loc?.results?.items?.map((program) => program.program_id)) || [];
     const treatmentTypes = ExtractSidebarElements('treatment_types');
     const tumourPrimarySites = ExtractSidebarElements('tumour_primary_sites');
@@ -686,16 +686,16 @@ function Sidebar() {
     chromosomes.push('');
     genes?.push('');
 
-    const hideGenomic = selectedtab !== 'All' && selectedtab !== 'Genomic';
+    const hideGenomic = true; // selectedtab !== 'All' && selectedtab !== 'Genomic';
     const hideClinical = selectedtab !== 'All' && selectedtab !== 'Clinical';
 
     return (
         <Root>
-            <Tabs value={selectedtab} onChange={(_, value) => setSelectedTab(value)}>
+            {/* <Tabs value={selectedtab} onChange={(_, value) => setSelectedTab(value)}>
                 <Tab className={classes.tab} value="All" label="All" />
                 <Tab className={classes.tab} value="Clinical" label="Clinical" />
                 <Tab className={classes.tab} value="Genomic" label="Genomic" />
-            </Tabs>
+            </Tabs> */}
             <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
                 <Button className={classes.button} onClick={() => resetButton()}>
                     Reset

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -670,7 +670,7 @@ function Sidebar() {
 
     // Parse out what we need:
     const sites = readerContext?.federation?.map((loc) => loc.location.name) || [];
-    const programs = readerContext?.federation?.map((loc) => loc.results?.map((program) => program.program_id) || [])?.flat(1) || [];
+    const programs = readerContext?.federation?.map((loc) => Object.keys(loc.results?.info?.patients_per_program) || [])?.flat(1) || [];
     const authorizedPrograms = readerContext?.programs?.flatMap((loc) => loc?.results?.items?.map((program) => program.program_id)) || [];
     const treatmentTypes = ExtractSidebarElements('treatment_types');
     const tumourPrimarySites = ExtractSidebarElements('tumour_primary_sites');

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -670,7 +670,7 @@ function Sidebar() {
 
     // Parse out what we need:
     const sites = readerContext?.federation?.map((loc) => loc.location.name) || [];
-    const programs = readerContext?.federation?.map((loc) => Object.keys(loc.results?.info?.patients_per_program) || [])?.flat(1) || [];
+    const programs = readerContext?.federation?.map((loc) => Object.keys(loc.results?.patients_per_program) || [])?.flat(1) || [];
     const authorizedPrograms = readerContext?.programs?.flatMap((loc) => loc?.results?.items?.map((program) => program.program_id)) || [];
     const treatmentTypes = ExtractSidebarElements('treatment_types');
     const tumourPrimarySites = ExtractSidebarElements('tumour_primary_sites');

--- a/src/views/pages/authentication/AuthCheck.js
+++ b/src/views/pages/authentication/AuthCheck.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 // project imports
-import { INGEST_URL } from 'store/api';
+import { API_URL } from 'store/api';
 import { UseUnauthorizedRoutes } from 'routes/UnauthorizedRoutes';
 import { AuthContext } from './AuthContext';
 
@@ -28,7 +28,7 @@ function AuthCheck(props) {
     // Fire off the authorization check
     useEffect(() => {
         setAuthCheckValue('loading', true);
-        fetch(`${INGEST_URL}/user/me`)
+        fetch(`${API_URL}/v1/authz/user/me`)
             .then((request) => {
                 if (request.ok) {
                     return request.json();
@@ -43,7 +43,7 @@ function AuthCheck(props) {
                 setAuthCheckValue('authorized', false);
 
                 // Request not ok: double check to see if we're pending
-                return fetch(`${INGEST_URL}/user/pending/me`)
+                return fetch(`${API_URL}/v1/authz/user/pending/me`)
                     .then((request) => {
                         if (request.ok) {
                             return request.text();


### PR DESCRIPTION
## Ticket(s)

- [DIG-2169](https://candig.atlassian.net/browse/DIG-2169)

## Description

- This alters the frontend in order to support the OMOP backend and candig-api. This is meant to be used for the CanDIGv3 version of the stack only, as large parts of functionality have been removed/altered. Among the removed components:
1. Genomic search
2. Summary page
3. Single Patient view (will come in a different PR)
4. Completeness stats (will come in a different PR)

In addition, we have explicit removal of the 'No value' / 'No matching concept' search terms, as they do not play nicely with the backend at the moment.

## Expected Behaviour

- The frontend should be capable of performing a search and showing results with this new frontend. In order to test this, you will have to do the following:
1. Make sure you are on the [CanDIGv3](https://github.com/CanDIG/CanDIGv3) version of the CanDIG repo, branch `feature/beacon-frontend`
2. `make build-all`
3. `source env.sh`
4. `export TOKEN=$(python site_admin_token.py)`
5. `curl -X POST candig.docker.internal:5080/candig-api/v1/datasets/upload -H "Authorization: Bearer $TOKEN" -H "Content-Type: multipart/form-data" -F "file=@${HOME}/Downloads/output_omop_data_fixed.json;type=application/json"` where `output_omop_data_fixed.json` is the file given from Justin/Son.
6. Log into the frontend. You should see the search page and be able to search as per normal, though this PR does not cover the per-patient view

## Screenshots (if appropriate)

### After PR
<img width="1857" height="936" alt="image" src="https://github.com/user-attachments/assets/a4df30be-b482-4594-9aa2-9479e397904b" />

## To do/Tickets to be made before merging branch

-

## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-2169]: https://candig.atlassian.net/browse/DIG-2169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ