### PR TITLE
DIG-1838: if nodes are specified, pass them as exclude_servers

### DIFF
--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -18,6 +18,15 @@ function SearchHandler({ setLoading }) {
     const summaryFetchAbort = useRef(new AbortController());
     const clinicalFetchAbort = useRef(new AbortController());
 
+    const { ...fullQuery } = reader.query || {};
+    // **Add genomic_data_types if it exists**
+    if (reader.query?.genomic_data_types) {
+        fullQuery.genomic_data_types = reader.query.genomic_data_types;
+    }
+    if (reader.filter?.node) {
+        fullQuery.exclude_servers = reader.filter.node.join('|');
+    }
+
     // Query 1: always have the federation sites and authorized programs query results available
     let lastPromise = null;
     useEffect(() => {
@@ -64,21 +73,13 @@ function SearchHandler({ setLoading }) {
         };
 
         // Prepare query excluding pagination
-        const { ...queryNoPageSize } = reader.query || {};
-        if ('page' in queryNoPageSize) delete queryNoPageSize.page;
-        if ('page_size' in queryNoPageSize) delete queryNoPageSize.page_size;
-
-        // **Add genomic_data_types if it exists**
-        if (reader.query?.genomic_data_types) {
-            queryNoPageSize.genomic_data_types = reader.query.genomic_data_types;
-        }
-        if (reader.filter?.node) {
-            queryNoPageSize.exclude_servers = reader.filter.node.join('|');
-        }
+        const { ...discoveryQuery } = fullQuery || {};
+        if ('page' in discoveryQuery) delete discoveryQuery.page;
+        if ('page_size' in discoveryQuery) delete discoveryQuery.page_size;
 
         setLoading(true);
         const discoveryPromise = () =>
-            query(queryNoPageSize, newAbort.signal, 'discovery/query')
+            query(discoveryQuery, newAbort.signal, 'discovery/query')
                 .then((data) => {
                     if (reader.filter?.node) {
                         data = data.filter((site) => !reader.filter.node.includes(site.location.name));
@@ -119,7 +120,7 @@ function SearchHandler({ setLoading }) {
         const newAbort = new AbortController();
 
         const donorQueryPromise = () =>
-            query(reader.query, newAbort.signal)
+            query(fullQuery, newAbort.signal)
                 .then((data) => {
                     if (reader.filter?.node) {
                         data = data.filter((site) => !reader.filter.node.includes(site.location.name));

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -72,6 +72,9 @@ function SearchHandler({ setLoading }) {
         if (reader.query?.genomic_data_types) {
             queryNoPageSize.genomic_data_types = reader.query.genomic_data_types;
         }
+        if (reader.filter?.node) {
+            queryNoPageSize.exclude_servers = reader.filter.node.join('|');
+        }
 
         setLoading(true);
         const discoveryPromise = () =>


### PR DESCRIPTION
## Ticket(s)

- DIG-1838

## Description

-

## Expected Behaviour

-

## Related Issues (if appropriate)

-

## Screenshots (if appropriate)

### Before PR

### After PR

## To do/Tickets to be made before merging branch

-

## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
