### PR TITLE
Disable unhealthy node

### DIFF
--- a/src/views/clinicalGenomic/widgets/patientCountSingle.js
+++ b/src/views/clinicalGenomic/widgets/patientCountSingle.js
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Avatar, Box, Button, CardHeader, Divider, Grid, Tooltip, Typography } from '@mui/material';
 import { useTheme } from '@mui/system';
 import { styled } from '@mui/material/styles';
 import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
 import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
 import PropTypes from 'prop-types';
 import { SITE } from 'store/constant';
 import siteLogo from 'assets/images/users/siteLogo.png';
@@ -18,7 +19,9 @@ const classes = {
     siteName: `${PREFIX}-siteName`,
     locked: `${PREFIX}-locked`,
     button: `${PREFIX}-button`,
-    divider: `${PREFIX}-divider`
+    divider: `${PREFIX}-divider`,
+    unhealthy: `${PREFIX}-unhealthy`,
+    warningIcon: `${PREFIX}-warningIcon`
 };
 
 const StyledBox = styled(Box)(({ theme }) => ({
@@ -55,6 +58,15 @@ const StyledBox = styled(Box)(({ theme }) => ({
         borderColor: theme.palette.primary.main,
         marginTop: 20,
         marginBottom: 4
+    },
+    [`& .${classes.unhealthy}`]: {
+        color: theme.palette.text.disabled
+    },
+    [`& .${classes.warningIcon}`]: {
+        color: theme.palette.warning.main,
+        marginLeft: '0.25em',
+        fontSize: '1.25em',
+        verticalAlign: 'text-bottom'
     }
 }));
 
@@ -63,6 +75,22 @@ function PatientCountSingle(props) {
     const theme = useTheme();
 
     const [expanded, setExpanded] = useState(false);
+
+    const nodeStatus = useMemo(() => {
+        const map = {};
+        const isHealthy = Object.keys(counts.totals).length > 0 && Object.keys(counts.counts).length > 0;
+        if (!isHealthy) {
+            console.log(counts);
+            console.log(counts.location);
+            map[counts.location] = {
+                healthy: false,
+                reason: 'Connection Error: No data returned from node'
+            };
+        } else {
+            map[counts.location] = { healthy: true };
+        }
+        return map;
+    }, [site, counts]);
 
     const SumCensoredTotals = (countsArray) =>
         countsArray.reduce(
@@ -93,7 +121,16 @@ function PatientCountSingle(props) {
                 <Grid item xs={2}>
                     <CardHeader
                         avatar={<Avatar src={SITE === site ? siteLogo : ''}>{SITE === site ? '' : site.slice(0, 1).toUpperCase()}</Avatar>}
-                        title={<b>{site}</b>}
+                        title={
+                            <Typography component="span" className={!nodeStatus[site].healthy ? classes.unhealthy : ''}>
+                                <b>{site}</b>
+                                {!nodeStatus[site].healthy && (
+                                    <Tooltip title={nodeStatus[site].reason || 'Node connection issue'} placement="right">
+                                        <WarningAmberOutlinedIcon className={classes.warningIcon} />
+                                    </Tooltip>
+                                )}
+                            </Typography>
+                        }
                     />
                 </Grid>
                 <Divider flexItem orientation="vertical" className={classes.divider} />

--- a/src/views/clinicalGenomic/widgets/patientCountSingle.js
+++ b/src/views/clinicalGenomic/widgets/patientCountSingle.js
@@ -63,7 +63,7 @@ const StyledBox = styled(Box)(({ theme }) => ({
         color: theme.palette.text.disabled
     },
     [`& .${classes.warningIcon}`]: {
-        color: theme.palette.warning.main,
+        color: theme.palette.tertiary[800],
         marginLeft: '0.25em',
         fontSize: '1.25em',
         verticalAlign: 'text-bottom'

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -22,6 +22,7 @@ import { styled } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
 
 import { useSearchQueryWriterContext, useSearchResultsReaderContext } from '../SearchResultsContext';
 
@@ -35,7 +36,8 @@ const classes = {
     hidden: `${PREFIX}-hidden`,
     button: `${PREFIX}-button`,
     lockIcon: `${PREFIX}-lockIcon`,
-    lockContainer: `${PREFIX}-lockContainer`
+    lockContainer: `${PREFIX}-lockContainer`,
+    warningIcon: `${PREFIX}-warningIcon`
 };
 
 // TODO jss-to-styled codemod: The Fragment root was replaced by div. Change the tag if needed.
@@ -77,6 +79,11 @@ const Root = styled('div')(({ theme }) => ({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center'
+    },
+    [`& .${classes.warningIcon}`]: {
+        color: theme.palette.tertiary[800],
+        marginLeft: '0.25em',
+        fontSize: '1.25em'
     }
 }));
 
@@ -133,15 +140,14 @@ function StyledCheckboxList(props) {
         selectedPrograms,
         setSelectedPrograms,
         checked,
-        setChecked
+        setChecked,
+        optionStatusMap
     } = props;
 
     const context = useSearchResultsReaderContext();
     const sites = context?.federation;
 
-    if (hide) {
-        return null;
-    }
+    if (hide) return null;
 
     const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
     const checkedIcon = <CheckBoxIcon fontSize="small" />;
@@ -274,35 +280,87 @@ function StyledCheckboxList(props) {
             id={`checkboxes-tags-${groupName}`}
             options={options}
             disableCloseOnSelect
-            renderOption={(props, option, { selected }) => (
-                <li {...props} key={option}>
-                    <div
-                        style={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            width: '100%'
-                        }}
-                    >
-                        <Checkbox
-                            icon={icon}
-                            checkedIcon={checkedIcon}
-                            sx={{
-                                paddingTop: 0,
-                                paddingBottom: 0,
-                                marginRight: 1
-                            }}
-                            checked={isExclusion ? !selected : selected}
-                            value={option}
-                        />
+            renderOption={(props, option, { selected }) => {
+                const status = optionStatusMap?.[option];
+                const isHealthy = status?.healthy !== false;
 
-                        <span
+                return (
+                    <li {...props} key={option}>
+                        <div
                             style={{
-                                display: 'inline-flex',
-                                alignItems: 'baseline',
-                                gap: '4px',
-                                lineHeight: 1.2
+                                display: 'flex',
+                                alignItems: 'center',
+                                width: '100%'
                             }}
                         >
+                            <Checkbox
+                                icon={icon}
+                                checkedIcon={checkedIcon}
+                                sx={{
+                                    paddingTop: 0,
+                                    paddingBottom: 0,
+                                    marginRight: 1
+                                }}
+                                checked={isExclusion ? !selected : selected}
+                                value={option}
+                                disabled={!isHealthy}
+                            />
+                            <span
+                                style={{
+                                    display: 'inline-flex',
+                                    alignItems: 'baseline',
+                                    gap: '4px',
+                                    lineHeight: 1.2
+                                }}
+                            >
+                                {option}
+                                {groupName === 'exclude_programs' && authorizedPrograms && !authorizedPrograms.includes(option) && (
+                                    <Tooltip title="Unauthorized Program" placement="right">
+                                        <LockOutlinedIcon
+                                            sx={{
+                                                color: 'primary.main',
+                                                fontSize: '1.1rem',
+                                                verticalAlign: 'text-bottom',
+                                                position: 'relative',
+                                                top: '3px'
+                                            }}
+                                        />
+                                    </Tooltip>
+                                )}
+                                {!isHealthy && (
+                                    <Tooltip title={status?.reason || 'Node connection issue'} placement="right">
+                                        <WarningAmberOutlinedIcon className={classes.warningIcon} />
+                                    </Tooltip>
+                                )}
+                            </span>
+                        </div>
+                    </li>
+                );
+            }}
+            value={checkedList}
+            // set width to match parent
+            sx={{ width: '100%', paddingTop: '0.5em', paddingBottom: '0.5em' }}
+            onChange={(_, value, reason) => {
+                const safeValue = value.filter((v) => optionStatusMap?.[v]?.healthy !== false);
+                HandleChange(safeValue, reason === 'selectOption');
+            }}
+            renderInput={(params) => <TextField {...params} label={groupName === 'exclude_programs' ? 'Programs' : groupName} />}
+            renderTags={(tagValue, getTagProps) =>
+                tagValue.map((option, index) => <Chip {...getTagProps({ index })} key={option} label={option} />)
+            }
+            getOptionDisabled={(option) => optionStatusMap?.[option]?.healthy === false}
+        />
+    ) : (
+        options?.map((option) => {
+            const status = optionStatusMap?.[option];
+            const isHealthy = status?.healthy !== false;
+
+            return (
+                <FormControlLabel
+                    key={option}
+                    className={classes.checkboxLabel}
+                    label={
+                        <div className={classes.lockContainer}>
                             {option}
                             {groupName === 'exclude_programs' && authorizedPrograms && !authorizedPrograms.includes(option) && (
                                 <Tooltip title="Unauthorized Program" placement="right">
@@ -317,58 +375,37 @@ function StyledCheckboxList(props) {
                                     />
                                 </Tooltip>
                             )}
-                        </span>
-                    </div>
-                </li>
-            )}
-            renderInput={(params) => <TextField {...params} label={groupName === 'exclude_programs' ? 'Programs' : groupName} />}
-            renderTags={(tagValue, getTagProps) =>
-                tagValue.map((option, index) => <Chip {...getTagProps({ index })} key={option} label={option} />)
-            }
-            // set width to match parent
-            sx={{ width: '100%', paddingTop: '0.5em', paddingBottom: '0.5em' }}
-            onChange={(_, value, reason) => {
-                HandleChange(value, reason === 'selectOption');
-            }}
-            value={checkedList}
-        />
-    ) : (
-        options?.map((option) => (
-            <FormControlLabel
-                label={
-                    <div className={classes.lockContainer}>
-                        {option}
-                        {groupName === 'exclude_programs' && authorizedPrograms && !authorizedPrograms.includes(option) && (
-                            <Tooltip title="Unauthorized Program" placement="right">
-                                <LockOutlinedIcon className={classes.lockIcon} />
-                            </Tooltip>
-                        )}
-                    </div>
-                }
-                control={
-                    <Checkbox
-                        className={classes.checkbox}
-                        checked={isExclusion ? !(option in checked) : option in checked}
-                        onChange={(event) => {
-                            const newList = Object.keys(checked).slice();
-                            if (!(option in checked)) {
-                                // Add to list
-                                newList.push(option);
-                            } else {
-                                // Remove from list
-                                const oldPos = newList.indexOf(option);
-                                if (oldPos >= 0) {
-                                    newList.splice(oldPos, 1);
+                            {!isHealthy && (
+                                <Tooltip title={status?.reason || 'Node connection issue'} placement="right">
+                                    <WarningAmberOutlinedIcon className={classes.warningIcon} />
+                                </Tooltip>
+                            )}
+                        </div>
+                    }
+                    control={
+                        <Checkbox
+                            className={classes.checkbox}
+                            checked={isExclusion ? !(option in checked) : option in checked}
+                            disabled={!isHealthy}
+                            onChange={(event) => {
+                                const newList = Object.keys(checked).slice();
+                                if (!(option in checked)) {
+                                    // Add to list
+                                    newList.push(option);
+                                } else {
+                                    // Remove from list
+                                    const oldPos = newList.indexOf(option);
+                                    if (oldPos >= 0) {
+                                        newList.splice(oldPos, 1);
+                                    }
                                 }
-                            }
-                            HandleChange(newList, event.target.checked);
-                        }}
-                    />
-                }
-                key={option}
-                className={classes.checkboxLabel}
-            />
-        ))
+                                HandleChange(newList, event.target.checked);
+                            }}
+                        />
+                    }
+                />
+            );
+        })
     );
 }
 
@@ -386,7 +423,8 @@ StyledCheckboxList.propTypes = {
     setSelectedPrograms: PropTypes.func,
     selectedPrograms: PropTypes.object,
     setChecked: PropTypes.func,
-    checked: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
+    checked: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+    optionStatusMap: PropTypes.object
 };
 
 // A group of genomics data
@@ -577,6 +615,26 @@ function Sidebar() {
     const [selectedPrimarySite, setSelectedPrimarySite] = useState({});
     const [selectedSystemicTherapy, setSelectedSystemicTherapy] = useState({});
 
+    const nodeStatusMap = (() => {
+        const map = {};
+        readerContext?.federation?.forEach((site) => {
+            const nodeName = site?.location?.name;
+
+            map[nodeName] = {
+                healthy: true
+            };
+
+            if (!site?.results) {
+                map[nodeName] = {
+                    healthy: false,
+                    reason: 'Connection Error: No data returned from node'
+                };
+            }
+        });
+
+        return map;
+    })();
+
     // On our first load, remove all query parameters
     useEffect(() => {
         writerContext(() => ({ reqNum: 0 }));
@@ -751,6 +809,7 @@ function Sidebar() {
                     setSelectedPrograms={setSelectedPrograms}
                     checked={selectedNodes}
                     setChecked={setSelectedNodes}
+                    optionStatusMap={nodeStatusMap}
                 />
             </SidebarGroup>
             <SidebarGroup name="Programs">


### PR DESCRIPTION
## Ticket(s)
[DIG-2139: Portal crashes if disconnected node is deselected](https://candig.atlassian.net/browse/DIG-2139)

## Description
If a node in the network is down and someone tries to deselect it in the sidebar on the clinical & genomic search page then the data portal crashes. Implementation add a warning for nodes that have connection errors and disable their selection.

## Expected Behaviour
You should no longer be able to change selection status of down node and a warning symbol should be present with a hover text saying the node is currently having connection issues. 


## Screenshots
<img width="1856" height="483" alt="image" src="https://github.com/user-attachments/assets/847fd20d-8df2-4db9-8571-5707b4a53536" />

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
