### PR TITLE
DIG-2225: (v3) Re-add dataset filtering

### DIFF
--- a/src/store/api.js
+++ b/src/store/api.js
@@ -267,21 +267,19 @@ export function queryBeacon(params, filter_mapping, programs, abort = null) {
 
             if (!NON_ID_FILTERS.includes(param) && !INVALID_FILTERS.includes(param)) {
                 // Determine if we're dealing with a list or not (and if so, are we dealing with the datasets?)
-                const new_param = {};
+                console.log(params[param]);
                 if (param === DATASET_PARAM) {
-                    new_param.id = `dataset_id:${params[param].join('|')}`;
-                } else if (Array.isArray(filter_mapping[params[param]])) {
-                    new_param.id = params[param].map((thisParam) => filter_mapping[thisParam]).join('|');
-                } else {
-                    new_param.id = filter_mapping[params[param]];
-                }
-
-                // Prevent an empty filter from somehow being passed on
-                if (typeof new_param.id === 'undefined') {
+                    params_filters.push({ id: `dataset_id:${params[param].join('|')}` });
+                } else if (Array.isArray(params[param])) {
+                    params[param].forEach((thisParam) => {
+                        params_filters.push({ id: filter_mapping[thisParam] });
+                    });
+                } else if (filter_mapping[params[param]] === 'undefined') {
+                    // Prevent an empty filter from somehow being passed on
                     console.log(`ID filter has no mapping: ${param} / ${params[param]}`);
-                    return;
+                } else {
+                    params_filters.push({ id: filter_mapping[params[param]] });
                 }
-                params_filters.push(new_param);
             } else {
                 // Non-ID filters need to be applied as well -- how should I approach this?
                 console.log(`Non-ID filter found but not yet supported: ${param}`);

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -254,7 +254,7 @@ export function queryBeacon(params, filter_mapping, programs, abort = null) {
     const page = params?.page ? `${params.page}` : undefined;
     const page_size = params?.page_size;
 
-    const NON_FILTER_PARAMS = ['page', 'page_size'];
+    const NON_FILTER_PARAMS = ['page', 'page_size', 'genomic_data_types'];
     const NON_ID_FILTERS = [];
     const INVALID_FILTERS = ['', null, undefined];
     const DATASET_PARAM = 'dataset_ids';
@@ -274,6 +274,12 @@ export function queryBeacon(params, filter_mapping, programs, abort = null) {
                     new_param.id = params[param].map((thisParam) => filter_mapping[thisParam]).join('|');
                 } else {
                     new_param.id = filter_mapping[params[param]];
+                }
+
+                // Prevent an empty filter from somehow being passed on
+                if (typeof new_param.id === 'undefined') {
+                    console.log(`ID filter has no mapping: ${param} / ${params[param]}`);
+                    return;
                 }
                 params_filters.push(new_param);
             } else {

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -247,7 +247,7 @@ export function fetchBeaconFilteringTerms() {
 
 // params.filters should be a list of objects
 // e.g. [{ "id": "SNOMED:33821000087103" }]
-export function queryBeacon(params, filter_mapping, abort = null) {
+export function queryBeacon(params, filter_mapping, programs, abort = null) {
     // Transform the parameters into something that it'll understand
     const params_filters = [];
     // Grab out the page and page number
@@ -257,6 +257,7 @@ export function queryBeacon(params, filter_mapping, abort = null) {
     const NON_FILTER_PARAMS = ['page', 'page_size'];
     const NON_ID_FILTERS = [];
     const INVALID_FILTERS = ['', null, undefined];
+    const DATASET_PARAM = 'dataset_ids';
 
     if (typeof params !== 'undefined' && params !== null) {
         Object.keys(params).forEach((param) => {
@@ -264,10 +265,16 @@ export function queryBeacon(params, filter_mapping, abort = null) {
                 return;
             }
 
-            const new_param = {};
-
             if (!NON_ID_FILTERS.includes(param) && !INVALID_FILTERS.includes(param)) {
-                new_param.id = filter_mapping[params[param]];
+                // Determine if we're dealing with a list or not (and if so, are we dealing with the datasets?)
+                const new_param = {};
+                if (param === DATASET_PARAM) {
+                    new_param.id = `dataset_id:${params[param].join('|')}`;
+                } else if (Array.isArray(filter_mapping[params[param]])) {
+                    new_param.id = params[param].map((thisParam) => filter_mapping[thisParam]).join('|');
+                } else {
+                    new_param.id = filter_mapping[params[param]];
+                }
                 params_filters.push(new_param);
             } else {
                 // Non-ID filters need to be applied as well -- how should I approach this?

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { trackPromise } from 'react-promise-tracker';
 
 import { useSearchResultsWriterContext, useSearchQueryReaderContext } from '../SearchResultsContext';
-import { fetchFederation, queryBeacon, fetchBeaconFilteringTerms } from 'store/api';
+import { queryBeacon, fetchBeaconFilteringTerms } from 'store/api';
 import { isCensored } from 'utils/utils';
 
 // The old function to collate summary statistics from multiple sites together

--- a/src/views/clinicalGenomic/widgets/matchingPatients.js
+++ b/src/views/clinicalGenomic/widgets/matchingPatients.js
@@ -132,7 +132,7 @@ function MatchingPatientsView() {
         () => searchResultsClinical && Object.values(searchResultsClinical).some((location) => location?.results?.length > 0),
         [searchResultsClinical]
     );
-    const hasValidQuery = (query?.assembly && query?.chrom) || query?.gene || query?.genomic_data_types?.trim().length > 0;
+    const hasValidQuery = (query?.assembly && query?.chrom) || query?.gene || query?.genomic_data_types?.length > 0;
 
     // Column definitions
     const clinicalFields = [

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -288,7 +288,12 @@ function StyledCheckboxList(props) {
 
     const checkedList = Array.isArray(checked) ? checked : Object.keys(checked || {});
     let label = groupName;
-    if (groupName === 'exclude_programs') {
+    let renderTags = (tagValue, getTagProps) =>
+        tagValue.map((option, index) => <Chip {...getTagProps({ index })} key={option} label={option} />);
+    if (groupName === 'dataset_ids') {
+        // Datasets: instead of using Chips to display the selected datasets (which can be confusing)
+        // we instead just show a short text description describing how many datasets have been selected
+        renderTags = (tagValue, _) => <span>{`${tagValue.length} datasets selected, expand to see more`}</span>;
         label = 'Datasets';
     } else if (groupName === 'primary_site') {
         label = 'Diseases';
@@ -314,9 +319,7 @@ function StyledCheckboxList(props) {
                 </li>
             )}
             renderInput={(params) => <TextField {...params} className={classes.inputDHDP} label={label} />}
-            renderTags={(tagValue, getTagProps) =>
-                tagValue.map((option, index) => <Chip {...getTagProps({ index })} key={option} label={option} />)
-            }
+            renderTags={renderTags}
             // set width to match parent
             sx={{ width: '100%', paddingTop: '0.5em', paddingBottom: '0.5em' }}
             onChange={(_, value, reason) => {
@@ -685,6 +688,14 @@ function Sidebar() {
         });
     }
 
+    function setPrograms(programs) {
+        const newPrograms = {};
+        programs.forEach((program) => {
+            newPrograms[program] = true;
+        });
+        setSelectedPrograms(newPrograms);
+    }
+
     // Fill up a list of options from the results of a Katsu query
     const ExtractSidebarElements = (key) => {
         const allResults = readerContext?.sidebar?.map((loc) => loc?.results?.[key] || [])?.flat(1) || [];
@@ -771,6 +782,14 @@ function Sidebar() {
                     checked={selectedPrograms}
                     setChecked={setSelectedPrograms}
                 />
+                <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+                    <Button className={classes.button} onClick={() => setPrograms(programs)}>
+                        Select all
+                    </Button>
+                    <Button className={classes.button} onClick={() => setPrograms([])}>
+                        Reset
+                    </Button>
+                </div>
             </SidebarGroup>
             <GenomicsGroup
                 chromosomes={chromosomes}

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -213,7 +213,7 @@ function StyledCheckboxList(props) {
                             const associatedNodes = cohortMap[programId] || new Set();
                             return Array.from(associatedNodes).every((node) => !(node in checked));
                         });
-                        retVal.query.exclude_programs = validProgramIds.join('|');
+                        retVal.query.exclude_programs = validProgramIds;
                         setSelectedPrograms((old) => {
                             const newPrograms = { ...old };
                             validProgramIds.forEach((id) => {
@@ -225,10 +225,10 @@ function StyledCheckboxList(props) {
 
                     // if this filter is genomicDataTypes, we also put it into query as a pipe-delimited string
                     if (groupName === 'genomic_data_types') {
-                        retVal.query.genomic_data_types = ids.join('|');
+                        retVal.query.genomic_data_types = ids;
                     }
                 } else if (ids.length > 0) {
-                    retVal.query[groupName] = ids.join('|');
+                    retVal.query[groupName] = ids;
                 }
                 retVal.query.page = 0;
                 retVal.query.page_size = old.query?.page_size || 10;
@@ -259,10 +259,9 @@ function StyledCheckboxList(props) {
                                 delete currentPrograms[id];
                             }
                         });
+
                         if (currentPrograms && Object.keys(currentPrograms).length > 0) {
-                            retVal.query.exclude_programs = Object.keys(currentPrograms)
-                                .filter((id) => currentPrograms[id])
-                                .join('|');
+                            retVal.query.exclude_programs = Object.keys(currentPrograms).filter((id) => currentPrograms[id]);
                         } else {
                             delete retVal.query.exclude_programs;
                             retVal.query = {};
@@ -272,12 +271,12 @@ function StyledCheckboxList(props) {
 
                     // if this filter is genomicDataTypes, also update query string
                     if (groupName === 'genomic_data_types') {
-                        retVal.query.genomic_data_types = ids.join('|');
+                        retVal.query.genomic_data_types = ids;
                     }
                 } else {
                     const newList = Object.fromEntries(Object.entries(retVal.query).filter(([name, _]) => name !== groupName));
                     if (ids.length > 0) {
-                        newList[groupName] = ids.join('|');
+                        newList[groupName] = ids;
                     }
                     retVal.query = newList;
                 }
@@ -410,12 +409,10 @@ function GenomicsGroup(props) {
     const formatGenomicDataTypes = (gdt) => {
         if (!gdt) return '';
         if (Array.isArray(gdt)) {
-            return gdt.join('|');
+            return gdt;
         }
         if (typeof gdt === 'object') {
-            return Object.keys(gdt)
-                .filter((k) => gdt[k])
-                .join('|');
+            return Object.keys(gdt).filter((k) => gdt[k]);
         }
         return String(gdt);
     };
@@ -764,18 +761,17 @@ function Sidebar() {
                     setChecked={setSelectedNodes}
                 />
             </SidebarGroup>
-            {/* <SidebarGroup name="Datasets">
+            <SidebarGroup name="Datasets">
                 <StyledCheckboxList
                     options={programs}
                     authorizedPrograms={authorizedPrograms}
                     onWrite={writerContext}
-                    groupName="exclude_programs"
+                    groupName="dataset_ids"
                     useAutoComplete={programs.length >= 5}
-                    isExclusion
                     checked={selectedPrograms}
                     setChecked={setSelectedPrograms}
                 />
-            </SidebarGroup> */}
+            </SidebarGroup>
             <GenomicsGroup
                 chromosomes={chromosomes}
                 genes={genes}


### PR DESCRIPTION
## Ticket(s)

- https://candig.atlassian.net/browse/DIG-2225

## Description

- This adds dataset filtering back in, but does **not** yet fix the lock behaviour that used to be present

## Expected Behaviour

- You can now search on datasets, select all/none, etc.

## Screenshots (if appropriate)

### After PR

[Screencast from 2026-02-04 15-53-41.webm](https://github.com/user-attachments/assets/db3e48e2-e0a3-4fb6-85af-23ce621a5723)

## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
