### PR TITLE
DIG-2223: CanDIG-API: Sidebar lock buttons/datasets broken

### DIFF
--- a/src/store/api.js
+++ b/src/store/api.js
@@ -271,7 +271,6 @@ export function queryBeacon(params, filter_mapping, programs, abort = null) {
 
             if (!NON_ID_FILTERS.includes(param) && !INVALID_FILTERS.includes(param)) {
                 // Determine if we're dealing with a list or not (and if so, are we dealing with the datasets?)
-                console.log(params[param]);
                 if (param === DATASET_PARAM) {
                     params_filters.push({ id: `dataset_id:${params[param].join('|')}` });
                 } else if (Array.isArray(params[param])) {

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -267,21 +267,19 @@ export function queryBeacon(params, filter_mapping, programs, abort = null) {
 
             if (!NON_ID_FILTERS.includes(param) && !INVALID_FILTERS.includes(param)) {
                 // Determine if we're dealing with a list or not (and if so, are we dealing with the datasets?)
-                const new_param = {};
+                console.log(params[param]);
                 if (param === DATASET_PARAM) {
-                    new_param.id = `dataset_id:${params[param].join('|')}`;
-                } else if (Array.isArray(filter_mapping[params[param]])) {
-                    new_param.id = params[param].map((thisParam) => filter_mapping[thisParam]).join('|');
-                } else {
-                    new_param.id = filter_mapping[params[param]];
-                }
-
-                // Prevent an empty filter from somehow being passed on
-                if (typeof new_param.id === 'undefined') {
+                    params_filters.push({ id: `dataset_id:${params[param].join('|')}` });
+                } else if (Array.isArray(params[param])) {
+                    params[param].forEach((thisParam) => {
+                        params_filters.push({ id: filter_mapping[thisParam] });
+                    });
+                } else if (filter_mapping[params[param]] === 'undefined') {
+                    // Prevent an empty filter from somehow being passed on
                     console.log(`ID filter has no mapping: ${param} / ${params[param]}`);
-                    return;
+                } else {
+                    params_filters.push({ id: filter_mapping[params[param]] });
                 }
-                params_filters.push(new_param);
             } else {
                 // Non-ID filters need to be applied as well -- how should I approach this?
                 console.log(`Non-ID filter found but not yet supported: ${param}`);

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -254,7 +254,7 @@ export function queryBeacon(params, filter_mapping, programs, abort = null) {
     const page = params?.page ? `${params.page}` : undefined;
     const page_size = params?.page_size;
 
-    const NON_FILTER_PARAMS = ['page', 'page_size'];
+    const NON_FILTER_PARAMS = ['page', 'page_size', 'genomic_data_types'];
     const NON_ID_FILTERS = [];
     const INVALID_FILTERS = ['', null, undefined];
     const DATASET_PARAM = 'dataset_ids';
@@ -274,6 +274,12 @@ export function queryBeacon(params, filter_mapping, programs, abort = null) {
                     new_param.id = params[param].map((thisParam) => filter_mapping[thisParam]).join('|');
                 } else {
                     new_param.id = filter_mapping[params[param]];
+                }
+
+                // Prevent an empty filter from somehow being passed on
+                if (typeof new_param.id === 'undefined') {
+                    console.log(`ID filter has no mapping: ${param} / ${params[param]}`);
+                    return;
                 }
                 params_filters.push(new_param);
             } else {

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -247,7 +247,7 @@ export function fetchBeaconFilteringTerms() {
 
 // params.filters should be a list of objects
 // e.g. [{ "id": "SNOMED:33821000087103" }]
-export function queryBeacon(params, filter_mapping, abort = null) {
+export function queryBeacon(params, filter_mapping, programs, abort = null) {
     // Transform the parameters into something that it'll understand
     const params_filters = [];
     // Grab out the page and page number
@@ -257,6 +257,7 @@ export function queryBeacon(params, filter_mapping, abort = null) {
     const NON_FILTER_PARAMS = ['page', 'page_size'];
     const NON_ID_FILTERS = [];
     const INVALID_FILTERS = ['', null, undefined];
+    const DATASET_PARAM = 'dataset_ids';
 
     if (typeof params !== 'undefined' && params !== null) {
         Object.keys(params).forEach((param) => {
@@ -264,10 +265,16 @@ export function queryBeacon(params, filter_mapping, abort = null) {
                 return;
             }
 
-            const new_param = {};
-
             if (!NON_ID_FILTERS.includes(param) && !INVALID_FILTERS.includes(param)) {
-                new_param.id = filter_mapping[params[param]];
+                // Determine if we're dealing with a list or not (and if so, are we dealing with the datasets?)
+                const new_param = {};
+                if (param === DATASET_PARAM) {
+                    new_param.id = `dataset_id:${params[param].join('|')}`;
+                } else if (Array.isArray(filter_mapping[params[param]])) {
+                    new_param.id = params[param].map((thisParam) => filter_mapping[thisParam]).join('|');
+                } else {
+                    new_param.id = filter_mapping[params[param]];
+                }
                 params_filters.push(new_param);
             } else {
                 // Non-ID filters need to be applied as well -- how should I approach this?

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -245,6 +245,10 @@ export function fetchBeaconFilteringTerms() {
     return fetchFederation('v1/beacon/datasets/filtering_terms', 'candig-api');
 }
 
+export function fetchDatasetPermissions() {
+    return fetchFederation('v1/authz/user/me', 'candig-api');
+}
+
 // params.filters should be a list of objects
 // e.g. [{ "id": "SNOMED:33821000087103" }]
 export function queryBeacon(params, filter_mapping, programs, abort = null) {

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { trackPromise } from 'react-promise-tracker';
 
 import { useSearchResultsWriterContext, useSearchQueryReaderContext } from '../SearchResultsContext';
-import { queryBeacon, fetchBeaconFilteringTerms } from 'store/api';
+import { queryBeacon, fetchBeaconFilteringTerms, fetchDatasetPermissions } from 'store/api';
 import { isCensored } from 'utils/utils';
 
 // The old function to collate summary statistics from multiple sites together
@@ -117,6 +117,35 @@ function FormatFilters(data) {
     return retVal;
 }
 
+function FormatAuthorization(authData, fedData) {
+    const allowedPrograms = {};
+    // authData contains the results from federating v1/authz/user/me
+    authData.forEach((site) => {
+        const siteID = site.location.name;
+
+        if (typeof site?.results?.site_roles === 'undefined') {
+            // We have run into some sort of error here
+            return;
+        }
+
+        // Each site has an object with: userinfo, site_roles, dataset_authorizations{ team_member: [], dataset_curator: [], dac_authorizaztions: [] }
+        // In the case of site-admins, we are allowed to see every authorization in this site
+        if (site.results.site_roles.includes('admin')) {
+            const matchingFedSite = fedData.find((fedSite) => fedSite.location.name === siteID);
+            if (matchingFedSite && Array.isArray(matchingFedSite.results)) {
+                allowedPrograms[siteID] = matchingFedSite.results.map((results) => results.program_id);
+            }
+            return;
+        }
+
+        // Otherwise, we are authorized to view each program with any of the given dataset_authorizations
+        allowedPrograms[siteID] = site.results.dataset_authorizations.team_member
+            .concat(site.results.dataset_authorizations.dataset_curator)
+            .concat(site.results.dataset_authorizations.dac_authorizations);
+    });
+    return allowedPrograms;
+}
+
 // This handles transforming queries in the SearchResultsContext to actual search queries
 // NB: I assign to lastPromise a bunch to keep track of whether or not we need to chain promises together
 // However, the linter really dislikes this, and assumes I want to put everything inside one useEffect?
@@ -139,13 +168,23 @@ function SearchHandler({ setLoading }) {
                     setFilters((_) => FormatFilters(data));
                 })
                 .then(() => queryBeacon({ page_size: 1 }))
-                .then((data) =>
+                .then((data) => {
                     writer((old) => ({
                         ...old,
                         federation: FormatFederationData(data),
                         sidebar: FormatSidebarData(data)
-                    }))
-                )
+                    }));
+                    return FormatFederationData(data);
+                })
+                .then((fedData) => Promise.all([fetchDatasetPermissions(), fedData]))
+                .then((data) => {
+                    const authData = data[0];
+                    const fedData = data[1];
+                    writer((old) => ({
+                        ...old,
+                        auth: FormatAuthorization(authData, fedData)
+                    }));
+                })
                 .finally(() => setLoading(false)),
             'federation'
             /* fetchFederatedSubServices(`v3/discovery/sidebar_list`)

--- a/src/views/clinicalGenomic/search/SearchHandler.js
+++ b/src/views/clinicalGenomic/search/SearchHandler.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { trackPromise } from 'react-promise-tracker';
 
 import { useSearchResultsWriterContext, useSearchQueryReaderContext } from '../SearchResultsContext';
-import { fetchFederation, queryBeacon, fetchBeaconFilteringTerms } from 'store/api';
+import { queryBeacon, fetchBeaconFilteringTerms } from 'store/api';
 import { isCensored } from 'utils/utils';
 
 // The old function to collate summary statistics from multiple sites together

--- a/src/views/clinicalGenomic/widgets/matchingPatients.js
+++ b/src/views/clinicalGenomic/widgets/matchingPatients.js
@@ -132,7 +132,7 @@ function MatchingPatientsView() {
         () => searchResultsClinical && Object.values(searchResultsClinical).some((location) => location?.results?.length > 0),
         [searchResultsClinical]
     );
-    const hasValidQuery = (query?.assembly && query?.chrom) || query?.gene || query?.genomic_data_types?.trim().length > 0;
+    const hasValidQuery = (query?.assembly && query?.chrom) || query?.gene || query?.genomic_data_types?.length > 0;
 
     // Column definitions
     const clinicalFields = [

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -288,7 +288,12 @@ function StyledCheckboxList(props) {
 
     const checkedList = Array.isArray(checked) ? checked : Object.keys(checked || {});
     let label = groupName;
-    if (groupName === 'exclude_programs') {
+    let renderTags = (tagValue, getTagProps) =>
+        tagValue.map((option, index) => <Chip {...getTagProps({ index })} key={option} label={option} />);
+    if (groupName === 'dataset_ids') {
+        // Datasets: instead of using Chips to display the selected datasets (which can be confusing)
+        // we instead just show a short text description describing how many datasets have been selected
+        renderTags = (tagValue, _) => <span>{`${tagValue.length} datasets selected, expand to see more`}</span>;
         label = 'Datasets';
     } else if (groupName === 'primary_site') {
         label = 'Diseases';
@@ -314,9 +319,7 @@ function StyledCheckboxList(props) {
                 </li>
             )}
             renderInput={(params) => <TextField {...params} className={classes.inputDHDP} label={label} />}
-            renderTags={(tagValue, getTagProps) =>
-                tagValue.map((option, index) => <Chip {...getTagProps({ index })} key={option} label={option} />)
-            }
+            renderTags={renderTags}
             // set width to match parent
             sx={{ width: '100%', paddingTop: '0.5em', paddingBottom: '0.5em' }}
             onChange={(_, value, reason) => {
@@ -685,6 +688,14 @@ function Sidebar() {
         });
     }
 
+    function setPrograms(programs) {
+        const newPrograms = {};
+        programs.forEach((program) => {
+            newPrograms[program] = true;
+        });
+        setSelectedPrograms(newPrograms);
+    }
+
     // Fill up a list of options from the results of a Katsu query
     const ExtractSidebarElements = (key) => {
         const allResults = readerContext?.sidebar?.map((loc) => loc?.results?.[key] || [])?.flat(1) || [];
@@ -771,6 +782,14 @@ function Sidebar() {
                     checked={selectedPrograms}
                     setChecked={setSelectedPrograms}
                 />
+                <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+                    <Button className={classes.button} onClick={() => setPrograms(programs)}>
+                        Select all
+                    </Button>
+                    <Button className={classes.button} onClick={() => setPrograms([])}>
+                        Reset
+                    </Button>
+                </div>
             </SidebarGroup>
             <GenomicsGroup
                 chromosomes={chromosomes}

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -333,7 +333,7 @@ function StyledCheckboxList(props) {
                 label={
                     <div className={classes.lockContainer + (config.isDHDP ? ` ${classes.checkboxLabelDHDP}` : '')}>
                         {option}
-                        {groupName === 'exclude_programs' && authorizedPrograms && !authorizedPrograms.includes(option) && (
+                        {groupName === 'dataset_ids' && authorizedPrograms && !authorizedPrograms.includes(option) && (
                             <Tooltip title="Unauthorized Program" placement="right">
                                 <LockOutlinedIcon className={classes.lockIcon} />
                             </Tooltip>
@@ -707,7 +707,7 @@ function Sidebar() {
     // Parse out what we need:
     const sites = readerContext?.federation?.map((loc) => loc.location.name) || [];
     const programs = readerContext?.federation?.map((loc) => loc.results?.map((program) => program.program_id) || [])?.flat(1) || [];
-    const authorizedPrograms = readerContext?.programs?.flatMap((loc) => loc?.results?.items?.map((program) => program.program_id)) || [];
+    const authorizedPrograms = Object.values(readerContext?.auth || {})?.flat(1);
     const treatmentTypes = ExtractSidebarElements('treatment_types');
     const tumourPrimarySites = ExtractSidebarElements('tumour_primary_sites');
     const systemicTherapyDrugNames = ExtractSidebarElements('drug_names');

--- a/src/views/clinicalGenomic/widgets/sidebar.js
+++ b/src/views/clinicalGenomic/widgets/sidebar.js
@@ -213,7 +213,7 @@ function StyledCheckboxList(props) {
                             const associatedNodes = cohortMap[programId] || new Set();
                             return Array.from(associatedNodes).every((node) => !(node in checked));
                         });
-                        retVal.query.exclude_programs = validProgramIds.join('|');
+                        retVal.query.exclude_programs = validProgramIds;
                         setSelectedPrograms((old) => {
                             const newPrograms = { ...old };
                             validProgramIds.forEach((id) => {
@@ -225,10 +225,10 @@ function StyledCheckboxList(props) {
 
                     // if this filter is genomicDataTypes, we also put it into query as a pipe-delimited string
                     if (groupName === 'genomic_data_types') {
-                        retVal.query.genomic_data_types = ids.join('|');
+                        retVal.query.genomic_data_types = ids;
                     }
                 } else if (ids.length > 0) {
-                    retVal.query[groupName] = ids.join('|');
+                    retVal.query[groupName] = ids;
                 }
                 retVal.query.page = 0;
                 retVal.query.page_size = old.query?.page_size || 10;
@@ -259,10 +259,9 @@ function StyledCheckboxList(props) {
                                 delete currentPrograms[id];
                             }
                         });
+
                         if (currentPrograms && Object.keys(currentPrograms).length > 0) {
-                            retVal.query.exclude_programs = Object.keys(currentPrograms)
-                                .filter((id) => currentPrograms[id])
-                                .join('|');
+                            retVal.query.exclude_programs = Object.keys(currentPrograms).filter((id) => currentPrograms[id]);
                         } else {
                             delete retVal.query.exclude_programs;
                             retVal.query = {};
@@ -272,12 +271,12 @@ function StyledCheckboxList(props) {
 
                     // if this filter is genomicDataTypes, also update query string
                     if (groupName === 'genomic_data_types') {
-                        retVal.query.genomic_data_types = ids.join('|');
+                        retVal.query.genomic_data_types = ids;
                     }
                 } else {
                     const newList = Object.fromEntries(Object.entries(retVal.query).filter(([name, _]) => name !== groupName));
                     if (ids.length > 0) {
-                        newList[groupName] = ids.join('|');
+                        newList[groupName] = ids;
                     }
                     retVal.query = newList;
                 }
@@ -410,12 +409,10 @@ function GenomicsGroup(props) {
     const formatGenomicDataTypes = (gdt) => {
         if (!gdt) return '';
         if (Array.isArray(gdt)) {
-            return gdt.join('|');
+            return gdt;
         }
         if (typeof gdt === 'object') {
-            return Object.keys(gdt)
-                .filter((k) => gdt[k])
-                .join('|');
+            return Object.keys(gdt).filter((k) => gdt[k]);
         }
         return String(gdt);
     };
@@ -764,18 +761,17 @@ function Sidebar() {
                     setChecked={setSelectedNodes}
                 />
             </SidebarGroup>
-            {/* <SidebarGroup name="Datasets">
+            <SidebarGroup name="Datasets">
                 <StyledCheckboxList
                     options={programs}
                     authorizedPrograms={authorizedPrograms}
                     onWrite={writerContext}
-                    groupName="exclude_programs"
+                    groupName="dataset_ids"
                     useAutoComplete={programs.length >= 5}
-                    isExclusion
                     checked={selectedPrograms}
                     setChecked={setSelectedPrograms}
                 />
-            </SidebarGroup> */}
+            </SidebarGroup>
             <GenomicsGroup
                 chromosomes={chromosomes}
                 genes={genes}


### PR DESCRIPTION
## Ticket(s)

- [DIG-2223](https://candig.atlassian.net/browse/DIG-2223)

## Description

- This re-adds the lock buttons to datasets on the sidebar

## Related Issues (if appropriate)

- Requires #244 to be merged first

## Screenshots (if appropriate)

### After PR

[Screencast from 2026-02-05 14-23-19.webm](https://github.com/user-attachments/assets/fc65db0e-9db6-40a5-bdc8-0bea96299de3)

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-2223]: https://candig.atlassian.net/browse/DIG-2223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ