### PR TITLE
DIG-2245: Reinstate new user request access portal functionality in CanDIGv3

### DIFF
--- a/src/views/pages/authentication/AuthDisplay.js
+++ b/src/views/pages/authentication/AuthDisplay.js
@@ -116,7 +116,7 @@ function AuthDisplay() {
 
     const requestAccess = () => {
         const authWriter = authContext[1];
-        fetch('/candig-api/user/pending/request', {
+        fetch('/candig-api/v1/authz/user/pending/request', {
             method: 'POST'
         }).then(() => {
             // Then, force re-check of the status

--- a/src/views/pages/authentication/AuthDisplay.js
+++ b/src/views/pages/authentication/AuthDisplay.js
@@ -116,7 +116,7 @@ function AuthDisplay() {
 
     const requestAccess = () => {
         const authWriter = authContext[1];
-        fetch('/ingest/user/pending/request', {
+        fetch('/candig-api/user/pending/request', {
             method: 'POST'
         }).then(() => {
             // Then, force re-check of the status
@@ -189,7 +189,7 @@ function AuthDisplay() {
                 }
                 button={
                     <Button variant="contained" onClick={requestAccess}>
-                        Request access
+                        Request&nbsp;access
                     </Button>
                 }
             />


### PR DESCRIPTION
## Ticket(s)

- [DIG-2245](DIG-2245)

## Description

- This re-adds the request access functionality.

## Screenshots (if appropriate)

<img width="1847" height="931" alt="image" src="https://github.com/user-attachments/assets/1211a0b2-0cee-4bdc-8bf1-fc476a68f5b5" />

## To test
- Navigate to `:8080/auth/admin/master/console/`
- Password will be in `tmp/keycloak/admin-password`
- Left dropdown from `Keycloak`->`candig`
- Users
- Add user
- Fill out some info, set email verified, Create User
- Go to the Credentials tab, add a non-temporary password
- Login, you should see the request access page
- Click on it, you should see the above screenshot
- Verify with an admin token:
```
(candig) 09:40 fnguyen@fnguyen-worktop:~/Documents/CanDIGv3$ curl candig.docker.internal:5080/candig-api/v1/authz/user/pending -H "Authorization: Bearer $TOKEN"
{"results": ["test@test.ca"]}
(candig) 09:40 fnguyen@fnguyen-worktop:~/Documents/CanDIGv3$ curl -X POST candig.docker.internal:5080/candig-api/v1/authz/user/pending -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '["test@test.ca"]'
{"approved": ["test@test.ca"]}
```
- Other permissions have to be added manually

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-2245]: https://candig.atlassian.net/browse/DIG-2245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ