### PR TITLE
Don't include descendant terms in the sidebar search

### DIFF
--- a/src/store/api.js
+++ b/src/store/api.js
@@ -249,6 +249,10 @@ export function fetchDatasetPermissions() {
     return fetchFederation('v1/authz/user/me', 'candig-api');
 }
 
+function getBeaconFilterForID(id) {
+    return { id: id, includeDescendantTerms: false };
+}
+
 // params.filters should be a list of objects
 // e.g. [{ "id": "SNOMED:33821000087103" }]
 export function queryBeacon(params, filter_mapping, programs, abort = null) {
@@ -272,16 +276,16 @@ export function queryBeacon(params, filter_mapping, programs, abort = null) {
             if (!NON_ID_FILTERS.includes(param) && !INVALID_FILTERS.includes(param)) {
                 // Determine if we're dealing with a list or not (and if so, are we dealing with the datasets?)
                 if (param === DATASET_PARAM) {
-                    params_filters.push({ id: `dataset_id:${params[param].join('|')}` });
+                    params_filters.push(getBeaconFilterForID(`dataset_id:${params[param].join('|')}`));
                 } else if (Array.isArray(params[param])) {
                     params[param].forEach((thisParam) => {
-                        params_filters.push({ id: filter_mapping[thisParam] });
+                        params_filters.push(getBeaconFilterForID(filter_mapping[thisParam]));
                     });
                 } else if (filter_mapping[params[param]] === 'undefined') {
                     // Prevent an empty filter from somehow being passed on
                     console.log(`ID filter has no mapping: ${param} / ${params[param]}`);
                 } else {
-                    params_filters.push({ id: filter_mapping[params[param]] });
+                    params_filters.push(getBeaconFilterForID(filter_mapping[params[param]]));
                 }
             } else {
                 // Non-ID filters need to be applied as well -- how should I approach this?

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -250,7 +250,7 @@ export function fetchDatasetPermissions() {
 }
 
 function getBeaconFilterForID(id) {
-    return { id: id, includeDescendantTerms: false };
+    return { id, includeDescendantTerms: false };
 }
 
 // params.filters should be a list of objects


### PR DESCRIPTION
## Description

- This turns off descendant search in Beacon search, which is [on by default](https://docs.genomebeacons.org/filters/#modified-hierarchical-ontology-query), but in our (OMOP) use-case it ends up bloating the size of the request in SQL by a lot.

As an example, this is what the query looks like when you search on "biopsy":
<img width="1348" height="718" alt="image" src="https://github.com/user-attachments/assets/f0c0ba72-e073-4a5e-9a65-1d00a3010350" />

## Expected Behaviour

- This turns off descendant search

## Screenshots (if appropriate)

### Before PR

<img width="1348" height="718" alt="image" src="https://github.com/user-attachments/assets/876f18cf-b5ad-43b0-8c0c-4ffdb01da1fd" />

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
