### PR TITLE
Add select all/ reset button, "x programs selected" instead of chips …

### DIFF
--- a/src/views/clinicalGenomic/widgets/sidebar.jsx
+++ b/src/views/clinicalGenomic/widgets/sidebar.jsx
@@ -851,7 +851,7 @@ function Sidebar() {
                 />
                 <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
                     <Button className={classes.button} onClick={() => setPrograms(programs)}>
-                        Select all
+                        Select&nbsp;all
                     </Button>
                     <Button className={classes.button} onClick={() => setPrograms([])}>
                         Reset

--- a/src/views/clinicalGenomic/widgets/sidebar.jsx
+++ b/src/views/clinicalGenomic/widgets/sidebar.jsx
@@ -851,7 +851,7 @@ function Sidebar() {
                 />
                 <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
                     <Button className={classes.button} onClick={() => setPrograms(programs)}>
-                        Select&nbsp;all
+                        Deselect&nbsp;all
                     </Button>
                     <Button className={classes.button} onClick={() => setPrograms([])}>
                         Reset

--- a/src/views/clinicalGenomic/widgets/sidebar.jsx
+++ b/src/views/clinicalGenomic/widgets/sidebar.jsx
@@ -272,6 +272,15 @@ function StyledCheckboxList(props) {
     };
 
     const checkedList = Array.isArray(checked) ? checked : Object.keys(checked || {});
+    let label = groupName;
+    let renderTags = (tagValue, getTagProps) =>
+        tagValue.map((option, index) => <Chip {...getTagProps({ index })} key={option} label={option} />);
+    if (groupName === 'exclude_programs') {
+        // Datasets: instead of using Chips to display the selected datasets (which can be confusing)
+        // we instead just show a short text description describing how many datasets have been selected
+        renderTags = (tagValue, _) => <span>{`${options.length - tagValue.length} programs selected, expand to see more`}</span>;
+        label = 'Programs';
+    }
 
     return useAutoComplete ? (
         <Autocomplete
@@ -344,10 +353,8 @@ function StyledCheckboxList(props) {
                 const safeValue = value.filter((v) => optionStatusMap?.[v]?.healthy !== false);
                 HandleChange(safeValue, reason === 'selectOption');
             }}
-            renderInput={(params) => <TextField {...params} label={groupName === 'exclude_programs' ? 'Programs' : groupName} />}
-            renderTags={(tagValue, getTagProps) =>
-                tagValue.map((option, index) => <Chip {...getTagProps({ index })} key={option} label={option} />)
-            }
+            renderInput={(params) => <TextField {...params} label={label} />}
+            renderTags={renderTags}
             getOptionDisabled={(option) => optionStatusMap?.[option]?.healthy === false}
         />
     ) : (
@@ -753,6 +760,25 @@ function Sidebar() {
         });
     }
 
+    // Set programs to the given list
+    function setPrograms(programs) {
+        const newPrograms = {};
+        programs.forEach((program) => {
+            newPrograms[program] = true;
+        });
+        setSelectedPrograms(newPrograms);
+
+        writerContext((old) => {
+            const retVal = { filter: {}, query: {}, ...old };
+            if (programs.length > 0) {
+                retVal.query.exclude_programs = programs.join('|');
+            } else {
+                delete retVal.query["exclude_programs"]
+            }
+            return retVal;
+        });
+    }
+
     // Fill up a list of options from the results of a Katsu query
     const ExtractSidebarElements = (key) => {
         const allResults = readerContext?.sidebar?.map((loc) => loc?.results?.[key] || [])?.flat(1) || [];
@@ -823,6 +849,14 @@ function Sidebar() {
                     checked={selectedPrograms}
                     setChecked={setSelectedPrograms}
                 />
+                <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+                    <Button className={classes.button} onClick={() => setPrograms(programs)}>
+                        Select all
+                    </Button>
+                    <Button className={classes.button} onClick={() => setPrograms([])}>
+                        Reset
+                    </Button>
+                </div>
             </SidebarGroup>
             <GenomicsGroup
                 chromosomes={chromosomes}


### PR DESCRIPTION
…for program search

## Ticket(s)

- [DIG-2246](https://candig.atlassian.net/browse/DIG-2246)

## Description

- This applies the same UI improvements requested for CanDIGv3 to the v2 version of the program search

## Related Issues (if appropriate)

- The same improvements first appeared in [this PR](https://github.com/CanDIG/candig-data-portal/pull/245)

## Screenshots (if appropriate)

### After PR

<img width="277" height="359" alt="image" src="https://github.com/user-attachments/assets/474f0baf-a866-4aa5-89c5-21d270e3fb59" />


## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots


[DIG-2246]: https://candig.atlassian.net/browse/DIG-2246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ