### PR TITLE
Add a fallback to email copying

### DIFF
--- a/src/views/clinicalGenomic/requestDataAccessForm.js
+++ b/src/views/clinicalGenomic/requestDataAccessForm.js
@@ -521,8 +521,27 @@ function RequestDataAccessForm() {
         window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
     }, [showForm]);
 
+    function fallbackCopyTextToClipboard(text) {
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        document.body.appendChild(textarea);
+        textarea.select();
+
+        try {
+            document.execCommand('copy');
+        } catch (err) {
+            console.error('Fallback copy failed:', err);
+        } finally {
+            document.body.removeChild(textarea);
+        }
+    }
+
     const handleCopy = async () => {
-        await navigator.clipboard.writeText(DHDP_EMAIL);
+        if (navigator.clipboard) {
+            await navigator.clipboard.writeText(DHDP_EMAIL);
+        } else {
+            fallbackCopyTextToClipboard(DHDP_EMAIL);
+        }
         setTooltipText('Copied');
     };
 


### PR DESCRIPTION
## Description

- On FireFox, clicking the copy email link on the data access request form was crashing. This fixes it by adding a fallback

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
