### PR TITLE
Persistent Chart colours

### DIFF
--- a/src/assets/scss/_themes-vars.module.scss
+++ b/src/assets/scss/_themes-vars.module.scss
@@ -22,6 +22,16 @@ $tertiaryMain: #ffd34f;
 $tertiaryDark: #ffb800;
 $tertiary800: #fc9803;
 
+// Stacked Charts Additional Colours
+// $primaryMain: #1e88e5;
+// $secondaryMain: #36b84c;
+// $tertiaryMain: #ffd34f;
+$burntOrangeMain: #c63d1e;
+$tealMain: #00796b;
+$plumMain: #B47EB3;
+$sageMain: #6b8f71;
+$coralMain: #E15554;
+
 // success Colors
 $successLight: #b9f6ca;
 $success200: #69f0ae;
@@ -79,6 +89,13 @@ $grey900: #212121;
     tertiaryDark: $tertiaryDark;
     tertiary200: $tertiary200;
     tertiary800: $tertiary800;
+
+    // Stacked Charts Additional Colours
+    burntOrangeMain: $burntOrangeMain;
+    tealMain: $tealMain;
+    plumMain: $plumMain;
+    sageMain: $sageMain;
+    coralMain: $coralMain;
 
     // success
     successLight: $successLight;

--- a/src/themes/palette.jsx
+++ b/src/themes/palette.jsx
@@ -29,6 +29,21 @@ export default function themePalette(theme) {
             200: theme.colors.tertiary200,
             800: theme.colors.tertiary800
         },
+        teal: {
+            main: theme.colors.tealMain
+        },
+        plum: {
+            main: theme.colors.plumMain
+        },
+        burntOrange: {
+            main: theme.colors.burntOrangeMain
+        },
+        sage: {
+            main: theme.colors.sageMain
+        },
+        coral: {
+            main: theme.colors.coralMain
+        },
         error: {
             light: theme.colors.errorLight,
             main: theme.colors.errorMain,

--- a/src/views/summary/CustomOfflineChart.jsx
+++ b/src/views/summary/CustomOfflineChart.jsx
@@ -28,6 +28,44 @@ export const VALID_CHART_TYPES = ['bar', 'line', 'column', 'scatter', 'pie'];
 // Defined here in order to prevent a circular dependancy
 export const VISUALIZATION_LOCAL_STORAGE_KEY = 'chartDefinitions';
 
+// Helper: find the index of the first non-zero value in an array, modded by the max number of colours we have (to prevent out of bounds errors)
+function findSiteIndexMod(value, max) {
+    const siteIndex = value.findIndex((v) => v!== 0) || 0;
+    return siteIndex % max;
+}
+
+// Helper: convert hex to HSL
+function hexToHSL(hex) {
+    const bigint = parseInt(hex.replace('#', ''), 16);
+    let r = ((bigint >> 16) & 255) / 255;
+    let g = ((bigint >> 8) & 255) / 255;
+    let b = (bigint & 255) / 255;
+
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    let h, s, l = (max + min) / 2;
+
+    if(max === min){
+        h = s = 0; // achromatic
+    } else {
+        const d = max - min;
+        s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+        switch(max){
+            case r: h = (g - b) / d + (g < b ? 6 : 0); break;
+            case g: h = (b - r) / d + 2; break;
+            case b: h = (r - g) / d + 4; break;
+        }
+        h /= 6;
+    }
+
+    return [h, s, l];
+}
+
+// Helper: HSL to CSS string
+function hslToCss([h, s, l]) {
+    return `hsl(${Math.round(h * 360)}, ${Math.round(s * 100)}%, ${Math.round(l * 100)}%)`;
+}
+
 /*
  * Component for offline chart
  * @param {string} chartType
@@ -97,6 +135,28 @@ function CustomOfflineChart({
     useEffect(() => {
         // Determine whether or not there exists censored data in the object provided
         function hasCensoredData(dataObj) {
+            // For testing purposes, generate some random censored data
+            // if (dataObj.local) {
+            //     const generateLocal = (name, cohortCount = 25) => {
+            //         dataObj[name] = {};
+
+            //         for (let i = 1; i <= cohortCount; i++) {
+            //             const cohortNum = String(i).padStart(2, '0');
+            //             const synthNum = (i % 30) + 1;
+
+            //             const key = `${name}_SYNTH_${synthNum.toString().padStart(2, '0')}`;
+
+            //             const value = Math.floor(Math.random() * 46) + 5;
+
+            //             dataObj[name][`${key}_${cohortNum}`] = value;
+            //         }
+            //     };
+
+            //     generateLocal("local2");
+            //     generateLocal("local3");
+            //     generateLocal("local4");
+            //     generateLocal("local6");
+            // }
             function isObjectCensored(obj) {
                 if (dataObj[HAS_CENSORED_DATA_MARKER]) {
                     return true;
@@ -186,12 +246,13 @@ function CustomOfflineChart({
                 const data = new Map();
                 let categories = [];
                 const thisData = dataObjectToUse;
+                const bars = Object.keys(thisData).length;
 
                 Object.keys(thisData).forEach((key, i) => {
                     categories.push(key);
                     Object.keys(thisData[key]).forEach((program) => {
                         if (!data.has(program)) {
-                            data.set(program, new Array(Object.keys(thisData).length).fill(0));
+                            data.set(program, new Array(bars).fill(0));
                         }
                         data.get(program).splice(i, 1, thisData[key][program]);
                     });
@@ -206,9 +267,7 @@ function CustomOfflineChart({
                 });
 
                 const stackSeries = [];
-                data?.forEach((value, key) => {
-                    stackSeries.push({ name: key, data: value });
-                });
+
                 const grayscaleTheme = [
                     theme.palette.grey[200],
                     theme.palette.grey[300],
@@ -218,20 +277,52 @@ function CustomOfflineChart({
                     theme.palette.grey[900]
                 ];
                 const colouredTheme = [
-                    theme.palette.secondary[200],
-                    theme.palette.tertiary[200],
-                    theme.palette.primary[200],
+                    theme.palette.primary.main,
                     theme.palette.secondary.main,
                     theme.palette.tertiary.main,
-                    theme.palette.primary.main,
-                    theme.palette.secondary.dark,
-                    theme.palette.tertiary.dark,
-                    theme.palette.primary.dark,
-                    theme.palette.secondary[800],
-                    theme.palette.tertiary[800],
-                    theme.palette.primary[800]
+                    theme.palette.teal.main,
+                    theme.palette.plum.main,
+                    theme.palette.coral.main,
+                    theme.palette.burntOrange.main,
+                    theme.palette.sage.main
                 ];
                 const stackedTheme = grayscale ? grayscaleTheme : colouredTheme;
+                const maxes = new Array(bars).fill(0);
+                const mins = new Array(bars).fill(Infinity);
+
+                // Site based max and min
+                data?.forEach((value) => {
+                    value.forEach((v, i) => {
+                        maxes[i] = Math.max(maxes[i], v);
+                        mins[i] = Math.min(mins[i], v === 0 ? mins[i] : v);
+                    });
+                });
+
+                data?.forEach((value, key) => {
+                    const baseIndex = findSiteIndexMod(value, stackedTheme.length);
+                    // Colour conversion and manipulation
+                    const baseHex = stackedTheme[baseIndex];
+                    const baseHSL = hexToHSL(baseHex);
+
+                    const points = value.map((y, i) => {
+                        let ratio = maxes[i] === mins[i] ? 0.5 : (y - mins[i]) / (maxes[i] - mins[i]);
+
+                        let [h, s, l] = baseHSL;
+
+                        // Hue shift ±5° but scaled up for small value differences
+                        h = (h + (ratio - 0.5) * (20 / 360) + 1) % 1; 
+
+                        // Lightness shift ±30% for small differences
+                        l = Math.min(1, Math.max(0, l - 0.15 + ratio * 0.3));
+
+                        // Saturation shift ±10% for small differences
+                        s = Math.min(1, Math.max(0, s - 0.05 + ratio * 0.1));
+
+                        return { y, color: hslToCss([h, s, l]) };
+                    });
+
+                    stackSeries.push({ name: key, data: points });
+                });
 
                 setChartOptions({
                     credits: {
@@ -249,7 +340,6 @@ function CustomOfflineChart({
                     },
                     xAxis: { title: { text: DataVisualizationChartInfo[chartData].xAxis }, categories, allowDecimals: false },
                     yAxis: { title: { text: DataVisualizationChartInfo[chartData].yAxis }, allowDecimals: false },
-                    colors: stackedTheme,
                     plotOptions: {
                         series: {
                             stacking: 'normal'

--- a/src/views/summary/CustomOfflineChart.jsx
+++ b/src/views/summary/CustomOfflineChart.jsx
@@ -54,6 +54,7 @@ function hexToHSL(hex) {
             case r: h = (g - b) / d + (g < b ? 6 : 0); break;
             case g: h = (b - r) / d + 2; break;
             case b: h = (r - g) / d + 4; break;
+            default: h = 0;break;
         }
         h /= 6;
     }
@@ -480,7 +481,12 @@ function CustomOfflineChart({
         theme.palette.grey,
         theme.palette.primary,
         theme.palette.secondary,
-        theme.palette.tertiary
+        theme.palette.tertiary,
+        theme.palette.teal,
+        theme.palette.plum,
+        theme.palette.coral,
+        theme.palette.burntOrange,
+        theme.palette.sage
     ]);
 
     function setLocalStorageDataVis(event, key) {


### PR DESCRIPTION
## Ticket(s)
[DIG-1632 Persistent Stacked bar chart](https://candig.atlassian.net/browse/DIG-1632)

## Description
This PR introduces persistent, site-specific base colours for the stacked bar chart in CustomOfflineChart.

Previously, stacked chart colours were derived from the existing theme palette and reused across series, which did not guarantee distinct, site-consistent colours.

This update:

- Adds new site-specific base colours to _themes-vars.module.scss
- Extends the MUI theme palette (palette.jsx) to expose these colours
- Updates CustomOfflineChart.jsx to:
  - Dynamically assign a base colour per site
  - Adjust colour variations using HSL transformations based on value ratios
  - Ensure colours remain visually distinct across sites
  - Bar length alignment by correctly initializing arrays using bars length

I have left in a comment for testing purposes that creates some fake data for the stacked bar chart

## Expected Behaviour

- Each site in a stacked bar chart is assigned a distinct, persistent base colour
- Individual stacked segments slightly vary in hue, saturation, and lightness based on relative value
- Charts remain visually consistent across renders

## Screenshots

### Before PR
<img width="463" height="449" alt="image" src="https://github.com/user-attachments/assets/e441a4ee-5f69-4020-9fe5-9cd981325e63" />


### After PR
<img width="377" height="501" alt="image" src="https://github.com/user-attachments/assets/ada1fffa-ef21-4023-8235-6939add6b5b2" />

### Palette
<img width="1181" height="133" alt="image" src="https://github.com/user-attachments/assets/d39d902b-80c5-4a91-a11c-450dbc6b273b" />

## Math Explanation
#### HSL Transformation Math
Each bar's colour is made from its series' base colour by computing a ratio; where the bar's value falls between the site-level min and max (y - min) / (max - min). A ratio of 0 means the lowest value at that site, 1 means the highest, and 0.5 is the midpoint. This ratio then drives three small HSL shifts:

- Hue: ±10° rotation (ratio below 0.5 shifts cooler, above shifts warmer)
- Lightness: ±15% (lower values darken, higher values lighten)
- Saturation: ±5% (lower values desaturate slightly, higher values become more vivid)

All values are clamped to [0, 1] to prevent colour artifacts. The intent is that each series retains a recognizable colour identity while individual bars encode their relative magnitude through subtle shading.


## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [x] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
