### PR TITLE
Fixup: Completeness page whitescreens with data in it

### DIFF
--- a/src/views/summary/CustomOfflineChart.jsx
+++ b/src/views/summary/CustomOfflineChart.jsx
@@ -30,7 +30,7 @@ export const VISUALIZATION_LOCAL_STORAGE_KEY = 'chartDefinitions';
 
 // Helper: find the index of the first non-zero value in an array, modded by the max number of colours we have (to prevent out of bounds errors)
 function findSiteIndexMod(value, max) {
-    const siteIndex = value.findIndex((v) => v!== 0) || 0;
+    const siteIndex = Math.max(0, value.findIndex((v) => v!== 0));
     return siteIndex % max;
 }
 


### PR DESCRIPTION
## Description

- Fixup a small arithmetic error in the new per-site-colouring (`|| 0` is not the same as `Math.max(0, <val>)`, which was breaking the completeness page

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [x] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
