### PR TITLE
add the query part of the path to the urls

### DIFF
--- a/src/store/api.jsx
+++ b/src/store/api.jsx
@@ -66,11 +66,11 @@ export function fetchFederation(path, service, payload = {}, fetchMethod = fetch
  *
  * @param {string} targetPath - The specific path within the target service to request data from
  * @param {string} [targetService='katsu'] - The target service being queried (default: 'katsu')
- * @param {string} [endpoint='discovery] - The endpoint used for the federation request (default: 'discovery')
+ * @param {string} [endpoint='discovery] - The endpoint used for the federation request (default: 'query/discovery')
  * @param {string} [service='query'] - The service handling the request (default: 'query')
  * @returns {Promise<Object|string>} A promise that resolves to the response data or 'error' if the request fails
  */
-export function fetchFederatedSubServices(targetPath, targetService = 'katsu', endpoint = 'discovery', service = 'query') {
+export function fetchFederatedSubServices(targetPath, targetService = 'katsu', endpoint = 'query/discovery', service = 'query') {
     const payload = {
         targetService,
         targetPath
@@ -91,7 +91,7 @@ export function fetchFederatedSubServices(targetPath, targetService = 'katsu', e
     * @param {path} Query API path used to send the request to, assumed to be /query but
     * can be used for e.g. /genomic_completeness if need be
 */
-export function query(parameters, abort, path = 'query') {
+export function query(parameters, abort, path = 'query/query') {
     const payload = {
         ...parameters
     };
@@ -161,7 +161,7 @@ export function ingestGenomicData(data, program_id) {
  * as a dictionary of {site: {program (type)} = #}
  */
 export function fetchGenomicCompleteness() {
-    return fetchFederation('genomic_completeness', 'query').then((data) => {
+    return fetchFederation('query/genomic_completeness', 'query').then((data) => {
         const numCompleteGenomic = {};
         data.filter((site) => site.status === 200).forEach((site) => {
             numCompleteGenomic[site.location.name] = {};
@@ -180,7 +180,7 @@ export function fetchGenomicCompleteness() {
  * with: numNodes, numErrorNodes, numDonors, numCompleteDonors, numClinicalComplete, data
  */
 export function fetchClinicalCompleteness() {
-    return fetchFederation('discovery/programs', 'query').then((data) => {
+    return fetchFederation('query/discovery/programs', 'query').then((data) => {
         // Step 1: Determine the number of provinces
         const provinces = data?.map((site) => site?.location?.province);
         const uniqueProvinces = [...new Set(provinces)];

--- a/src/views/clinicalGenomic/search/SearchHandler.jsx
+++ b/src/views/clinicalGenomic/search/SearchHandler.jsx
@@ -79,7 +79,7 @@ function SearchHandler({ setLoading }) {
 
         setLoading(true);
         const discoveryPromise = () =>
-            query(discoveryQuery, newAbort.signal, 'discovery/query')
+            query(discoveryQuery, newAbort.signal, 'query/discovery/query')
                 .then((data) => {
                     if (reader.filter?.node) {
                         data = data.filter((site) => !reader.filter.node.includes(site.location.name));


### PR DESCRIPTION
## Ticket(s)

- Required to function with the new API endpoints

## Types of Change(s)

-   [x] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [ ] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [ ] My change requires a change to the documentation
-   [ ] I have updated the documentation accordingly
-   [ ] Prettier linter doesn't return errors
-   [ ] Production branch PR browser testing: Chrome, Firefox, Edge, etc.
-   [ ] Locally tested
-   [ ] Dev server tested
-   [ ] Production tested when merging into stable/production branch
-   [ ] [Runbook tasks](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) pass locally/on UHN-Dev
-   [ ] If visuals have changed, [Runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) has been updated with new screenshots
