### PR TITLE
Add in-browser guided tours for the search and patient pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
                 "react-device-detect": "^2.2.3",
                 "react-dom": "^18.2.0",
                 "react-error-boundary": "^6.1.1",
+                "react-joyride": "^2.9.3",
                 "react-loader-spinner": "^6.1.6",
                 "react-multi-select-component": "^4.3.4",
                 "react-new-window": "^1.0.1",
@@ -2687,6 +2688,12 @@
             "version": "0.2.11",
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
             "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+            "license": "MIT"
+        },
+        "node_modules/@gilbarbara/deep-equal": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.3.1.tgz",
+            "integrity": "sha512-I7xWjLs2YSVMc5gGx1Z3ZG1lgFpITPndpi8Ku55GeEIKpACCPQNS/OTqQbxgTCfq0Ncvcc+CrFov96itVh6Qvw==",
             "license": "MIT"
         },
         "node_modules/@highcharts/map-collection": {
@@ -5870,6 +5877,13 @@
                 }
             }
         },
+        "node_modules/deep-diff": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
+            "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+            "license": "MIT"
+        },
         "node_modules/deep-equal": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
@@ -7789,6 +7803,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-lite": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-1.2.1.tgz",
+            "integrity": "sha512-pgF+L5bxC+10hLBgf6R2P4ZZUBOQIIacbdo8YvuCP8/JvsWxG7aZ9p10DYuLtifFci4l3VITphhMlMV4Y+urPw==",
+            "license": "MIT"
+        },
         "node_modules/is-map": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -8682,6 +8702,17 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/popper.js": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+            "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+            "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/popperjs"
+            }
+        },
         "node_modules/possible-typed-array-names": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -8901,11 +8932,119 @@
             "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==",
             "license": "MIT"
         },
+        "node_modules/react-floater": {
+            "version": "0.7.9",
+            "resolved": "https://registry.npmjs.org/react-floater/-/react-floater-0.7.9.tgz",
+            "integrity": "sha512-NXqyp9o8FAXOATOEo0ZpyaQ2KPb4cmPMXGWkx377QtJkIXHlHRAGer7ai0r0C1kG5gf+KJ6Gy+gdNIiosvSicg==",
+            "license": "MIT",
+            "dependencies": {
+                "deepmerge": "^4.3.1",
+                "is-lite": "^0.8.2",
+                "popper.js": "^1.16.0",
+                "prop-types": "^15.8.1",
+                "tree-changes": "^0.9.1"
+            },
+            "peerDependencies": {
+                "react": "15 - 18",
+                "react-dom": "15 - 18"
+            }
+        },
+        "node_modules/react-floater/node_modules/@gilbarbara/deep-equal": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.1.2.tgz",
+            "integrity": "sha512-jk+qzItoEb0D0xSSmrKDDzf9sheQj/BAPxlgNxgmOaA3mxpUa6ndJLYGZKsJnIVEQSD8zcTbyILz7I0HcnBCRA==",
+            "license": "MIT"
+        },
+        "node_modules/react-floater/node_modules/deepmerge": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-floater/node_modules/is-lite": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-0.8.2.tgz",
+            "integrity": "sha512-JZfH47qTsslwaAsqbMI3Q6HNNjUuq6Cmzzww50TdP5Esb6e1y2sK2UAaZZuzfAzpoI2AkxoPQapZdlDuP6Vlsw==",
+            "license": "MIT"
+        },
+        "node_modules/react-floater/node_modules/tree-changes": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.9.3.tgz",
+            "integrity": "sha512-vvvS+O6kEeGRzMglTKbc19ltLWNtmNt1cpBoSYLj/iEcPVvpJasemKOlxBrmZaCtDJoF+4bwv3m01UKYi8mukQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@gilbarbara/deep-equal": "^0.1.1",
+                "is-lite": "^0.8.2"
+            }
+        },
+        "node_modules/react-innertext": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
+            "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": ">=0.0.0 <=99",
+                "react": ">=0.0.0 <=99"
+            }
+        },
         "node_modules/react-is": {
             "version": "19.2.7",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
             "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
             "license": "MIT"
+        },
+        "node_modules/react-joyride": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-2.9.3.tgz",
+            "integrity": "sha512-1+Mg34XK5zaqJ63eeBhqdbk7dlGCFp36FXwsEvgpjqrtyywX2C6h9vr3jgxP0bGHCw8Ilsp/nRDzNVq6HJ3rNw==",
+            "license": "MIT",
+            "dependencies": {
+                "@gilbarbara/deep-equal": "^0.3.1",
+                "deep-diff": "^1.0.2",
+                "deepmerge": "^4.3.1",
+                "is-lite": "^1.2.1",
+                "react-floater": "^0.7.9",
+                "react-innertext": "^1.1.5",
+                "react-is": "^16.13.1",
+                "scroll": "^3.0.1",
+                "scrollparent": "^2.1.0",
+                "tree-changes": "^0.11.2",
+                "type-fest": "^4.27.0"
+            },
+            "peerDependencies": {
+                "react": "15 - 18",
+                "react-dom": "15 - 18"
+            }
+        },
+        "node_modules/react-joyride/node_modules/deepmerge": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-joyride/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "license": "MIT"
+        },
+        "node_modules/react-joyride/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/react-loader-spinner": {
             "version": "6.1.6",
@@ -9439,6 +9578,18 @@
                 "loose-envify": "^1.1.0"
             }
         },
+        "node_modules/scroll": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
+            "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==",
+            "license": "MIT"
+        },
+        "node_modules/scrollparent": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+            "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==",
+            "license": "ISC"
+        },
         "node_modules/semver": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -9916,6 +10067,16 @@
             "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
             "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
             "license": "MIT"
+        },
+        "node_modules/tree-changes": {
+            "version": "0.11.3",
+            "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.11.3.tgz",
+            "integrity": "sha512-r14mvDZ6tqz8PRQmlFKjhUVngu4VZ9d92ON3tp0EGpFBE6PAHOq8Bx8m8ahbNoGE3uI/npjYcJiqVydyOiYXag==",
+            "license": "MIT",
+            "dependencies": {
+                "@gilbarbara/deep-equal": "^0.3.1",
+                "is-lite": "^1.2.1"
+            }
         },
         "node_modules/tsconfig-paths": {
             "version": "3.15.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "react-device-detect": "^2.2.3",
         "react-dom": "^18.2.0",
         "react-error-boundary": "^6.1.1",
+        "react-joyride": "^2.9.3",
         "react-loader-spinner": "^6.1.6",
         "react-multi-select-component": "^4.3.4",
         "react-new-window": "^1.0.1",

--- a/src/layout/MainLayout/Header/TourButton.jsx
+++ b/src/layout/MainLayout/Header/TourButton.jsx
@@ -1,0 +1,39 @@
+import { useLocation } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { Button } from '@mui/material';
+import { IconPlayerPlay } from '@tabler/icons-react';
+
+import config from '../../../config';
+import { SET_MENU } from '../../../store/actions';
+import { useTour } from '../../../ui-component/tour/TourContext';
+import searchTourSteps from '../../../ui-component/tour/searchTourSteps';
+import waitForElement from '../../../ui-component/tour/waitForElement';
+
+const { basename } = config;
+const SEARCH_PATH = `${basename}/clinicalGenomicSearch`;
+
+// "Take a tour" button shown in the header (left of the profile menu). It only
+// appears on the Clinical & Genomic Search page — the search tour's steps target
+// elements on that page — and starts the tour in place without navigating.
+function TourButton() {
+    const location = useLocation();
+    const dispatch = useDispatch();
+    const { startTour } = useTour();
+
+    if (location.pathname !== SEARCH_PATH) return null;
+
+    const handleStartTour = () => {
+        // Ensure the filter drawer (which several steps target) is open, then start
+        // once the sidebar has mounted.
+        dispatch({ type: SET_MENU, opened: true });
+        waitForElement('[data-tour="search-sidebar"]').then(() => startTour(searchTourSteps));
+    };
+
+    return (
+        <Button variant="outlined" size="small" startIcon={<IconPlayerPlay size={18} />} onClick={handleStartTour} sx={{ mr: 1.5 }}>
+            Take a tour
+        </Button>
+    );
+}
+
+export default TourButton;

--- a/src/layout/MainLayout/Header/index.jsx
+++ b/src/layout/MainLayout/Header/index.jsx
@@ -6,6 +6,7 @@ import { Avatar, Box, ButtonBase } from '@mui/material';
 import LogoSection from '../LogoSection';
 // import SearchSection from './SearchSection';
 import ProfileSection from './ProfileSection';
+import TourButton from './TourButton';
 // import NotificationSection from './NotificationSection';
 import MenuList from '../../../MenuList';
 
@@ -74,6 +75,9 @@ function Header({ handleLeftDrawerToggle }) {
             {/* header search */}
             {/* <SearchSection theme="light" />  Currently not needed */}
             <StyledGrow className={classes.grow} />
+
+            {/* take a tour (search page only) */}
+            <TourButton />
 
             {/* notification & profile */}
             {/* <NotificationSection /> */}

--- a/src/layout/MainLayout/index.jsx
+++ b/src/layout/MainLayout/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, lazy, Suspense } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Outlet } from 'react-router-dom';
 
@@ -20,10 +20,13 @@ import { drawerWidth } from '../../store/constant';
 import { SET_MENU } from '../../store/actions';
 import { SidebarProvider } from './Sidebar/SidebarContext';
 import { TourProvider } from '../../ui-component/tour/TourContext';
-import TourRunner from '../../ui-component/tour/TourRunner';
 
 // assets
 import { IconChevronRight } from '@tabler/icons-react';
+
+// Lazy so react-joyride is code-split out of the main bundle (it's only used by
+// the guided tours). It starts loading on mount, so it's ready before any tour.
+const TourRunner = lazy(() => import('../../ui-component/tour/TourRunner'));
 
 // style constant
 const PREFIX = 'MainLayout';
@@ -160,7 +163,9 @@ function MainLayout() {
                     <Footer className={leftDrawerOpened ? classes.footerWidth : classes.footer} />
                 </SidebarProvider>
                 {/* Guided tour overlay (driven from the header "Take a tour" button and the patient page) */}
-                <TourRunner />
+                <Suspense fallback={null}>
+                    <TourRunner />
+                </Suspense>
             </TourProvider>
         </Root>
     );

--- a/src/layout/MainLayout/index.jsx
+++ b/src/layout/MainLayout/index.jsx
@@ -19,6 +19,8 @@ import navigation from '../../menu-items';
 import { drawerWidth } from '../../store/constant';
 import { SET_MENU } from '../../store/actions';
 import { SidebarProvider } from './Sidebar/SidebarContext';
+import { TourProvider } from '../../ui-component/tour/TourContext';
+import TourRunner from '../../ui-component/tour/TourRunner';
 
 // assets
 import { IconChevronRight } from '@tabler/icons-react';
@@ -121,41 +123,45 @@ function MainLayout() {
                 }
             ])}
         >
-            <SidebarProvider data={sidebarContent} setData={setSidebarContent}>
-                <CssBaseline />
-                {/* header */}
-                <AppBar
-                    enableColorOnDark
-                    position="fixed"
-                    color="inherit"
-                    elevation={0}
-                    className={leftDrawerOpened ? classes.appBarWidth : classes.appBar}
-                >
-                    <Toolbar>
-                        <Header handleLeftDrawerToggle={handleLeftDrawerToggle} />
-                    </Toolbar>
-                </AppBar>
+            <TourProvider>
+                <SidebarProvider data={sidebarContent} setData={setSidebarContent}>
+                    <CssBaseline />
+                    {/* header */}
+                    <AppBar
+                        enableColorOnDark
+                        position="fixed"
+                        color="inherit"
+                        elevation={0}
+                        className={leftDrawerOpened ? classes.appBarWidth : classes.appBar}
+                    >
+                        <Toolbar>
+                            <Header handleLeftDrawerToggle={handleLeftDrawerToggle} />
+                        </Toolbar>
+                    </AppBar>
 
-                {/* drawer */}
-                <Sidebar useFullScreen={!matchDownMd} drawerOpen={leftDrawerOpened} drawerToggle={handleLeftDrawerToggle} />
+                    {/* drawer */}
+                    <Sidebar useFullScreen={!matchDownMd} drawerOpen={leftDrawerOpened} drawerToggle={handleLeftDrawerToggle} />
 
-                {/* main content */}
-                <main
-                    className={clsx([
-                        classes.content,
-                        {
-                            [classes.contentShift]: leftDrawerOpened
-                        }
-                    ])}
-                >
-                    {/* breadcrumb */}
-                    <Breadcrumbs separator={IconChevronRight} navigation={navigation} icon title rightAlign />
-                    <Outlet />
-                </main>
+                    {/* main content */}
+                    <main
+                        className={clsx([
+                            classes.content,
+                            {
+                                [classes.contentShift]: leftDrawerOpened
+                            }
+                        ])}
+                    >
+                        {/* breadcrumb */}
+                        <Breadcrumbs separator={IconChevronRight} navigation={navigation} icon title rightAlign />
+                        <Outlet />
+                    </main>
 
-                {/* FOOTER */}
-                <Footer className={leftDrawerOpened ? classes.footerWidth : classes.footer} />
-            </SidebarProvider>
+                    {/* FOOTER */}
+                    <Footer className={leftDrawerOpened ? classes.footerWidth : classes.footer} />
+                </SidebarProvider>
+                {/* Guided tour overlay (driven from the header "Take a tour" button and the patient page) */}
+                <TourRunner />
+            </TourProvider>
         </Root>
     );
 }

--- a/src/ui-component/tour/TourContext.jsx
+++ b/src/ui-component/tour/TourContext.jsx
@@ -1,0 +1,48 @@
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import searchTourSteps from './searchTourSteps';
+
+// Holds the state of the in-browser guided tour so that a single <Joyride>
+// (mounted in MainLayout) can be driven from anywhere in the app — e.g. the
+// header's "Take a tour" button (search page) or the patient page.
+
+const TourContext = createContext(null);
+
+export function TourProvider({ children }) {
+    const [run, setRun] = useState(false);
+    const [stepIndex, setStepIndex] = useState(0);
+    const [steps, setSteps] = useState([]);
+
+    const startTour = useCallback((tourSteps = searchTourSteps) => {
+        setSteps(tourSteps);
+        setStepIndex(0);
+        setRun(true);
+    }, []);
+
+    const stopTour = useCallback(() => {
+        setRun(false);
+        setStepIndex(0);
+    }, []);
+
+    const value = useMemo(
+        () => ({ run, steps, stepIndex, setStepIndex, startTour, stopTour }),
+        [run, steps, stepIndex, startTour, stopTour]
+    );
+
+    return <TourContext.Provider value={value}>{children}</TourContext.Provider>;
+}
+
+TourProvider.propTypes = {
+    children: PropTypes.node
+};
+
+export function useTour() {
+    const context = useContext(TourContext);
+    if (!context) {
+        throw new Error('useTour must be used within a TourProvider');
+    }
+    return context;
+}
+
+export default TourContext;

--- a/src/ui-component/tour/TourRunner.jsx
+++ b/src/ui-component/tour/TourRunner.jsx
@@ -1,0 +1,79 @@
+import Joyride, { ACTIONS, EVENTS, STATUS } from 'react-joyride';
+import { useTheme } from '@mui/system';
+
+import { useTour } from './TourContext';
+
+// Expand/collapse the first node's per-program breakdown to demonstrate it during
+// the tour. The expand button toggles between an UnfoldMore icon (collapsed) and
+// an UnfoldLess icon (expanded), so we only click when a change is actually needed
+// — keeping this idempotent across Next/Back navigation.
+function setNodeExpanded(shouldExpand) {
+    const button = document.querySelector('[data-tour="results-expand-node"]');
+    if (!button) return;
+    const isCollapsed = !!button.querySelector('[data-testid="UnfoldMoreIcon"]');
+    if (shouldExpand && isCollapsed) {
+        button.click();
+    } else if (!shouldExpand && !isCollapsed) {
+        button.click();
+    }
+}
+
+// Single controlled <Joyride> instance for the whole app. Reads its run state
+// from TourContext so it can render over whichever page the tour targets.
+
+function TourRunner() {
+    const theme = useTheme();
+    const { run, steps, stepIndex, setStepIndex, stopTour } = useTour();
+
+    const handleCallback = (data) => {
+        const { action, index, status, step, type } = data;
+
+        if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status)) {
+            // Leave nothing expanded behind us. Tours run in place, so there's
+            // nothing to navigate to on finish/skip.
+            setNodeExpanded(false);
+            stopTour();
+            return;
+        }
+
+        // Demonstrate the per-program breakdown: expand as the step opens...
+        if (type === EVENTS.STEP_BEFORE && step?.expandDemo) {
+            setNodeExpanded(true);
+        }
+
+        if ([EVENTS.STEP_AFTER, EVENTS.TARGET_NOT_FOUND].includes(type)) {
+            // ...and collapse it again once we move on.
+            if (step?.expandDemo) {
+                setNodeExpanded(false);
+            }
+            // Advance (or go back) once the current step is done.
+            setStepIndex(index + (action === ACTIONS.PREV ? -1 : 1));
+        }
+    };
+
+    return (
+        <Joyride
+            run={run}
+            steps={steps}
+            stepIndex={stepIndex}
+            continuous
+            showProgress
+            showSkipButton
+            scrollToFirstStep
+            // The search page has a fixed global header + a sticky page AppBar
+            // (~200px). Offset scrolling so highlighted sections land below them
+            // instead of behind the header.
+            scrollOffset={200}
+            callback={handleCallback}
+            locale={{ last: 'Finish' }}
+            styles={{
+                options: {
+                    primaryColor: theme.palette.primary.main,
+                    zIndex: 10000
+                }
+            }}
+        />
+    );
+}
+
+export default TourRunner;

--- a/src/ui-component/tour/TourRunner.jsx
+++ b/src/ui-component/tour/TourRunner.jsx
@@ -87,6 +87,19 @@ function TourRunner() {
                 options: {
                     primaryColor: theme.palette.primary.main,
                     zIndex: 10000
+                },
+                // Keep the whole tooltip within the viewport on short/small screens
+                // so the footer (Back / Next / Finish) is always reachable...
+                tooltip: {
+                    maxWidth: 'min(90vw, 380px)',
+                    maxHeight: '85vh',
+                    display: 'flex',
+                    flexDirection: 'column'
+                },
+                // ...and let only the body scroll when the content is tall, rather
+                // than pushing the footer buttons off-screen.
+                tooltipContent: {
+                    overflowY: 'auto'
                 }
             }}
         />

--- a/src/ui-component/tour/TourRunner.jsx
+++ b/src/ui-component/tour/TourRunner.jsx
@@ -23,6 +23,26 @@ function setNodeExpanded(shouldExpand) {
     }
 }
 
+// The sidebar lives in a fixed MUI Drawer that scrolls via react-perfect-scrollbar
+// (overflow: hidden), which Joyride's auto-scroll doesn't recognize — so lower
+// sections (genomic / clinical filters) stay below the drawer's fold and Joyride
+// anchors the tooltip off-screen. For any step whose target is inside the
+// scrollbar container, scroll that container so the target sits near the top of
+// the drawer before Joyride positions the tooltip.
+function scrollSidebarTargetIntoView(step) {
+    const selector = typeof step?.target === 'string' ? step.target : null;
+    if (!selector) return;
+    const target = document.querySelector(selector);
+    if (!target) return;
+    // react-perfect-scrollbar renders `<div class="scrollbar-container ...">`.
+    const scrollParent = target.closest('.scrollbar-container');
+    if (!scrollParent) return; // not a sidebar step — Joyride handles page scroll.
+    const parentTop = scrollParent.getBoundingClientRect().top;
+    const targetTop = target.getBoundingClientRect().top;
+    // Leave a small gap above the target so it isn't flush against the drawer edge.
+    scrollParent.scrollTop += targetTop - parentTop - 12;
+}
+
 // Single controlled <Joyride> instance for the whole app. Reads its run state
 // from TourContext so it can render over whichever page the tour targets.
 
@@ -54,6 +74,12 @@ function TourRunner() {
             setNodeExpanded(false);
             stopTour();
             return;
+        }
+
+        // Before a step opens, make sure a sidebar target is scrolled into the
+        // visible part of the drawer so its tooltip lands on screen.
+        if (type === EVENTS.STEP_BEFORE) {
+            scrollSidebarTargetIntoView(step);
         }
 
         // Demonstrate the per-program breakdown: expand as the step opens...
@@ -92,14 +118,16 @@ function TourRunner() {
                 // so the footer (Back / Next / Finish) is always reachable...
                 tooltip: {
                     maxWidth: 'min(90vw, 380px)',
-                    maxHeight: '85vh',
+                    maxHeight: '80vh',
                     display: 'flex',
                     flexDirection: 'column'
                 },
-                // ...and let only the body scroll when the content is tall, rather
-                // than pushing the footer buttons off-screen.
-                tooltipContent: {
-                    overflowY: 'auto'
+                // ...and let the title+body region scroll when the content is tall
+                // rather than pushing the footer buttons off-screen. `minHeight: 0`
+                // is required for a flex child to shrink below its content size.
+                tooltipContainer: {
+                    overflowY: 'auto',
+                    minHeight: 0
                 }
             }}
         />

--- a/src/ui-component/tour/TourRunner.jsx
+++ b/src/ui-component/tour/TourRunner.jsx
@@ -46,9 +46,11 @@ function TourRunner() {
     const handleCallback = (data) => {
         const { action, index, status, step, type } = data;
 
-        if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status)) {
+        // Clicking the close (X) button ends the tour — the user has opted out,
+        // so don't advance to the next step (which would render its beacon).
+        if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status) || action === ACTIONS.CLOSE) {
             // Leave nothing expanded behind us. Tours run in place, so there's
-            // nothing to navigate to on finish/skip.
+            // nothing to navigate to on finish/skip/close.
             setNodeExpanded(false);
             stopTour();
             return;

--- a/src/ui-component/tour/TourRunner.jsx
+++ b/src/ui-component/tour/TourRunner.jsx
@@ -1,19 +1,24 @@
+import { useEffect } from 'react';
 import Joyride, { ACTIONS, EVENTS, STATUS } from 'react-joyride';
+import { useLocation } from 'react-router-dom';
 import { useTheme } from '@mui/system';
 
 import { useTour } from './TourContext';
 
+// The search page has a fixed global header + a sticky page AppBar (~200px tall).
+// Offset Joyride's scrolling so highlighted sections land below them rather than
+// behind the header.
+const HEADER_SCROLL_OFFSET = 200;
+
 // Expand/collapse the first node's per-program breakdown to demonstrate it during
-// the tour. The expand button toggles between an UnfoldMore icon (collapsed) and
-// an UnfoldLess icon (expanded), so we only click when a change is actually needed
-// — keeping this idempotent across Next/Back navigation.
+// the tour. The button exposes its state via data-expanded (set in
+// patientCountSingle.jsx), so we only click when a change is actually needed —
+// keeping this idempotent across Next/Back navigation.
 function setNodeExpanded(shouldExpand) {
     const button = document.querySelector('[data-tour="results-expand-node"]');
     if (!button) return;
-    const isCollapsed = !!button.querySelector('[data-testid="UnfoldMoreIcon"]');
-    if (shouldExpand && isCollapsed) {
-        button.click();
-    } else if (!shouldExpand && !isCollapsed) {
+    const isExpanded = button.dataset.expanded === 'true';
+    if (shouldExpand !== isExpanded) {
         button.click();
     }
 }
@@ -23,7 +28,20 @@ function setNodeExpanded(shouldExpand) {
 
 function TourRunner() {
     const theme = useTheme();
+    const location = useLocation();
     const { run, steps, stepIndex, setStepIndex, stopTour } = useTour();
+
+    // If the user navigates to another page mid-tour, end it — its targets are
+    // gone, so continuing would just skip through the remaining steps.
+    useEffect(() => {
+        if (run) {
+            setNodeExpanded(false);
+            stopTour();
+        }
+        // Only react to path changes; including `run` would stop the tour the
+        // instant it starts.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [location.pathname]);
 
     const handleCallback = (data) => {
         const { action, index, status, step, type } = data;
@@ -60,10 +78,7 @@ function TourRunner() {
             showProgress
             showSkipButton
             scrollToFirstStep
-            // The search page has a fixed global header + a sticky page AppBar
-            // (~200px). Offset scrolling so highlighted sections land below them
-            // instead of behind the header.
-            scrollOffset={200}
+            scrollOffset={HEADER_SCROLL_OFFSET}
             callback={handleCallback}
             locale={{ last: 'Finish' }}
             styles={{

--- a/src/ui-component/tour/patientTourSteps.jsx
+++ b/src/ui-component/tour/patientTourSteps.jsx
@@ -1,0 +1,51 @@
+// Step definitions for the guided tour of the patient information page.
+// Targets are matched by the `data-tour` attributes in
+// src/views/clinicalGenomic/clinicalPatientView.jsx. This tour runs in place on
+// the patient page (it sets no endRoute), so finishing leaves the user there.
+
+const patientTourSteps = [
+    {
+        target: 'body',
+        placement: 'center',
+        disableBeacon: true,
+        title: 'The patient information page',
+        content:
+            'This page shows a single patient’s full record. Here’s a quick tour of what you’ll find. Use Next and Back to move through it, or Skip to exit.'
+    },
+    {
+        target: '[data-tour="patient-info"]',
+        placement: 'bottom',
+        disableBeacon: true,
+        title: 'Donor summary',
+        content: 'Key details about the donor — program, sex at birth, age at first diagnosis, and other top-level attributes.'
+    },
+    {
+        target: '[data-tour="patient-sidebar"]',
+        placement: 'right',
+        title: 'Browse clinical categories',
+        content:
+            'Use these folders to move between clinical categories — primary diagnoses, treatments, specimens, follow-ups and more. Selecting one shows its details in the table.'
+    },
+    {
+        target: '[data-tour="patient-clinical"]',
+        placement: 'top',
+        title: 'Clinical data table',
+        content: 'The records for the selected category, one row per entry.'
+    },
+    {
+        target: '[data-tour="patient-timeline"]',
+        placement: 'top',
+        title: 'Patient timeline',
+        content:
+            'A timeline of the donor’s diagnosis, treatments and follow-ups. The timeline can be zoomed in and out to focus on different time periods. The list of treatments can be expanded and clicking on an event will show its details in the table above.'
+    },
+    {
+        target: '[data-tour="patient-genomic"]',
+        placement: 'top',
+        title: 'Genomic data',
+        content:
+            'Any genomic samples associated with this donor — sample and experiment IDs, variant counts, and links to the associated files.'
+    }
+];
+
+export default patientTourSteps;

--- a/src/ui-component/tour/searchTourSteps.jsx
+++ b/src/ui-component/tour/searchTourSteps.jsx
@@ -44,7 +44,10 @@ const searchTourSteps = [
     },
     {
         target: '[data-tour="search-genomic"]',
-        placement: 'right',
+        // 'right-start' top-aligns the tooltip to this (tall) section so its footer
+        // stays on screen; plain 'right' would center it and push the footer below
+        // the fold on short viewports.
+        placement: 'right-start',
         title: 'Genomic filters',
         content: (
             <>

--- a/src/ui-component/tour/searchTourSteps.jsx
+++ b/src/ui-component/tour/searchTourSteps.jsx
@@ -40,7 +40,7 @@ const searchTourSteps = [
         placement: 'right',
         title: 'Scope by program',
         content:
-            'Narrow results to particular programs. A locked padlock icon marks programs you are not authorized to see individual-level data for, whereas an unlocked padlock means you have full authorization to see donor-level metadata for all donors in the program.'
+            'Narrow results to particular programs. A locked padlock icon marks programs you are not authorized to see donor-level data for, whereas an unlocked padlock means you have full authorization to see donor-level metadata for all donors in the program.'
     },
     {
         target: '[data-tour="search-genomic"]',
@@ -67,7 +67,8 @@ const searchTourSteps = [
         target: '[data-tour="results-counts"]',
         placement: 'top',
         title: 'Patient counts',
-        content: 'A summary of how many patients match your query, broken down by node across the federated network.'
+        content:
+            'A summary of how many patients match your query, broken down by node across the federated network. If any count is below 10 donors, it will show as <10.'
     },
     {
         target: '[data-tour="results-expand-node"]',
@@ -82,7 +83,8 @@ const searchTourSteps = [
         target: '[data-tour="results-visualization"]',
         placement: 'top',
         title: 'Data visualization',
-        content: 'Charts summarising the matching cohort — for example age distribution, treatment types, and primary sites.'
+        content:
+            'Charts summarising the matching cohort — for example age distribution, treatment types, and primary sites. If any category has less than 10 donors, the chart is censored for that category.'
     },
     {
         target: '[data-tour="results-matching"]',
@@ -98,13 +100,6 @@ const searchTourSteps = [
         title: 'Opening a patient',
         content:
             'Click any patient row like this one to open their full clinical and genomic record in a new tab. A short tour of that page starts automatically the first time you open it.'
-    },
-    {
-        target: '[data-tour="results-counts"]',
-        placement: 'top',
-        title: 'A note on small counts',
-        content:
-            'To protect privacy, small counts are censored. A value shown as "<10" means the true count is below the reporting threshold.'
     }
 ];
 

--- a/src/ui-component/tour/searchTourSteps.jsx
+++ b/src/ui-component/tour/searchTourSteps.jsx
@@ -1,0 +1,111 @@
+// Step definitions for the guided "CanDIG Clinical & Genomic Search" tour.
+// Targets are matched by the `data-tour` attributes added to the search page
+// (src/views/clinicalGenomic/clinicalGenomicSearch.jsx) and its sidebar
+// (src/views/clinicalGenomic/widgets/sidebar.jsx).
+
+// Genomic-filters documentation (opens in a new tab from the Genomic filters step).
+const GENOMIC_DOCS_URL = 'https://candig.github.io/candigv2-docs/explore/clinical-genomic-search/#variant-search';
+
+const searchTourSteps = [
+    {
+        target: 'body',
+        placement: 'center',
+        disableBeacon: true,
+        title: "Welcome to CanDIG's Clinical & Genomic search page!",
+        content:
+            'This short tour shows you how to search across the federated network and how to read the results. Use Next and Back to move through it, or Skip to exit at any time.'
+    },
+    {
+        target: '[data-tour="search-sidebar"]',
+        placement: 'right',
+        disableBeacon: true,
+        title: 'Build your search here',
+        content:
+            'The left sidebar is where you build a query. Choose clinical and genomic filters, then run the search — results update in the main panel on the right after you hit the search button.'
+    },
+    {
+        target: '[data-tour="search-tabs"]',
+        placement: 'right',
+        title: 'Filter categories',
+        content: 'Switch between All, Clinical, and Genomic to focus the filters shown below.'
+    },
+    {
+        target: '[data-tour="search-nodes"]',
+        placement: 'right',
+        title: 'Scope by node',
+        content: 'Limit the search to specific federated sites (nodes). Leave everything selected to search the entire network.'
+    },
+    {
+        target: '[data-tour="search-programs"]',
+        placement: 'right',
+        title: 'Scope by program',
+        content:
+            'Narrow results to particular programs. A locked padlock icon marks programs you are not authorized to see individual-level data for, whereas an unlocked padlock means you have full authorization to see donor-level metadata for all donors in the program.'
+    },
+    {
+        target: '[data-tour="search-genomic"]',
+        placement: 'right',
+        title: 'Genomic filters',
+        content: (
+            <>
+                Search by gene, or by a chromosome position range, and restrict to genomic data types (variants, transcriptomes, reads). You
+                can filter by one gene or one position range at a time.{' '}
+                <a href={GENOMIC_DOCS_URL} target="_blank" rel="noopener noreferrer">
+                    Learn more about genomic filters
+                </a>
+                .
+            </>
+        )
+    },
+    {
+        target: '[data-tour="search-run"]',
+        placement: 'right',
+        title: 'Run the search',
+        content: 'When your filters are set, press Search to query the network. Use Reset to clear all filters and start over.'
+    },
+    {
+        target: '[data-tour="results-counts"]',
+        placement: 'top',
+        title: 'Patient counts',
+        content: 'A summary of how many patients match your query, broken down by node across the federated network.'
+    },
+    {
+        target: '[data-tour="results-expand-node"]',
+        placement: 'left',
+        title: 'Counts per program',
+        // expandDemo: TourRunner expands this node while the step is shown, then
+        // collapses it again when the tour moves on.
+        expandDemo: true,
+        content: 'Nodes hosting more than one program show an expand button. Expanding breaks that node’s donor counts down by program.'
+    },
+    {
+        target: '[data-tour="results-visualization"]',
+        placement: 'top',
+        title: 'Data visualization',
+        content: 'Charts summarising the matching cohort — for example age distribution, treatment types, and primary sites.'
+    },
+    {
+        target: '[data-tour="results-matching"]',
+        placement: 'top',
+        title: 'Matching patients',
+        content: 'The list of patients matching the given query.'
+    },
+    {
+        // Highlight the first data row of the Matching Patients table (a MUI
+        // DataGrid renders each row as a .MuiDataGrid-row element).
+        target: '[data-tour="results-matching"] .MuiDataGrid-row',
+        placement: 'bottom',
+        title: 'Opening a patient',
+        content:
+            'Click any patient row like this one to open their full clinical and genomic record in a new tab. A short tour of that page starts automatically the first time you open it.'
+    },
+    {
+        target: '[data-tour="results-counts"]',
+        placement: 'top',
+        title: 'A note on small counts',
+        content:
+            'To protect privacy, small counts are censored. A value shown as "<10" means the true count is below the reporting threshold.'
+    }
+];
+
+export default searchTourSteps;

--- a/src/ui-component/tour/waitForElement.js
+++ b/src/ui-component/tour/waitForElement.js
@@ -1,0 +1,20 @@
+// Poll for a selector to appear in the DOM (up to `timeout` ms) before resolving.
+// The tour navigates between lazy-loaded routes whose targets (and, for the
+// sidebar, a drawer) aren't in the DOM immediately — this lets callers wait for
+// a target to exist before starting/resuming Joyride. Resolves true if found,
+// false on timeout (callers proceed either way so the tour degrades gracefully).
+export default function waitForElement(selector, timeout = 6000, interval = 100) {
+    return new Promise((resolve) => {
+        const startedAt = Date.now();
+        const check = () => {
+            if (document.querySelector(selector)) {
+                resolve(true);
+            } else if (Date.now() - startedAt > timeout) {
+                resolve(false);
+            } else {
+                setTimeout(check, interval);
+            }
+        };
+        check();
+    });
+}

--- a/src/views/clinicalGenomic/clinicalGenomicSearch.jsx
+++ b/src/views/clinicalGenomic/clinicalGenomicSearch.jsx
@@ -93,6 +93,13 @@ const StyledMainCard = styled(MainCard)((_) => ({
     position: 'relative'
 }));
 
+// Maps section ids to the guided-tour target names (see searchTourSteps.js).
+const sectionTourTargets = {
+    counts: 'results-counts',
+    visualization: 'results-visualization',
+    'Matching Patients': 'results-matching'
+};
+
 const sections = [
     {
         id: 'Programs summary',
@@ -170,7 +177,7 @@ function ClinicalGenomicSearch() {
                 <SearchHandler setLoading={setLoading} />
                 <MainCard sx={{ minHeight: 830, position: 'relative', borderRadius: customization.borderRadius * 0.25, marginTop: '2.5em' }}>
                     {sections.map((section) => (
-                        <div key={section.id}>
+                        <div key={section.id} data-tour={sectionTourTargets[section.id]}>
                             <a id={section.id} className={classes.anchor} aria-hidden="true" href={`#${section.id}`}>
                                 &nbsp;
                             </a>

--- a/src/views/clinicalGenomic/clinicalPatientView.jsx
+++ b/src/views/clinicalGenomic/clinicalPatientView.jsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react';
 import { styled } from '@mui/system';
-import { Box, Typography } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 import Alert from '@mui/material/Alert';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
+import { IconPlayerPlay } from '@tabler/icons-react';
 
 import MainCard from '../../ui-component/cards/MainCard';
 import useClinicalPatientData from './useClinicalPatientData';
@@ -11,6 +12,13 @@ import { formatKey, handleTableSet } from '../../utils/utils';
 import Timeline from './widgets/timeline';
 import { query } from '../../store/api';
 import DefaultErrorBoundary from '../../ui-component/DefaultErrorBoundary';
+import { SET_MENU } from '../../store/actions';
+import { useTour } from '../../ui-component/tour/TourContext';
+import patientTourSteps from '../../ui-component/tour/patientTourSteps';
+import waitForElement from '../../ui-component/tour/waitForElement';
+
+// Only auto-start the patient-page tour the first time (per browser).
+const PATIENT_TOUR_SEEN_KEY = 'candig_patient_tour_seen';
 
 const StyledTopLevelBox = styled(Box)(({ theme }) => ({
     border: `1px solid ${theme.palette.primary.main}`,
@@ -34,6 +42,8 @@ const TimelineContainer = styled(Box)(({ theme }) => ({
 
 function ClinicalPatientView() {
     const { customization } = useSelector((state) => state);
+    const dispatch = useDispatch();
+    const { startTour } = useTour();
     const [patientId, setPatientId] = useState('');
     const [programId, setProgramId] = useState('');
     const [location, setLocation] = useState('');
@@ -59,6 +69,21 @@ function ClinicalPatientView() {
     );
     const ageAtFirstDiagnosis = topLevel.age_at_first_diagnosis;
     const dateOfBirth = data?.date_of_birth;
+
+    // Start the patient-page tour, making sure the folder sidebar is open and the
+    // page has rendered before Joyride looks for its targets.
+    const runPatientTour = () => {
+        dispatch({ type: SET_MENU, opened: true });
+        waitForElement('[data-tour="patient-info"]').then(() => startTour(patientTourSteps));
+    };
+
+    // Auto-start the tour the first time a patient page is opened (per browser).
+    useEffect(() => {
+        if (localStorage.getItem(PATIENT_TOUR_SEEN_KEY)) return;
+        localStorage.setItem(PATIENT_TOUR_SEEN_KEY, 'true');
+        runPatientTour();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const handleEventClick = (category, array) => {
         const { titleClick, reorderedColumns, rowsClick } = handleTableSet(category[0], array, ageAtFirstDiagnosis);
@@ -117,13 +142,18 @@ function ClinicalPatientView() {
                         </Alert>
                     </div>
                 )}
-                <Typography pb={1} variant="h5" style={{ fontWeight: 'bold' }}>
-                    {title}
-                </Typography>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                    <Typography pb={1} variant="h5" style={{ fontWeight: 'bold' }}>
+                        {title}
+                    </Typography>
+                    <Button size="small" startIcon={<IconPlayerPlay size={18} />} onClick={runPatientTour}>
+                        Take a tour
+                    </Button>
+                </Box>
                 <Typography pb={1} variant="h6">
                     {patientId}
                 </Typography>
-                <StyledTopLevelBox>
+                <StyledTopLevelBox data-tour="patient-info">
                     {Object.entries(topLevel).map(([key, value]) => (
                         <div
                             key={key}
@@ -138,7 +168,7 @@ function ClinicalPatientView() {
                         </div>
                     ))}
                 </StyledTopLevelBox>
-                <div style={{ width: '100%' }}>
+                <div style={{ width: '100%' }} data-tour="patient-clinical">
                     <DataGrid
                         sx={{ minHeight: '30vh', maxHeight: '68vh' }}
                         rows={rows}
@@ -154,7 +184,7 @@ function ClinicalPatientView() {
                             Genomic Data
                         </Typography>
 
-                        <div style={{ width: '100%' }}>
+                        <div style={{ width: '100%' }} data-tour="patient-genomic">
                             <DataGrid
                                 sx={{ minHeight: '20vh', marginBottom: '2em' }}
                                 rows={genomicRows}
@@ -167,7 +197,7 @@ function ClinicalPatientView() {
                     </>
                 )}
                 {dateOfBirth && (
-                    <TimelineContainer>
+                    <TimelineContainer data-tour="patient-timeline">
                         <Timeline data={data} onEventClick={handleEventClick} />
                     </TimelineContainer>
                 )}

--- a/src/views/clinicalGenomic/clinicalPatientView.jsx
+++ b/src/views/clinicalGenomic/clinicalPatientView.jsx
@@ -71,17 +71,24 @@ function ClinicalPatientView() {
     const dateOfBirth = data?.date_of_birth;
 
     // Start the patient-page tour, making sure the folder sidebar is open and the
-    // page has rendered before Joyride looks for its targets.
+    // page has rendered before Joyride looks for its targets. Resolves true if the
+    // tour actually started (its first target appeared), false otherwise.
     const runPatientTour = () => {
         dispatch({ type: SET_MENU, opened: true });
-        waitForElement('[data-tour="patient-info"]').then(() => startTour(patientTourSteps));
+        return waitForElement('[data-tour="patient-info"]').then((found) => {
+            if (found) startTour(patientTourSteps);
+            return found;
+        });
     };
 
     // Auto-start the tour the first time a patient page is opened (per browser).
+    // Only record it as "seen" once it has actually started, so a page that never
+    // renders (e.g. a failed load) doesn't permanently suppress the auto-tour.
     useEffect(() => {
         if (localStorage.getItem(PATIENT_TOUR_SEEN_KEY)) return;
-        localStorage.setItem(PATIENT_TOUR_SEEN_KEY, 'true');
-        runPatientTour();
+        runPatientTour().then((started) => {
+            if (started) localStorage.setItem(PATIENT_TOUR_SEEN_KEY, 'true');
+        });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 

--- a/src/views/clinicalGenomic/widgets/patientCountSingle.jsx
+++ b/src/views/clinicalGenomic/widgets/patientCountSingle.jsx
@@ -154,6 +154,7 @@ function PatientCountSingle(props) {
                 <Grid item className={classes.button} pr={-2}>
                     {numPrograms > 1 ? (
                         <Button
+                            data-tour="results-expand-node"
                             onClick={(_) => setExpanded((old) => !old)}
                             variant="contained"
                             sx={{

--- a/src/views/clinicalGenomic/widgets/patientCountSingle.jsx
+++ b/src/views/clinicalGenomic/widgets/patientCountSingle.jsx
@@ -155,6 +155,7 @@ function PatientCountSingle(props) {
                     {numPrograms > 1 ? (
                         <Button
                             data-tour="results-expand-node"
+                            data-expanded={expanded ? 'true' : 'false'}
                             onClick={(_) => setExpanded((old) => !old)}
                             variant="contained"
                             sx={{

--- a/src/views/clinicalGenomic/widgets/patientSidebar.jsx
+++ b/src/views/clinicalGenomic/widgets/patientSidebar.jsx
@@ -342,7 +342,11 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtFirs
         return sidebarTitles;
     }
 
-    return <div style={{ marginTop: 12 }}>{createMainSidebarHeaders(sidebar)}</div>;
+    return (
+        <div style={{ marginTop: 12 }} data-tour="patient-sidebar">
+            {createMainSidebarHeaders(sidebar)}
+        </div>
+    );
 }
 
 PatientSidebar.propTypes = {

--- a/src/views/clinicalGenomic/widgets/sidebar.jsx
+++ b/src/views/clinicalGenomic/widgets/sidebar.jsx
@@ -809,8 +809,8 @@ function Sidebar() {
     const hideClinical = selectedtab !== 'All' && selectedtab !== 'Clinical';
 
     return (
-        <Root>
-            <Tabs value={selectedtab} onChange={(_, value) => setSelectedTab(value)}>
+        <Root data-tour="search-sidebar">
+            <Tabs data-tour="search-tabs" value={selectedtab} onChange={(_, value) => setSelectedTab(value)}>
                 <Tab className={classes.tab} value="All" label="All" />
                 <Tab className={classes.tab} value="Clinical" label="Clinical" />
                 <Tab className={classes.tab} value="Genomic" label="Genomic" />
@@ -819,61 +819,67 @@ function Sidebar() {
                 <Button className={classes.button} onClick={() => resetButton()}>
                     Reset
                 </Button>
-                <Button className={classes.button} onClick={triggerSearch}>
+                <Button data-tour="search-run" className={classes.button} onClick={triggerSearch}>
                     Search
                 </Button>
             </div>
-            <SidebarGroup name="Nodes">
-                <StyledCheckboxList
-                    options={sites}
+            <div data-tour="search-nodes">
+                <SidebarGroup name="Nodes">
+                    <StyledCheckboxList
+                        options={sites}
+                        onWrite={writerContext}
+                        groupName="node"
+                        useAutoComplete={sites.length >= 5}
+                        isFilterList
+                        isExclusion
+                        selectedPrograms={selectedPrograms}
+                        setSelectedPrograms={setSelectedPrograms}
+                        checked={selectedNodes}
+                        setChecked={setSelectedNodes}
+                        optionStatusMap={nodeStatusMap}
+                    />
+                </SidebarGroup>
+            </div>
+            <div data-tour="search-programs">
+                <SidebarGroup name="Programs">
+                    <StyledCheckboxList
+                        options={programs}
+                        authorizedPrograms={authorizedPrograms}
+                        onWrite={writerContext}
+                        groupName="exclude_programs"
+                        useAutoComplete={programs.length >= 5}
+                        isExclusion
+                        checked={selectedPrograms}
+                        setChecked={setSelectedPrograms}
+                    />
+                    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+                        <Button className={classes.button} onClick={() => setPrograms(programs)}>
+                            Deselect&nbsp;all
+                        </Button>
+                        <Button className={classes.button} onClick={() => setPrograms([])}>
+                            Reset
+                        </Button>
+                    </div>
+                </SidebarGroup>
+            </div>
+            <div data-tour="search-genomic">
+                <GenomicsGroup
+                    chromosomes={chromosomes}
+                    genes={genes}
                     onWrite={writerContext}
-                    groupName="node"
-                    useAutoComplete={sites.length >= 5}
-                    isFilterList
-                    isExclusion
-                    selectedPrograms={selectedPrograms}
-                    setSelectedPrograms={setSelectedPrograms}
-                    checked={selectedNodes}
-                    setChecked={setSelectedNodes}
-                    optionStatusMap={nodeStatusMap}
+                    hide={hideGenomic}
+                    selectedChromosomes={selectedChromosomes}
+                    selectedGenes={selectedGenes}
+                    startPos={startPos}
+                    endPos={endPos}
+                    setSelectedChromosomes={setSelectedChromosomes}
+                    setSelectedGenes={setSelectedGenes}
+                    setStartPos={setStartPos}
+                    setEndPos={setEndPos}
+                    setGenomicDataTypes={setGenomicDataTypes}
+                    selectedGenomicDataTypes={selectedGenomicDataTypes}
                 />
-            </SidebarGroup>
-            <SidebarGroup name="Programs">
-                <StyledCheckboxList
-                    options={programs}
-                    authorizedPrograms={authorizedPrograms}
-                    onWrite={writerContext}
-                    groupName="exclude_programs"
-                    useAutoComplete={programs.length >= 5}
-                    isExclusion
-                    checked={selectedPrograms}
-                    setChecked={setSelectedPrograms}
-                />
-                <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-                    <Button className={classes.button} onClick={() => setPrograms(programs)}>
-                        Deselect&nbsp;all
-                    </Button>
-                    <Button className={classes.button} onClick={() => setPrograms([])}>
-                        Reset
-                    </Button>
-                </div>
-            </SidebarGroup>
-            <GenomicsGroup
-                chromosomes={chromosomes}
-                genes={genes}
-                onWrite={writerContext}
-                hide={hideGenomic}
-                selectedChromosomes={selectedChromosomes}
-                selectedGenes={selectedGenes}
-                startPos={startPos}
-                endPos={endPos}
-                setSelectedChromosomes={setSelectedChromosomes}
-                setSelectedGenes={setSelectedGenes}
-                setStartPos={setStartPos}
-                setEndPos={setEndPos}
-                setGenomicDataTypes={setGenomicDataTypes}
-                selectedGenomicDataTypes={selectedGenomicDataTypes}
-            />
+            </div>
             <SidebarGroup name="Treatments" hide={hideClinical}>
                 <StyledCheckboxList
                     options={treatmentTypes}

--- a/src/views/clinicalGenomic/widgets/sidebar.jsx
+++ b/src/views/clinicalGenomic/widgets/sidebar.jsx
@@ -890,39 +890,41 @@ function Sidebar() {
                     selectedGenomicDataTypes={selectedGenomicDataTypes}
                 />
             </div>
-            <SidebarGroup name="Treatments" hide={hideClinical}>
-                <StyledCheckboxList
-                    options={treatmentTypes}
-                    onWrite={writerContext}
-                    groupName="treatment"
-                    useAutoComplete={treatmentTypes.length >= 5}
-                    hide={hideClinical}
-                    checked={selectedTreatment}
-                    setChecked={setSelectedTreatment}
-                />
-            </SidebarGroup>
-            <SidebarGroup name="Tumour Primary Sites" hide={hideClinical}>
-                <StyledCheckboxList
-                    options={tumourPrimarySites}
-                    onWrite={writerContext}
-                    groupName="primary_site"
-                    useAutoComplete={tumourPrimarySites.length >= 5}
-                    hide={hideClinical}
-                    checked={selectedPrimarySite}
-                    setChecked={setSelectedPrimarySite}
-                />
-            </SidebarGroup>
-            <SidebarGroup name="Systemic Therapy Drug Names" hide={hideClinical}>
-                <StyledCheckboxList
-                    options={systemicTherapyDrugNames}
-                    onWrite={writerContext}
-                    groupName="drug_name"
-                    useAutoComplete={systemicTherapyDrugNames.length >= 5}
-                    hide={hideClinical}
-                    checked={selectedSystemicTherapy}
-                    setChecked={setSelectedSystemicTherapy}
-                />
-            </SidebarGroup>
+            <div data-tour="search-clinical">
+                <SidebarGroup name="Treatments" hide={hideClinical}>
+                    <StyledCheckboxList
+                        options={treatmentTypes}
+                        onWrite={writerContext}
+                        groupName="treatment"
+                        useAutoComplete={treatmentTypes.length >= 5}
+                        hide={hideClinical}
+                        checked={selectedTreatment}
+                        setChecked={setSelectedTreatment}
+                    />
+                </SidebarGroup>
+                <SidebarGroup name="Tumour Primary Sites" hide={hideClinical}>
+                    <StyledCheckboxList
+                        options={tumourPrimarySites}
+                        onWrite={writerContext}
+                        groupName="primary_site"
+                        useAutoComplete={tumourPrimarySites.length >= 5}
+                        hide={hideClinical}
+                        checked={selectedPrimarySite}
+                        setChecked={setSelectedPrimarySite}
+                    />
+                </SidebarGroup>
+                <SidebarGroup name="Systemic Therapy Drug Names" hide={hideClinical}>
+                    <StyledCheckboxList
+                        options={systemicTherapyDrugNames}
+                        onWrite={writerContext}
+                        groupName="drug_name"
+                        useAutoComplete={systemicTherapyDrugNames.length >= 5}
+                        hide={hideClinical}
+                        checked={selectedSystemicTherapy}
+                        setChecked={setSelectedSystemicTherapy}
+                    />
+                </SidebarGroup>
+            </div>
         </Root>
     );
 }

--- a/src/views/clinicalGenomic/widgets/sidebar.jsx
+++ b/src/views/clinicalGenomic/widgets/sidebar.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import {
     Chip,
@@ -25,6 +25,7 @@ import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
 
 import { useSearchQueryWriterContext, useSearchResultsReaderContext } from '../SearchResultsContext';
+import { useTour } from '../../../ui-component/tour/TourContext';
 
 const PREFIX = 'Sidebar';
 
@@ -603,6 +604,15 @@ function Sidebar() {
     const [selectedtab, setSelectedTab] = useState('All');
     const readerContext = useSearchResultsReaderContext();
     const writerContext = useSearchQueryWriterContext();
+
+    // When a tour starts, switch to the "All" tab so every filter group (and the
+    // steps that target them) is mounted, regardless of which tab was last active.
+    const { run: tourRunning } = useTour();
+    const prevTourRunning = useRef(false);
+    useEffect(() => {
+        if (tourRunning && !prevTourRunning.current) setSelectedTab('All');
+        prevTourRunning.current = tourRunning;
+    }, [tourRunning]);
 
     // Genomic data
     const [selectedChromosomes, setSelectedChromosomes] = useState('');

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,7 +1,15 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig(() => {
+export default defineConfig(({ mode }) => {
+    const env = loadEnv(mode, process.cwd(), '');
+    // In local dev the portal makes a few same-origin requests (e.g. the gene
+    // autocomplete at /genomics/htsget/v1/genes and the profile /query/whoami)
+    // that are normally routed by the API gateway. Point them at the mock server
+    // (candig-mock-server) so they don't fall through to the SPA index.html and
+    // blow up JSON parsing. Falls back to the documented mock port 4000.
+    const mockTarget = env.VITE_FEDERATION_API_SERVER || 'http://localhost:4000';
+
     return {
         base: '/',
         plugins: [react()],
@@ -13,7 +21,11 @@ export default defineConfig(() => {
             host: '0.0.0.0',
             strictPort: true,
             port: 4173,
-            allowedHosts: true
+            allowedHosts: true,
+            proxy: {
+                '/genomics': { target: mockTarget, changeOrigin: true },
+                '/query/whoami': { target: mockTarget, changeOrigin: true }
+            }
         }
     };
 });

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -3,12 +3,17 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, process.cwd(), '');
-    // In local dev the portal makes a few same-origin requests (e.g. the gene
-    // autocomplete at /genomics/htsget/v1/genes and the profile /query/whoami)
-    // that are normally routed by the API gateway. Point them at the mock server
-    // (candig-mock-server) so they don't fall through to the SPA index.html and
-    // blow up JSON parsing. Falls back to the documented mock port 4000.
+    // In local dev against the mock server (candig-mock-server) the portal makes a
+    // few same-origin requests (e.g. the gene autocomplete at
+    // /genomics/htsget/v1/genes and the profile /query/whoami) that are normally
+    // routed by the API gateway. Proxy them to the mock so they don't fall through
+    // to the SPA index.html and blow up JSON parsing.
+    //
+    // Only enable this when the federation target is a local mock — against a real
+    // backend these paths are served by the gateway, not the federation host, so
+    // proxying them there would misroute the requests.
     const mockTarget = env.VITE_FEDERATION_API_SERVER || 'http://localhost:4000';
+    const useMockProxy = /localhost|127\.0\.0\.1/.test(mockTarget);
 
     return {
         base: '/',
@@ -22,10 +27,12 @@ export default defineConfig(({ mode }) => {
             strictPort: true,
             port: 4173,
             allowedHosts: true,
-            proxy: {
-                '/genomics': { target: mockTarget, changeOrigin: true },
-                '/query/whoami': { target: mockTarget, changeOrigin: true }
-            }
+            proxy: useMockProxy
+                ? {
+                      '/genomics': { target: mockTarget, changeOrigin: true },
+                      '/query/whoami': { target: mockTarget, changeOrigin: true }
+                  }
+                : undefined
         }
     };
 });


### PR DESCRIPTION
## Summary

Adds an in-browser **guided tour** (react-joyride) to the data portal, launched in place — no separate tutorial page.

- **Search tour** — started from a **"Take a tour"** button in the header that only appears on the Clinical & Genomic Search page. Walks through the sidebar filters, the Search button, patient counts (with a live per-program expand demo), data visualization, matching patients (highlighting a specific results row), a genomic-filters docs link, and the small-counts (`<N`) note.
- **Patient-page tour** — auto-starts the first time a patient record is opened (once per browser, via `localStorage`) and can be replayed from a **"Take a tour"** button on the page. Covers the donor summary, the folder sidebar, the clinical data table, the treatment timeline, and the genomic data table.

## Implementation

- New tour plumbing under `src/ui-component/tour/`: `TourContext` (`TourProvider`/`useTour`), a single controlled `TourRunner` mounted once in `MainLayout`, `searchTourSteps` / `patientTourSteps`, and a `waitForElement` helper.
- `data-tour` targets added across the search sidebar, results sections, per-node patient-count rows, and the patient view.
- `TourButton` in the header (search page only).
- Adds the `react-joyride` dependency.

The last commit adds a **dev-only** Vite proxy (`/genomics`, `/query/whoami` → mock server) to support local development against `candig-mock-server`; it only affects `npm start`, not production builds. It's isolated in its own commit so it can be dropped if undesired.

## Testing

- `npm run build` and `npm run lint` pass.
- Verified end-to-end against a local mock server: both tours run, navigation (Next/Back/Skip/Finish) works, the per-program expand demo opens/closes, the results-row highlight lands on a row, and the patient tour auto-starts on first open.

### Testing with the mock server (no full stack needed)

You can exercise both tours locally against the **[CanDIG/candig-mock-server](https://github.com/CanDIG/candig-mock-server)** repo, which serves synthetic data and mocks auth (you're treated as a logged-in, authorized user).

1. **Start the mock server** (in its own terminal):
   ```bash
   git clone https://github.com/CanDIG/candig-mock-server.git
   cd candig-mock-server
   npm install
   npm start          # -> http://localhost:4000
   ```

2. **Point the portal at it.** In the portal, create `.env.development` (it's git-ignored) with **both**:
   ```
   VITE_FEDERATION_API_SERVER=http://localhost:4000
   VITE_INGEST_SERVER=http://localhost:4000
   ```
   The Vite dev proxy added in this PR forwards the portal's same-origin `/genomics` (gene autocomplete) and `/query/whoami` requests to that same target, so no extra config is needed for those.

3. **Run the portal:**
   ```bash
   npm install        # picks up react-joyride
   npm start          # -> http://localhost:4173
   ```

4. **Exercise the tours:**
   - **Search tour** — go to **Clinical & Genomic Search** and click **"Take a tour"** (top-right of the header, shown only on that page).
   - **Patient tour** — open any row in the Matching Patients table. The patient-page tour **auto-starts the first time** (once per browser); replay it with the **"Take a tour"** button on the page. To re-trigger the auto-start, clear the `candig_patient_tour_seen` key in `localStorage`.

> Note: the mock server also populates the sidebar filter options (treatment type, tumour primary site, systemic therapy drug names) from katsu's permissible values, and returns a full nested donor record for the patient view.

## Notes

- No backend/API changes; portal frontend only.
- Because Vite bakes deps at build time, deployed environments need an image rebuild (`make build-candig-data-portal`), not just a restart, to pick up react-joyride.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
