### PR TITLE
Improve node/program filtering UX in clinical search sidebar

### DIFF
--- a/src/views/clinicalGenomic/widgets/searchExplainer.jsx
+++ b/src/views/clinicalGenomic/widgets/searchExplainer.jsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { styled } from '@mui/material/styles';
-import { Box, Chip } from '@mui/material';
+import { Box, Chip, Tooltip } from '@mui/material';
 import { useSearchQueryReaderContext, useSearchResultsWriterContext } from '../SearchResultsContext';
 
 const PREFIX = 'SearchExplainer';
@@ -33,6 +33,11 @@ function SearchExplainer() {
     const query = reader.query;
     const queryChips = [];
 
+    // Once an OR-list gets long (e.g. deselecting a node can exclude dozens of
+    // programs at once), listing every value would overflow the bar. Past this
+    // threshold we collapse to a count and reveal the full list on hover.
+    const COMPACT_THRESHOLD = 3;
+
     // Decompose the query into its roots: what are we searching on?
     if (query !== undefined) {
         const ignoredKeys = ['page', 'page_size']; // These are never included in the explanation
@@ -41,17 +46,35 @@ function SearchExplainer() {
                 const onDelete = () => {
                     writer((old) => ({ ...old, clear: key }));
                 };
-                const splitQuery = query[key].split('|');
-                const newVal = splitQuery.flatMap((value) => [<b key={value}> OR </b>, value]).slice(1);
+                const splitQuery = String(query[key])
+                    .split('|')
+                    .filter((value) => value !== '');
                 const formattedKey = key.replaceAll('_', ' ');
-                newVal.splice(
-                    0,
-                    0,
-                    <span className={`${PREFIX}-chiptext`} key={`${key} span`}>
-                        {formattedKey}:{' '}
-                    </span>
-                );
-                queryChips.push([key, newVal, onDelete]);
+
+                let label;
+                if (splitQuery.length > COMPACT_THRESHOLD) {
+                    // Compact: a count with the full list revealed on hover.
+                    const compactText =
+                        key === 'exclude_programs'
+                            ? `Excluding ${splitQuery.length} programs`
+                            : `${formattedKey}: ${splitQuery.length} selected`;
+                    label = (
+                        <Tooltip title={splitQuery.join(', ')} placement="bottom" arrow>
+                            <span className={`${PREFIX}-chiptext`}>{compactText}</span>
+                        </Tooltip>
+                    );
+                } else {
+                    const newVal = splitQuery.flatMap((value) => [<b key={value}> OR </b>, value]).slice(1);
+                    newVal.splice(
+                        0,
+                        0,
+                        <span className={`${PREFIX}-chiptext`} key={`${key} span`}>
+                            {formattedKey}:{' '}
+                        </span>
+                    );
+                    label = newVal;
+                }
+                queryChips.push([key, label, onDelete]);
             }
         });
     }
@@ -65,31 +88,30 @@ function SearchExplainer() {
         queryChips.push(['all', 'All results', undefined]);
     }
 
-    return useMemo(
-        () => (
-            <Root>
-                <Box className={`${PREFIX}-background`}>
-                    {queryChips
-                        /* NB: FlatMap+slice(1) to insert ANDs between entries */
-                        .flatMap((chip) => [
-                            <span className={`${PREFIX}-bold`} key={`${chip[0]} and`}>
-                                <b>&nbsp;AND&nbsp;</b>
-                            </span>,
-                            <Chip
-                                key={`${chip[0]} chip`}
-                                label={chip[1]}
-                                onDelete={chip[2]}
-                                variant="outlined"
-                                color="primary"
-                                className={`${PREFIX}-chip`}
-                            />
-                        ])
-                        .slice(1)}
-                </Box>
-            </Root>
-        ),
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [reader.reqNum]
+    // NB: intentionally not memoized on reqNum — this bar summarizes the CURRENT
+    // sidebar selection, so it must re-render whenever the query changes (e.g. a
+    // program is deselected), not only when a search is submitted.
+    return (
+        <Root>
+            <Box className={`${PREFIX}-background`}>
+                {queryChips
+                    /* NB: FlatMap+slice(1) to insert ANDs between entries */
+                    .flatMap((chip) => [
+                        <span className={`${PREFIX}-bold`} key={`${chip[0]} and`}>
+                            <b>&nbsp;AND&nbsp;</b>
+                        </span>,
+                        <Chip
+                            key={`${chip[0]} chip`}
+                            label={chip[1]}
+                            onDelete={chip[2]}
+                            variant="outlined"
+                            color="primary"
+                            className={`${PREFIX}-chip`}
+                        />
+                    ])
+                    .slice(1)}
+            </Box>
+        </Root>
     );
 }
 

--- a/src/views/clinicalGenomic/widgets/sidebar.jsx
+++ b/src/views/clinicalGenomic/widgets/sidebar.jsx
@@ -161,15 +161,49 @@ function StyledCheckboxList(props) {
             ids = [ids];
         }
 
-        const cohortMap = {};
-        sites?.forEach((site) => {
-            site?.results?.forEach((result) => {
-                if (!cohortMap[result.program_id]) {
-                    cohortMap[result.program_id] = new Set();
-                }
-                cohortMap[result.program_id].add(site.location.name);
+        // Keep the Programs filter in sync with the Nodes filter. We apply only
+        // the DELTA of nodes whose selection changed: a node just deselected
+        // excludes all its programs, a node just reselected re-includes them.
+        // Programs on nodes that didn't change are left untouched, so manual
+        // per-program (de)selections survive node toggles. `checked` is the OLD
+        // excluded-node set (state before this change); `newExcludedNodeIds` the new.
+        const syncProgramExclusionsWithNodes = (newExcludedNodeIds, retVal) => {
+            const oldExcludedNodes = new Set(Array.isArray(checked) ? checked : Object.keys(checked || {}));
+            const newExcludedNodes = new Set(newExcludedNodeIds);
+
+            const programsByNode = {};
+            sites?.forEach((site) => {
+                const nodeName = site?.location?.name;
+                if (!nodeName) return;
+                programsByNode[nodeName] = (site.results || []).map((result) => result.program_id);
             });
-        });
+
+            const newExcludedPrograms = { ...selectedPrograms };
+            Object.keys(programsByNode).forEach((nodeName) => {
+                const wasExcluded = oldExcludedNodes.has(nodeName);
+                const isExcluded = newExcludedNodes.has(nodeName);
+                if (isExcluded && !wasExcluded) {
+                    // node just deselected -> exclude all of its programs
+                    programsByNode[nodeName].forEach((programId) => {
+                        newExcludedPrograms[programId] = true;
+                    });
+                } else if (!isExcluded && wasExcluded) {
+                    // node just reselected -> re-include all of its programs
+                    programsByNode[nodeName].forEach((programId) => {
+                        delete newExcludedPrograms[programId];
+                    });
+                }
+            });
+
+            setSelectedPrograms(newExcludedPrograms);
+
+            const excludeList = Object.keys(newExcludedPrograms).filter((id) => newExcludedPrograms[id]);
+            if (excludeList.length > 0) {
+                retVal.query.exclude_programs = excludeList.join('|');
+            } else {
+                delete retVal.query.exclude_programs;
+            }
+        };
 
         if (isExclusion ? !isChecked : isChecked) {
             // set local checked state (object shape)
@@ -189,23 +223,9 @@ function StyledCheckboxList(props) {
                     // keep filter entry
                     retVal.filter[groupName] = ids;
 
-                    // special-case node handling from original code
+                    // Keep the Programs filter in sync with node (de)selection.
                     if (groupName === 'node') {
-                        const programIds = sites
-                            .filter((item) => ids.includes(item.location.name))
-                            .flatMap((item) => item.results.map((result) => result.program_id));
-                        const validProgramIds = programIds.filter((programId) => {
-                            const associatedNodes = cohortMap[programId] || new Set();
-                            return Array.from(associatedNodes).every((node) => !(node in checked));
-                        });
-                        retVal.query.exclude_programs = validProgramIds.join('|');
-                        setSelectedPrograms((old) => {
-                            const newPrograms = { ...old };
-                            validProgramIds.forEach((id) => {
-                                newPrograms[id] = true;
-                            });
-                            return newPrograms;
-                        });
+                        syncProgramExclusionsWithNodes(ids, retVal);
                     }
 
                     // if this filter is genomicDataTypes, we also put it into query as a pipe-delimited string
@@ -234,25 +254,9 @@ function StyledCheckboxList(props) {
                     newList[groupName] = ids;
                     retVal.filter = newList;
 
+                    // Keep the Programs filter in sync with node (de)selection.
                     if (groupName === 'node') {
-                        const currentPrograms = { ...selectedPrograms };
-                        const programIds = sites
-                            .filter((item) => ids.includes(item.location.name)) // Check if location.name is in ids array
-                            .flatMap((item) => item.results.map((result) => result.program_id)); // Extract program_id
-                        Object.keys(selectedPrograms).forEach((id) => {
-                            if (currentPrograms[id] && !programIds.includes(id)) {
-                                delete currentPrograms[id];
-                            }
-                        });
-                        if (currentPrograms && Object.keys(currentPrograms).length > 0) {
-                            retVal.query.exclude_programs = Object.keys(currentPrograms)
-                                .filter((id) => currentPrograms[id])
-                                .join('|');
-                        } else {
-                            delete retVal.query.exclude_programs;
-                            retVal.query = {};
-                        }
-                        setSelectedPrograms(currentPrograms);
+                        syncProgramExclusionsWithNodes(ids, retVal);
                     }
 
                     // if this filter is genomicDataTypes, also update query string
@@ -276,18 +280,34 @@ function StyledCheckboxList(props) {
     let label = groupName;
     let renderTags = (tagValue, getTagProps) =>
         tagValue.map((option, index) => <Chip {...getTagProps({ index })} key={option} label={option} />);
+    // For the exclusion filters (Nodes, Programs) the Autocomplete `value` is the
+    // list of *deselected* items, so rendering those as chips inside the box is
+    // counter-intuitive (deselecting adds a chip). Instead we show a short
+    // "N of M selected" summary ABOVE the dropdown and render nothing inside it.
+    // `options.length - checkedList.length` is the count still selected.
+    let summaryText = null;
     if (groupName === 'exclude_programs') {
-        // Datasets: instead of using Chips to display the selected datasets (which can be confusing)
-        // we instead just show a short text description describing how many datasets have been selected
-        renderTags = (tagValue, _) => <span>{`${options.length - tagValue.length} programs selected, expand to see more`}</span>;
+        summaryText = `${options.length - checkedList.length} of ${options.length} programs selected`;
         label = 'Programs';
+    } else if (groupName === 'node') {
+        summaryText = `${options.length - checkedList.length} of ${options.length} nodes selected`;
+        label = 'Nodes';
+    }
+    if (summaryText) {
+        renderTags = () => null;
     }
 
     return useAutoComplete ? (
-        <Autocomplete
-            size="small"
-            multiple
-            id={`checkboxes-tags-${groupName}`}
+        <>
+            {summaryText && (
+                <Typography variant="body2" sx={{ paddingTop: '0.5em', fontStyle: 'italic', color: 'text.secondary' }}>
+                    {summaryText}
+                </Typography>
+            )}
+            <Autocomplete
+                size="small"
+                multiple
+                id={`checkboxes-tags-${groupName}`}
             options={options}
             disableCloseOnSelect
             renderOption={(props, option, { selected }) => {
@@ -357,7 +377,8 @@ function StyledCheckboxList(props) {
             renderInput={(params) => <TextField {...params} label={label} />}
             renderTags={renderTags}
             getOptionDisabled={(option) => optionStatusMap?.[option]?.healthy === false}
-        />
+            />
+        </>
     ) : (
         options?.map((option) => {
             const status = optionStatusMap?.[option];


### PR DESCRIPTION
## Summary

Improvements to the clinical & genomic search sidebar's Nodes/Programs filters and the search summary bar.

- **Selection summary above the dropdown**: The Nodes and Programs filters now show an `N of M selected` line above the dropdown instead of rendering chips of the *deselected* items inside the input (which was counter-intuitive — deselecting added a chip).
- **Node → program sync fix**: Deselecting a node now deselects that node's programs, and reselecting the node re-selects them. This is done by applying only the *delta* of nodes whose selection changed, so manual per-program (de)selections on unchanged nodes are preserved.
- **Live search summary bar**: `SearchExplainer` now updates as filters change rather than only on search submit, and collapses long exclusion lists to `Excluding N programs` with the full list revealed on hover (so deselecting a large node doesn't overflow the bar).

## Files
- `src/views/clinicalGenomic/widgets/sidebar.jsx`
- `src/views/clinicalGenomic/widgets/searchExplainer.jsx`

## Testing locally with the mock server

These changes can be exercised without the full CanDIG stack using the [candig-mock-server](https://github.com/CanDIG/candig-mock-server), which serves a synthetic federation (6 online nodes + 1 offline, 10 programs) through the same `/v1/fanout` endpoint the portal uses.

### 1. Start the mock server
In a separate directory (it is not a submodule of this repo). Defaults to `http://localhost:4000`:
```bash
git clone https://github.com/CanDIG/candig-mock-server.git
cd candig-mock-server
npm install
npm start
```

### 2. Start the data portal dev server
In a clone of this repo:
```bash
# from the repo root (candig-data-portal/)
npm install       # first time only
npm start         # runs Vite dev server on http://localhost:4173
```
Make sure `.env.development` points the portal at the mock server (this is the default in the repo):
```
VITE_FEDERATION_API_SERVER=http://localhost:4000
VITE_INGEST_SERVER=http://localhost:4000
```
Then open **http://localhost:4173/** and go to the clinical & genomic search page. Vite hot-reloads on save, so edits to the sidebar show up without a restart.

### What to check in the sidebar
- **Nodes / Programs** filters show `N of M selected` above each dropdown (7 nodes incl. the offline node; 10 programs, 2 showing a lock icon).
- Deselecting a **node** deselects its programs; reselecting the node restores them. A manually deselected program on another node survives node toggles.
- The **top summary bar** updates live as you (de)select, and shows `Excluding N programs` (hover for the full list) once more than 3 are excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)