### PR TITLE
DIG-2318: Sort programs alphabetically in search sidebar and patient counts

### DIFF
--- a/src/views/clinicalGenomic/widgets/patientCountSingle.jsx
+++ b/src/views/clinicalGenomic/widgets/patientCountSingle.jsx
@@ -172,7 +172,9 @@ function PatientCountSingle(props) {
             </Grid>
 
             {expanded
-                ? counts.totals.map((program) => {
+                ? [...counts.totals]
+                      .sort((a, b) => a.program_id.localeCompare(b.program_id, undefined, { numeric: true, sensitivity: 'base' }))
+                      .map((program) => {
                     const locked = !counts.unlockedPrograms?.some((programID) => programID === program.program_id);
                     const accessRequested = counts.accessRequestedPrograms?.some(
                         ({ programId, this_site }) => programId === program.program_id && this_site === counts.location

--- a/src/views/clinicalGenomic/widgets/sidebar.jsx
+++ b/src/views/clinicalGenomic/widgets/sidebar.jsx
@@ -799,7 +799,9 @@ function Sidebar() {
 
     // Parse out what we need:
     const sites = readerContext?.federation?.map((loc) => loc.location.name) || [];
-    const programs = readerContext?.federation?.map((loc) => loc.results?.map((program) => program.program_id) || [])?.flat(1) || [];
+    const programs = (readerContext?.federation?.map((loc) => loc.results?.map((program) => program.program_id) || [])?.flat(1) || []).sort(
+        (a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
+    );
     const authorizedPrograms = readerContext?.programs?.flatMap((loc) => loc?.results?.items?.map((program) => program.program_id)) || [];
     const treatmentTypes = ExtractSidebarElements('treatment_types');
     const tumourPrimarySites = ExtractSidebarElements('tumour_primary_sites');


### PR DESCRIPTION
## Summary

Programs previously rendered in federation/backend order in the clinical & genomic search page. This sorts them alphabetically (natural alphanumeric, so `-2` sorts before `-10`) in two places:

- **Sidebar Programs filter** — the dropdown options are now alphabetical.
- **Patient Data counts table** — the expanded per-program rows under each node are now alphabetical.

Both are **display-only** sorts; they don't affect counts, totals, or the query parameters sent to the backend.

Relates to **DIG-2318**.

## Files
- `src/views/clinicalGenomic/widgets/sidebar.jsx`
- `src/views/clinicalGenomic/widgets/patientCountSingle.jsx`

## Testing locally with the mock server

Uses the [candig-mock-server](https://github.com/CanDIG/candig-mock-server) (synthetic federation: 6 online nodes + 1 offline, 10 programs).

1. **Start the mock server** (defaults to `http://localhost:4000`):
   ```bash
   git clone https://github.com/CanDIG/candig-mock-server.git
   cd candig-mock-server
   npm install
   npm start
   ```
2. **Start the data portal dev server** (in a clone of this repo):
   ```bash
   npm install       # first time only
   npm start         # Vite dev server on http://localhost:4173
   ```
   `.env.development` should point at the mock (the repo default):
   ```
   VITE_FEDERATION_API_SERVER=http://localhost:4000
   VITE_INGEST_SERVER=http://localhost:4000
   ```
   Open http://localhost:4173/ and go to the clinical & genomic search page.

### What to check
- The **Programs** dropdown in the sidebar lists programs alphabetically across all nodes.
- Expanding a node in the **Patient Data** table shows its programs alphabetically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)