### PR TITLE
Patient info page: timeline sub-treatments, tooltips, and donor lookup

### DIFF
--- a/src/layout/MainLayout/Header/TourButton.jsx
+++ b/src/layout/MainLayout/Header/TourButton.jsx
@@ -7,26 +7,38 @@ import config from '../../../config';
 import { SET_MENU } from '../../../store/actions';
 import { useTour } from '../../../ui-component/tour/TourContext';
 import searchTourSteps from '../../../ui-component/tour/searchTourSteps';
+import patientTourSteps from '../../../ui-component/tour/patientTourSteps';
 import waitForElement from '../../../ui-component/tour/waitForElement';
 
 const { basename } = config;
 const SEARCH_PATH = `${basename}/clinicalGenomicSearch`;
+const PATIENT_PATH = `${basename}/patientView`;
 
-// "Take a tour" button shown in the header (left of the profile menu). It only
-// appears on the Clinical & Genomic Search page — the search tour's steps target
-// elements on that page — and starts the tour in place without navigating.
+// Pages that have a guided tour: each maps to the first target the tour needs
+// (also used to confirm the page has mounted) and the steps to run.
+const TOURS = {
+    [SEARCH_PATH]: { target: '[data-tour="search-sidebar"]', steps: searchTourSteps },
+    [PATIENT_PATH]: { target: '[data-tour="patient-info"]', steps: patientTourSteps }
+};
+
+// "Take a tour" button shown in the header (left of the profile menu). It appears
+// only on pages that have a tour, and starts that page's tour in place without
+// navigating.
 function TourButton() {
     const location = useLocation();
     const dispatch = useDispatch();
     const { startTour } = useTour();
 
-    if (location.pathname !== SEARCH_PATH) return null;
+    const tour = TOURS[location.pathname];
+    if (!tour) return null;
 
     const handleStartTour = () => {
-        // Ensure the filter drawer (which several steps target) is open, then start
-        // once the sidebar has mounted.
+        // Ensure the sidebar drawer (which several steps target) is open, then start
+        // once the page's first target has mounted.
         dispatch({ type: SET_MENU, opened: true });
-        waitForElement('[data-tour="search-sidebar"]').then(() => startTour(searchTourSteps));
+        waitForElement(tour.target).then((found) => {
+            if (found) startTour(tour.steps);
+        });
     };
 
     return (

--- a/src/layout/MainLayout/Header/index.jsx
+++ b/src/layout/MainLayout/Header/index.jsx
@@ -76,7 +76,7 @@ function Header({ handleLeftDrawerToggle }) {
             {/* <SearchSection theme="light" />  Currently not needed */}
             <StyledGrow className={classes.grow} />
 
-            {/* take a tour (search page only) */}
+            {/* take a tour (shown on pages that have a guided tour) */}
             <TourButton />
 
             {/* notification & profile */}

--- a/src/ui-component/tour/TourRunner.jsx
+++ b/src/ui-component/tour/TourRunner.jsx
@@ -23,6 +23,19 @@ function setNodeExpanded(shouldExpand) {
     }
 }
 
+// Expand (or reset) a systemic-therapy treatment on the patient timeline to
+// demonstrate its per-drug rows. The timeline exposes a hidden control whose
+// data-active reflects the current state, so we only click when a change is
+// needed — keeping this idempotent across Next/Back navigation.
+function setTimelineTreatmentExpanded(shouldExpand) {
+    const button = document.querySelector('[data-tour="timeline-expand-demo"]');
+    if (!button) return;
+    const isActive = button.dataset.active === 'true';
+    if (shouldExpand !== isActive) {
+        button.click();
+    }
+}
+
 // The sidebar lives in a fixed MUI Drawer that scrolls via react-perfect-scrollbar
 // (overflow: hidden), which Joyride's auto-scroll doesn't recognize — so lower
 // sections (genomic / clinical filters) stay below the drawer's fold and Joyride
@@ -56,6 +69,7 @@ function TourRunner() {
     useEffect(() => {
         if (run) {
             setNodeExpanded(false);
+            setTimelineTreatmentExpanded(false);
             stopTour();
         }
         // Only react to path changes; including `run` would stop the tour the
@@ -72,6 +86,7 @@ function TourRunner() {
             // Leave nothing expanded behind us. Tours run in place, so there's
             // nothing to navigate to on finish/skip/close.
             setNodeExpanded(false);
+            setTimelineTreatmentExpanded(false);
             stopTour();
             return;
         }
@@ -87,10 +102,18 @@ function TourRunner() {
             setNodeExpanded(true);
         }
 
+        // Demonstrate a treatment expanding into its systemic-therapy drug rows.
+        if (type === EVENTS.STEP_BEFORE && step?.expandTreatmentDemo) {
+            setTimelineTreatmentExpanded(true);
+        }
+
         if ([EVENTS.STEP_AFTER, EVENTS.TARGET_NOT_FOUND].includes(type)) {
             // ...and collapse it again once we move on.
             if (step?.expandDemo) {
                 setNodeExpanded(false);
+            }
+            if (step?.expandTreatmentDemo) {
+                setTimelineTreatmentExpanded(false);
             }
             // Advance (or go back) once the current step is done.
             setStepIndex(index + (action === ACTIONS.PREV ? -1 : 1));

--- a/src/ui-component/tour/patientTourSteps.jsx
+++ b/src/ui-component/tour/patientTourSteps.jsx
@@ -27,6 +27,13 @@ const patientTourSteps = [
             'Use these folders to move between clinical categories — primary diagnoses, treatments, specimens, follow-ups and more. Selecting one shows its details in the table.'
     },
     {
+        target: '[data-tour="patient-donor-lookup"]',
+        placement: 'right',
+        title: 'Jump to another donor',
+        content:
+            'Look up a specific donor without going back to search. Pick a node and program you have access to, then choose a donor ID from the list — only donors you’re authorized to view appear — to open that patient’s page.'
+    },
+    {
         target: '[data-tour="patient-clinical"]',
         placement: 'top',
         title: 'Clinical data table',

--- a/src/ui-component/tour/patientTourSteps.jsx
+++ b/src/ui-component/tour/patientTourSteps.jsx
@@ -27,13 +27,6 @@ const patientTourSteps = [
             'Use these folders to move between clinical categories — primary diagnoses, treatments, specimens, follow-ups and more. Selecting one shows its details in the table.'
     },
     {
-        target: '[data-tour="patient-donor-lookup"]',
-        placement: 'right',
-        title: 'Jump to another donor',
-        content:
-            'Look up a specific donor without going back to search. Pick a node and program you have access to, then choose a donor ID from the list — only donors you’re authorized to view appear — to open that patient’s page.'
-    },
-    {
         target: '[data-tour="patient-clinical"]',
         placement: 'top',
         title: 'Clinical data table',
@@ -44,7 +37,17 @@ const patientTourSteps = [
         placement: 'top',
         title: 'Patient timeline',
         content:
-            'A timeline of the donor’s diagnosis, treatments and follow-ups. The timeline can be zoomed in and out to focus on different time periods. The list of treatments can be expanded and clicking on an event will show its details in the table above.'
+            'A timeline of the donor’s diagnosis, treatments and follow-ups. The timeline can be zoomed in and out to focus on different time periods, and clicking an event shows its details in the table above.'
+    },
+    {
+        target: '[data-tour="patient-timeline"]',
+        placement: 'top',
+        title: 'Expand treatment details',
+        // Live-demonstrates expanding a systemic-therapy treatment into its drug
+        // rows while the step is shown (handled in TourRunner), then resets on exit.
+        expandTreatmentDemo: true,
+        content:
+            'Use the triangle toggles on the left edge of the chart to expand rows. The “Treatments” row expands to list each individual treatment, and any treatment that includes systemic therapy expands again to show each drug on its own dated row — as shown here.'
     },
     {
         target: '[data-tour="patient-genomic"]',
@@ -52,6 +55,13 @@ const patientTourSteps = [
         title: 'Genomic data',
         content:
             'Any genomic samples associated with this donor — sample and experiment IDs, variant counts, and links to the associated files.'
+    },
+    {
+        target: '[data-tour="patient-donor-lookup"]',
+        placement: 'right',
+        title: 'Look up another donor',
+        content:
+            'Finally, you can look up a specific donor without going back to search. Pick a node and program you have access to, then choose a donor ID from the list to open that patient’s page.'
     }
 ];
 

--- a/src/utils/utils.jsx
+++ b/src/utils/utils.jsx
@@ -213,6 +213,9 @@ export function handleTableSet(title, array, ageAtFirstDiagnosis) {
         } else if (key.startsWith('date_of_')) {
             value = key.split('date_of_')[1];
             value = `Diagnosis_to_${value.trim()}`;
+        } else if (key === 'specimen_collection_date') {
+            // Table cell shows the interval relative to diagnosis, so label it as such.
+            value = `Diagnosis_to_specimen_collection_date`;
         }
 
         return hasNonEmptyValue

--- a/src/views/clinicalGenomic/clinicalPatientView.jsx
+++ b/src/views/clinicalGenomic/clinicalPatientView.jsx
@@ -1,10 +1,9 @@
 import { useState, useEffect } from 'react';
 import { styled } from '@mui/system';
-import { Box, Button, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 import Alert from '@mui/material/Alert';
 import { useSelector, useDispatch } from 'react-redux';
-import { IconPlayerPlay } from '@tabler/icons-react';
 
 import MainCard from '../../ui-component/cards/MainCard';
 import useClinicalPatientData from './useClinicalPatientData';
@@ -149,14 +148,9 @@ function ClinicalPatientView() {
                         </Alert>
                     </div>
                 )}
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-                    <Typography pb={1} variant="h5" style={{ fontWeight: 'bold' }}>
-                        {title}
-                    </Typography>
-                    <Button size="small" startIcon={<IconPlayerPlay size={18} />} onClick={runPatientTour}>
-                        Take a tour
-                    </Button>
-                </Box>
+                <Typography pb={1} variant="h5" style={{ fontWeight: 'bold' }}>
+                    {title}
+                </Typography>
                 <Typography pb={1} variant="h6">
                     {patientId}
                 </Typography>

--- a/src/views/clinicalGenomic/widgets/donorLookup.jsx
+++ b/src/views/clinicalGenomic/widgets/donorLookup.jsx
@@ -1,0 +1,192 @@
+import { useEffect, useState } from 'react';
+import { Alert, Box, Button, CircularProgress, MenuItem, TextField, Typography } from '@mui/material';
+import { useTheme } from '@mui/system';
+
+import { fetchFederation } from '../../../store/api';
+
+/*
+ * A small form, shown beneath the clinical metadata folders, that lets a user jump
+ * to a specific donor. Node and program are dropdowns limited to what the user is
+ * actually authorized for (from v3/authorized/programs); donor ID is free text.
+ *
+ * Authorization is still enforced by katsu on fetch: the donor endpoint returns 404
+ * ("does not exist or inaccessible") for anything the user cannot see, so we only
+ * navigate on a real hit and otherwise show an error without revealing any data.
+ */
+function DonorLookup() {
+    const theme = useTheme();
+
+    const [programsByNode, setProgramsByNode] = useState({});
+    const [loadingPrograms, setLoadingPrograms] = useState(true);
+    const [loadError, setLoadError] = useState('');
+
+    const [node, setNode] = useState('');
+    const [programId, setProgramId] = useState('');
+    const [donorId, setDonorId] = useState('');
+    const [error, setError] = useState('');
+    const [looking, setLooking] = useState(false);
+
+    // Build a { nodeName: [program_id, ...] } map of what the user may access.
+    useEffect(() => {
+        let active = true;
+        // Plain fetch (not the relogin wrapper) so a katsu 401 doesn't reload the page.
+        fetchFederation('v3/authorized/programs', 'katsu', {}, fetch)
+            .then((data) => {
+                if (!active) return;
+                const map = {};
+                (Array.isArray(data) ? data : []).forEach((entry) => {
+                    const name = entry?.location?.name;
+                    if (!name) return;
+                    // katsu returns results as an array; the mock nests it under items.
+                    const items = Array.isArray(entry.results) ? entry.results : entry.results?.items || [];
+                    const ids = items.map((program) => program?.program_id).filter(Boolean);
+                    if (ids.length === 0) return;
+                    map[name] = Array.from(new Set([...(map[name] || []), ...ids])).sort();
+                });
+                setProgramsByNode(map);
+            })
+            .catch(() => {
+                if (active) setLoadError('Could not load the list of authorized programs.');
+            })
+            .finally(() => {
+                if (active) setLoadingPrograms(false);
+            });
+        return () => {
+            active = false;
+        };
+    }, []);
+
+    const nodes = Object.keys(programsByNode).sort();
+    const programs = node ? programsByNode[node] || [] : [];
+    const canSubmit = node && programId && donorId.trim() && !looking;
+
+    const handleNodeChange = (value) => {
+        setNode(value);
+        setProgramId(''); // program list depends on the node, so reset it
+        setError('');
+    };
+
+    const handleLookup = async () => {
+        setError('');
+        setLooking(true);
+        const trimmedDonor = donorId.trim();
+
+        try {
+            const path = `v3/authorized/donor_with_clinical_data/program/${encodeURIComponent(
+                programId
+            )}/donor/${encodeURIComponent(trimmedDonor)}`;
+            const result = await fetchFederation(path, 'katsu');
+
+            const match = Array.isArray(result) ? result.find((obj) => obj?.location?.name === node) : null;
+            const donor = match?.results;
+            const found = donor && !donor.error && (donor.submitter_donor_id || donor.program_id);
+
+            if (found) {
+                window.location.href =
+                    `/patientView?patientId=${encodeURIComponent(trimmedDonor)}` +
+                    `&programId=${encodeURIComponent(programId)}` +
+                    `&location=${encodeURIComponent(node)}` +
+                    `&submitterDonorId=${encodeURIComponent(trimmedDonor)}`;
+            } else {
+                setError(
+                    `No donor "${trimmedDonor}" found in program "${programId}" at "${node}". ` +
+                        `Check the donor ID — the donor may not exist or may not be accessible to you.`
+                );
+            }
+        } catch (e) {
+            setError('Something went wrong looking up that donor. Please try again.');
+        } finally {
+            setLooking(false);
+        }
+    };
+
+    return (
+        <Box sx={{ mt: 2, pt: 1.5, px: 1, borderTop: `1px solid ${theme.palette.divider}` }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mb: 1 }}>
+                Look up donor by ID
+            </Typography>
+
+            {loadingPrograms ? (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, color: 'text.secondary' }}>
+                    <CircularProgress size={16} />
+                    <Typography variant="body2">Loading your programs…</Typography>
+                </Box>
+            ) : loadError ? (
+                <Alert severity="error" variant="outlined">
+                    {loadError}
+                </Alert>
+            ) : nodes.length === 0 ? (
+                <Typography variant="body2" color="text.secondary">
+                    You do not have access to any programs to look up.
+                </Typography>
+            ) : (
+                <Box
+                    component="form"
+                    onSubmit={(event) => {
+                        event.preventDefault();
+                        if (canSubmit) handleLookup();
+                    }}
+                    sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
+                >
+                    <TextField
+                        select
+                        size="small"
+                        label="Node"
+                        value={node}
+                        onChange={(event) => handleNodeChange(event.target.value)}
+                    >
+                        {nodes.map((name) => (
+                            <MenuItem key={name} value={name}>
+                                {name}
+                            </MenuItem>
+                        ))}
+                    </TextField>
+
+                    <TextField
+                        select
+                        size="small"
+                        label="Program"
+                        value={programId}
+                        onChange={(event) => {
+                            setProgramId(event.target.value);
+                            setError('');
+                        }}
+                        disabled={!node}
+                        helperText={node ? '' : 'Select a node first'}
+                    >
+                        {programs.map((id) => (
+                            <MenuItem key={id} value={id}>
+                                {id}
+                            </MenuItem>
+                        ))}
+                    </TextField>
+
+                    <TextField
+                        size="small"
+                        label="Donor ID"
+                        value={donorId}
+                        onChange={(event) => setDonorId(event.target.value)}
+                    />
+
+                    <Button
+                        type="submit"
+                        variant="contained"
+                        size="small"
+                        disabled={!canSubmit}
+                        startIcon={looking ? <CircularProgress size={16} color="inherit" /> : null}
+                    >
+                        Look up donor
+                    </Button>
+
+                    {error && (
+                        <Alert severity="error" variant="outlined">
+                            {error}
+                        </Alert>
+                    )}
+                </Box>
+            )}
+        </Box>
+    );
+}
+
+export default DonorLookup;

--- a/src/views/clinicalGenomic/widgets/donorLookup.jsx
+++ b/src/views/clinicalGenomic/widgets/donorLookup.jsx
@@ -133,7 +133,7 @@ function DonorLookup() {
     };
 
     return (
-        <Box sx={{ mt: 2, pt: 1.5, px: 1, borderTop: `1px solid ${theme.palette.divider}` }}>
+        <Box data-tour="patient-donor-lookup" sx={{ mt: 2, pt: 1.5, px: 1, borderTop: `1px solid ${theme.palette.divider}` }}>
             <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mb: 1 }}>
                 Look up donor by ID
             </Typography>

--- a/src/views/clinicalGenomic/widgets/donorLookup.jsx
+++ b/src/views/clinicalGenomic/widgets/donorLookup.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Alert, Box, Button, CircularProgress, MenuItem, TextField, Typography } from '@mui/material';
+import { Alert, Autocomplete, Box, Button, CircularProgress, MenuItem, TextField, Typography } from '@mui/material';
 import { useTheme } from '@mui/system';
 
 import { fetchFederation } from '../../../store/api';
@@ -7,12 +7,22 @@ import { fetchFederation } from '../../../store/api';
 /*
  * A small form, shown beneath the clinical metadata folders, that lets a user jump
  * to a specific donor. Node and program are dropdowns limited to what the user is
- * actually authorized for (from v3/authorized/programs); donor ID is free text.
+ * actually authorized for (from v3/authorized/programs). Once a program is chosen we
+ * load the donors the user may read in that program (v3/authorized/donors/) and offer
+ * them as a searchable dropdown, so a valid ID in the wrong program is impossible.
  *
- * Authorization is still enforced by katsu on fetch: the donor endpoint returns 404
- * ("does not exist or inaccessible") for anything the user cannot see, so we only
- * navigate on a real hit and otherwise show an error without revealing any data.
+ * Because the donor is picked from the authorized list, it is guaranteed to exist and
+ * be accessible, so we can navigate straight to the patient view without re-fetching
+ * (which, on a real deployment, would come back as an aggregate 404 for anything a node
+ * cannot return and be surfaced as a generic error).
  */
+
+// katsu returns list results as a plain array; the mock nests them under `items`.
+function resultItems(results) {
+    if (Array.isArray(results)) return results;
+    return Array.isArray(results?.items) ? results.items : [];
+}
+
 function DonorLookup() {
     const theme = useTheme();
 
@@ -23,8 +33,13 @@ function DonorLookup() {
     const [node, setNode] = useState('');
     const [programId, setProgramId] = useState('');
     const [donorId, setDonorId] = useState('');
+
+    // Donor IDs available in the selected node+program, cached by `${node}|||${program}`.
+    const [donorCache, setDonorCache] = useState({});
+    const [loadingDonors, setLoadingDonors] = useState(false);
+    const [donorLoadError, setDonorLoadError] = useState('');
+
     const [error, setError] = useState('');
-    const [looking, setLooking] = useState(false);
 
     // Build a { nodeName: [program_id, ...] } map of what the user may access.
     useEffect(() => {
@@ -37,9 +52,9 @@ function DonorLookup() {
                 (Array.isArray(data) ? data : []).forEach((entry) => {
                     const name = entry?.location?.name;
                     if (!name) return;
-                    // katsu returns results as an array; the mock nests it under items.
-                    const items = Array.isArray(entry.results) ? entry.results : entry.results?.items || [];
-                    const ids = items.map((program) => program?.program_id).filter(Boolean);
+                    const ids = resultItems(entry.results)
+                        .map((program) => program?.program_id)
+                        .filter(Boolean);
                     if (ids.length === 0) return;
                     map[name] = Array.from(new Set([...(map[name] || []), ...ids])).sort();
                 });
@@ -56,48 +71,65 @@ function DonorLookup() {
         };
     }, []);
 
+    const cacheKey = node && programId ? `${node}|||${programId}` : '';
+
+    // When a node+program is chosen, load the donors the user may read there.
+    useEffect(() => {
+        if (!cacheKey || donorCache[cacheKey]) return undefined;
+        let active = true;
+        setLoadingDonors(true);
+        setDonorLoadError('');
+        // Plain fetch so a katsu 401 doesn't reload the page mid-selection.
+        fetchFederation('v3/authorized/donors/', 'katsu', { program_id: programId }, fetch)
+            .then((data) => {
+                if (!active) return;
+                const match = Array.isArray(data) ? data.find((obj) => obj?.location?.name === node) : null;
+                const ids = resultItems(match?.results)
+                    .map((donor) => donor?.submitter_donor_id)
+                    .filter(Boolean);
+                setDonorCache((prev) => ({ ...prev, [cacheKey]: Array.from(new Set(ids)).sort() }));
+            })
+            .catch(() => {
+                if (active) setDonorLoadError('Could not load the donors for this program.');
+            })
+            .finally(() => {
+                if (active) setLoadingDonors(false);
+            });
+        return () => {
+            active = false;
+        };
+    }, [cacheKey, node, programId, donorCache]);
+
     const nodes = Object.keys(programsByNode).sort();
     const programs = node ? programsByNode[node] || [] : [];
-    const canSubmit = node && programId && donorId.trim() && !looking;
+    const donorOptions = cacheKey ? donorCache[cacheKey] || [] : [];
+    const canSubmit = Boolean(node && programId && donorId && donorOptions.includes(donorId));
 
     const handleNodeChange = (value) => {
         setNode(value);
         setProgramId(''); // program list depends on the node, so reset it
+        setDonorId('');
         setError('');
     };
 
-    const handleLookup = async () => {
+    const handleProgramChange = (value) => {
+        setProgramId(value);
+        setDonorId(''); // donor list depends on the program, so reset it
         setError('');
-        setLooking(true);
-        const trimmedDonor = donorId.trim();
+    };
 
-        try {
-            const path = `v3/authorized/donor_with_clinical_data/program/${encodeURIComponent(
-                programId
-            )}/donor/${encodeURIComponent(trimmedDonor)}`;
-            const result = await fetchFederation(path, 'katsu');
-
-            const match = Array.isArray(result) ? result.find((obj) => obj?.location?.name === node) : null;
-            const donor = match?.results;
-            const found = donor && !donor.error && (donor.submitter_donor_id || donor.program_id);
-
-            if (found) {
-                window.location.href =
-                    `/patientView?patientId=${encodeURIComponent(trimmedDonor)}` +
-                    `&programId=${encodeURIComponent(programId)}` +
-                    `&location=${encodeURIComponent(node)}` +
-                    `&submitterDonorId=${encodeURIComponent(trimmedDonor)}`;
-            } else {
-                setError(
-                    `No donor "${trimmedDonor}" found in program "${programId}" at "${node}". ` +
-                        `Check the donor ID — the donor may not exist or may not be accessible to you.`
-                );
-            }
-        } catch (e) {
-            setError('Something went wrong looking up that donor. Please try again.');
-        } finally {
-            setLooking(false);
+    const handleLookup = () => {
+        setError('');
+        // donorId came from the authorized list for this node+program, so it is known-good.
+        if (!donorOptions.includes(donorId)) {
+            setError('Please choose a donor from the list.');
+            return;
         }
+        window.location.href =
+            `/patientView?patientId=${encodeURIComponent(donorId)}` +
+            `&programId=${encodeURIComponent(programId)}` +
+            `&location=${encodeURIComponent(node)}` +
+            `&submitterDonorId=${encodeURIComponent(donorId)}`;
     };
 
     return (
@@ -147,10 +179,7 @@ function DonorLookup() {
                         size="small"
                         label="Program"
                         value={programId}
-                        onChange={(event) => {
-                            setProgramId(event.target.value);
-                            setError('');
-                        }}
+                        onChange={(event) => handleProgramChange(event.target.value)}
                         disabled={!node}
                         helperText={node ? '' : 'Select a node first'}
                     >
@@ -161,20 +190,49 @@ function DonorLookup() {
                         ))}
                     </TextField>
 
-                    <TextField
+                    <Autocomplete
                         size="small"
-                        label="Donor ID"
-                        value={donorId}
-                        onChange={(event) => setDonorId(event.target.value)}
+                        options={donorOptions}
+                        value={donorId || null}
+                        onChange={(event, value) => {
+                            setDonorId(value || '');
+                            setError('');
+                        }}
+                        disabled={!programId || loadingDonors}
+                        loading={loadingDonors}
+                        noOptionsText={donorLoadError || 'No donors found'}
+                        renderInput={(params) => (
+                            <TextField
+                                {...params}
+                                label="Donor ID"
+                                helperText={
+                                    // eslint-disable-next-line no-nested-ternary
+                                    !programId
+                                        ? 'Select a program first'
+                                        : loadingDonors
+                                        ? 'Loading donors…'
+                                        : `${donorOptions.length} donor${donorOptions.length === 1 ? '' : 's'} available`
+                                }
+                                InputProps={{
+                                    ...params.InputProps,
+                                    endAdornment: (
+                                        <>
+                                            {loadingDonors ? <CircularProgress color="inherit" size={16} /> : null}
+                                            {params.InputProps.endAdornment}
+                                        </>
+                                    )
+                                }}
+                            />
+                        )}
                     />
 
-                    <Button
-                        type="submit"
-                        variant="contained"
-                        size="small"
-                        disabled={!canSubmit}
-                        startIcon={looking ? <CircularProgress size={16} color="inherit" /> : null}
-                    >
+                    {donorLoadError && (
+                        <Alert severity="error" variant="outlined">
+                            {donorLoadError}
+                        </Alert>
+                    )}
+
+                    <Button type="submit" variant="contained" size="small" disabled={!canSubmit}>
                         Look up donor
                     </Button>
 

--- a/src/views/clinicalGenomic/widgets/donorLookup.jsx
+++ b/src/views/clinicalGenomic/widgets/donorLookup.jsx
@@ -45,7 +45,9 @@ function DonorLookup() {
     useEffect(() => {
         let active = true;
         // Plain fetch (not the relogin wrapper) so a katsu 401 doesn't reload the page.
-        fetchFederation('v3/authorized/programs', 'katsu', {}, fetch)
+        // Paginated like the donors endpoint (default 100/page); pass a very large
+        // page_size so every authorized program appears rather than truncating.
+        fetchFederation('v3/authorized/programs', 'katsu', { page_size: 1000000000 }, fetch)
             .then((data) => {
                 if (!active) return;
                 const map = {};
@@ -80,7 +82,11 @@ function DonorLookup() {
         setLoadingDonors(true);
         setDonorLoadError('');
         // Plain fetch so a katsu 401 doesn't reload the page mid-selection.
-        fetchFederation('v3/authorized/donors/', 'katsu', { program_id: programId }, fetch)
+        // katsu paginates this endpoint (default 100/page); pass a very large
+        // page_size so the dropdown lists every authorized donor rather than
+        // silently truncating. The page_size cap in the docstring isn't enforced,
+        // so this returns the whole set in one request.
+        fetchFederation('v3/authorized/donors/', 'katsu', { program_id: programId, page_size: 1000000000 }, fetch)
             .then((data) => {
                 if (!active) return;
                 const match = Array.isArray(data) ? data.find((obj) => obj?.location?.name === node) : null;

--- a/src/views/clinicalGenomic/widgets/patientSidebar.jsx
+++ b/src/views/clinicalGenomic/widgets/patientSidebar.jsx
@@ -5,6 +5,7 @@ import { Button, Typography } from '@mui/material';
 import FolderOpenIcon from '@mui/icons-material/FolderOpen';
 import FolderIcon from '@mui/icons-material/Folder';
 import { formatKey } from '../../../utils/utils';
+import DonorLookup from './donorLookup';
 
 const HeaderButton = styled(Button)(({ theme, selected }) => ({
     textAlign: 'left',
@@ -114,6 +115,9 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtFirs
             } else if (key.startsWith('date_of_')) {
                 value = key.split('date_of_')[1];
                 value = `Diagnosis_to_${value.trim()}`;
+            } else if (key === 'specimen_collection_date') {
+                // Table cell shows the interval relative to diagnosis, so label it as such.
+                value = `Diagnosis_to_specimen_collection_date`;
             }
 
             return hasNonEmptyValue
@@ -345,6 +349,7 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtFirs
     return (
         <div style={{ marginTop: 12 }} data-tour="patient-sidebar">
             {createMainSidebarHeaders(sidebar)}
+            <DonorLookup />
         </div>
     );
 }

--- a/src/views/clinicalGenomic/widgets/patientSidebar.jsx
+++ b/src/views/clinicalGenomic/widgets/patientSidebar.jsx
@@ -347,8 +347,8 @@ function PatientSidebar({ sidebar = {}, setColumns, setRows, setTitle, ageAtFirs
     }
 
     return (
-        <div style={{ marginTop: 12 }} data-tour="patient-sidebar">
-            {createMainSidebarHeaders(sidebar)}
+        <div style={{ marginTop: 12 }}>
+            <div data-tour="patient-sidebar">{createMainSidebarHeaders(sidebar)}</div>
             <DonorLookup />
         </div>
     );

--- a/src/views/clinicalGenomic/widgets/timeline.jsx
+++ b/src/views/clinicalGenomic/widgets/timeline.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsGantt from 'highcharts/modules/gantt';
 import HighchartsReact from 'highcharts-react-official';
@@ -47,9 +47,9 @@ const tooltipFormatter = () =>
             const endYearText = `End: ${getDateText(this.end)}`;
 
             if (this.name === 'Treatments') {
-                tooltipContent = `${boldName}${startYearText}<br/>${endYearText}<br/>`;
+                tooltipContent = `${boldName}${startYearText}<br/>${endYearText}`;
             } else {
-                tooltipContent = `${boldName}${treatmentTypeText}<br/>${startYearText}<br/>${endYearText}<br/>`;
+                tooltipContent = `${boldName}${treatmentTypeText}<br/>${startYearText}<br/>${endYearText}`;
             }
         } else {
             tooltipContent = `${boldName}${getDateText(this.x)}`;
@@ -102,6 +102,38 @@ function Timeline({ data, onEventClick }) {
             return next;
         });
     }, []);
+
+    // The first treatment that has an expand toggle — i.e. it is placed on the
+    // timeline (has a treatment date) AND carries dated systemic therapies. The
+    // guided tour expands this one to demonstrate the per-drug rows. Mirrors the
+    // conditions used when building the sub-treatment rows in the effect below.
+    const firstExpandableTreatmentId = useMemo(() => {
+        let found = null;
+        (data?.primary_diagnoses || []).forEach((diagnosis) =>
+            (diagnosis.treatments || []).forEach((treatment) => {
+                if (found) return;
+                const hasTreatmentDate =
+                    treatment.treatment_start_date?.month_interval != null || treatment.treatment_end_date?.month_interval != null;
+                if (!hasTreatmentDate) return;
+                const hasDatedTherapy = (treatment.systemic_therapies || []).some(
+                    (therapy) => therapy?.start_date?.month_interval != null || therapy?.end_date?.month_interval != null
+                );
+                if (hasDatedTherapy) found = treatment.submitter_treatment_id;
+            })
+        );
+        return found;
+    }, [data]);
+
+    const demoTreatmentExpanded = firstExpandableTreatmentId ? expandedTreatments.has(firstExpandableTreatmentId) : false;
+
+    // Driven by the guided tour (via a hidden control) to show a systemic-therapy
+    // treatment expanding into its drug rows. Also ensures the Treatments group is
+    // open so the expanded rows are visible.
+    const toggleDemoTreatmentExpand = useCallback(() => {
+        if (!firstExpandableTreatmentId) return;
+        setIsTreatmentsCollapsed(false);
+        toggleTreatmentExpand(firstExpandableTreatmentId);
+    }, [firstExpandableTreatmentId, toggleTreatmentExpand]);
     useEffect(() => {
         let dob = data?.date_of_birth?.month_interval ?? 0;
         dob += data?.date_of_birth?.day_interval ? (data.date_of_birth.day_interval % 32) / 32 : 0;
@@ -813,7 +845,23 @@ function Timeline({ data, onEventClick }) {
     ]);
 
     // Render the HighchartsReact component with the configured chart options
-    return <HighchartsReact highcharts={Highcharts} constructorType="ganttChart" options={chartOptions} />;
+    return (
+        <>
+            {/* Hidden control the guided tour clicks to demonstrate a systemic-therapy
+                treatment expanding into its per-drug rows. Not a visible/targetable
+                tour step — the step anchors to the timeline container. */}
+            <button
+                type="button"
+                data-tour="timeline-expand-demo"
+                data-active={demoTreatmentExpanded ? 'true' : 'false'}
+                aria-hidden="true"
+                tabIndex={-1}
+                style={{ display: 'none' }}
+                onClick={toggleDemoTreatmentExpand}
+            />
+            <HighchartsReact highcharts={Highcharts} constructorType="ganttChart" options={chartOptions} />
+        </>
+    );
 }
 
 // PropTypes for component validation

--- a/src/views/clinicalGenomic/widgets/timeline.jsx
+++ b/src/views/clinicalGenomic/widgets/timeline.jsx
@@ -429,13 +429,20 @@ function Timeline({ data, onEventClick }) {
         // Category names in row order (parent treatments interleaved with their
         // expanded sub-treatments), used to build the yAxis categories.
         const orderedTreatmentNames = [];
+        // Display label and indent depth per treatment row, parallel to
+        // orderedTreatmentNames. Depth drives the y-axis label indentation so each
+        // treatment sits under the "Treatments" bar and each drug sits under its
+        // treatment. The display label can differ from the point name (used in
+        // tooltips), so an indented drug row needn't repeat its treatment id.
+        const orderedTreatmentLabels = [];
+        const orderedTreatmentDepths = [];
         // Treatments that have at least one dated sub-treatment; each gets an
         // expand/collapse toggle rendered next to its row.
         const subTreatmentParents = [];
 
         // Adds one dated row (a gantt bar if it has both dates, otherwise a single
         // point) and records its category name in row order.
-        const pushDatedRow = ({ name, start, end, treatment_type, intervalColour, pointColour, isSubTreatment, surgeries, radiations }) => {
+        const pushDatedRow = ({ name, displayLabel, start, end, treatment_type, intervalColour, pointColour, isSubTreatment, surgeries, radiations }) => {
             if (start != null && end != null) {
                 treatmentIntervals.push({
                     name,
@@ -468,6 +475,8 @@ function Timeline({ data, onEventClick }) {
                 });
             }
             orderedTreatmentNames.push(name);
+            orderedTreatmentLabels.push(displayLabel ?? name);
+            orderedTreatmentDepths.push(isSubTreatment ? 2 : 1);
         };
 
         // Pulls surgery/radiation detail for a treatment's tooltip, but only when the
@@ -489,6 +498,11 @@ function Timeline({ data, onEventClick }) {
             treatmentTypeIncludes(treatment, 'radiation') && Array.isArray(treatment?.radiations)
                 ? treatment.radiations.map((radiation) => radiation?.radiation_therapy_modality).filter(Boolean)
                 : [];
+
+        // treatment_type may be a single string or an array of them; join into a
+        // readable string for the row label (e.g. "Systemic therapy, Surgery").
+        const formatTreatmentType = (type) =>
+            (Array.isArray(type) ? type : type != null ? [type] : []).filter(Boolean).join(', ');
 
         // The parent "Treatments" summary bar spans the full treatment range, so
         // compute that range from the raw dates regardless of collapse state.
@@ -519,8 +533,13 @@ function Timeline({ data, onEventClick }) {
                         return;
                     }
 
+                    const treatmentTypeText = formatTreatmentType(treatment?.treatment_type);
                     pushDatedRow({
                         name: treatmentId,
+                        // Show the treatment type next to the id in the row label,
+                        // e.g. "TR_001: Systemic therapy". The point name stays the
+                        // bare id (the tooltip lists the type separately).
+                        displayLabel: treatmentTypeText ? `${treatmentId}: ${treatmentTypeText}` : treatmentId,
                         start: treatmentStart,
                         end: treatmentEnd,
                         treatment_type: treatment?.treatment_type,
@@ -550,6 +569,9 @@ function Timeline({ data, onEventClick }) {
                         const rowName = `↳ ${treatmentId}: ${label}`;
                         pushDatedRow({
                             name: rowName,
+                            // Indentation conveys the parent, so the row label shows
+                            // just the drug/therapy; the full name is kept for tooltips.
+                            displayLabel: label,
                             start: therapy.start_date?.month_interval,
                             end: therapy.end_date?.month_interval,
                             treatment_type: therapy.systemic_therapy_type,
@@ -612,6 +634,11 @@ function Timeline({ data, onEventClick }) {
         Updatedseries.push(treatmentsSeries);
 
         const newCategories = activeCategories.concat(orderedTreatmentNames);
+        // Indent depth and display text for every y category, parallel to
+        // newCategories. Non-treatment rows and the "Treatments" summary bar are
+        // depth 0; individual treatments depth 1; expanded drug rows depth 2.
+        const categoryDepths = [...activeCategories.map(() => 0), ...orderedTreatmentDepths];
+        const categoryLabels = [...activeCategories, ...orderedTreatmentLabels];
 
         // Initial view: zoom to the span between the first day of diagnosis and the
         // last displayed event. Earlier events (e.g. birth) remain reachable via the
@@ -697,9 +724,16 @@ function Timeline({ data, onEventClick }) {
                 // name, so the interleaved sub-treatment rows stay in the right order.
                 uniqueNames: false,
                 labels: {
-                    style: {
-                        fontFamily: 'Arial, sans-serif',
-                        fontWeight: 'bold'
+                    useHTML: true,
+                    align: 'left',
+                    // Indent each row by its depth so individual treatments sit under
+                    // the "Treatments" bar and expanded drug rows sit under their
+                    // treatment. Points are placed by explicit y index, so changing
+                    // the label text here doesn't affect row placement.
+                    formatter() {
+                        const depth = categoryDepths[this.pos] || 0;
+                        const label = categoryLabels[this.pos] ?? this.value;
+                        return `<span style="padding-left:${depth * 14}px;font-family:Arial,sans-serif;font-weight:bold">${label}</span>`;
                     }
                 },
                 min: 0,

--- a/src/views/clinicalGenomic/widgets/timeline.jsx
+++ b/src/views/clinicalGenomic/widgets/timeline.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsGantt from 'highcharts/modules/gantt';
 import HighchartsReact from 'highcharts-react-official';
@@ -55,6 +55,28 @@ const tooltipFormatter = () =>
             tooltipContent = `${boldName}${getDateText(this.x)}`;
         }
 
+        if (this.disease_status_at_followup) {
+            tooltipContent += `<br/>Disease status: ${this.disease_status_at_followup}`;
+        }
+
+        // Surgery / radiation detail for treatments whose type calls for it.
+        if (Array.isArray(this.surgeries)) {
+            this.surgeries.forEach((surgery) => {
+                if (surgery.type && surgery.site) {
+                    tooltipContent += `<br/>Surgery: ${surgery.type} (${surgery.site})`;
+                } else if (surgery.type) {
+                    tooltipContent += `<br/>Surgery: ${surgery.type}`;
+                } else if (surgery.site) {
+                    tooltipContent += `<br/>Surgery site: ${surgery.site}`;
+                }
+            });
+        }
+        if (Array.isArray(this.radiations)) {
+            this.radiations.forEach((modality) => {
+                tooltipContent += `<br/>Radiation modality: ${modality}`;
+            });
+        }
+
         return tooltipContent;
     };
 
@@ -63,7 +85,23 @@ function Timeline({ data, onEventClick }) {
     const [chartOptions, setChartOptions] = useState({});
     const birthMonthInterval = data?.date_of_birth?.month_interval ?? 0;
     const [isTreatmentsCollapsed, setIsTreatmentsCollapsed] = useState(false);
+    // Set of submitter_treatment_ids whose dated sub-treatments are expanded.
+    const [expandedTreatments, setExpandedTreatments] = useState(() => new Set());
     const theme = useTheme();
+
+    // Toggle whether a single treatment's dated sub-treatments (systemic therapies)
+    // are shown as indented rows beneath it.
+    const toggleTreatmentExpand = useCallback((treatmentId) => {
+        setExpandedTreatments((prev) => {
+            const next = new Set(prev);
+            if (next.has(treatmentId)) {
+                next.delete(treatmentId);
+            } else {
+                next.add(treatmentId);
+            }
+            return next;
+        });
+    }, []);
     useEffect(() => {
         let dob = data?.date_of_birth?.month_interval ?? 0;
         dob += data?.date_of_birth?.day_interval ? (data.date_of_birth.day_interval % 32) / 32 : 0;
@@ -100,7 +138,8 @@ function Timeline({ data, onEventClick }) {
                       name: `${namePrefix}${item?.[id]}`,
                       color: colour,
                       customGroupId: name,
-                      showInNavigator: true
+                      showInNavigator: true,
+                      disease_status_at_followup: item?.disease_status_at_followup
                   }))
                 : [];
 
@@ -173,7 +212,8 @@ function Timeline({ data, onEventClick }) {
                           name: `${namePrefix}${subItem?.[id]}`,
                           color: colour,
                           customGroupId: name,
-                          showInNavigator: true
+                          showInNavigator: true,
+                          disease_status_at_followup: subItem?.disease_status_at_followup
                       }))
                     : []
             ) || [];
@@ -190,7 +230,8 @@ function Timeline({ data, onEventClick }) {
                                     name: `${namePrefix}${subItem2?.[id]}`,
                                     color: colour,
                                     customGroupId: name,
-                                    showInNavigator: true
+                                    showInNavigator: true,
+                                    disease_status_at_followup: subItem2?.disease_status_at_followup
                                 }))
                               : []
                       )
@@ -353,71 +394,178 @@ function Timeline({ data, onEventClick }) {
         let yIndex = activeCategories.length - 1;
         const treatmentIntervals = [];
         const treatmentPoints = [];
+        // Category names in row order (parent treatments interleaved with their
+        // expanded sub-treatments), used to build the yAxis categories.
+        const orderedTreatmentNames = [];
+        // Treatments that have at least one dated sub-treatment; each gets an
+        // expand/collapse toggle rendered next to its row.
+        const subTreatmentParents = [];
+
+        // Adds one dated row (a gantt bar if it has both dates, otherwise a single
+        // point) and records its category name in row order.
+        const pushDatedRow = ({ name, start, end, treatment_type, intervalColour, pointColour, isSubTreatment, surgeries, radiations }) => {
+            if (start != null && end != null) {
+                treatmentIntervals.push({
+                    name,
+                    start: start - birthMonthInterval,
+                    end: end - birthMonthInterval,
+                    treatment_type,
+                    y: (yIndex += 1),
+                    color: intervalColour,
+                    customGroupId: 'treatments',
+                    isSubTreatment,
+                    // A same-day treatment has zero width; render it as a visible milestone.
+                    milestone: start === end,
+                    surgeries,
+                    radiations
+                });
+            } else {
+                const presentDate = start != null ? start : end;
+                treatmentPoints.push({
+                    x: presentDate - birthMonthInterval,
+                    name,
+                    y: (yIndex += 1),
+                    color: pointColour,
+                    treatment_type,
+                    extra_info: start != null ? 'Start' : 'End',
+                    missing_info: start != null ? 'End' : 'Start',
+                    customGroupId: 'treatments',
+                    isSubTreatment,
+                    surgeries,
+                    radiations
+                });
+            }
+            orderedTreatmentNames.push(name);
+        };
+
+        // Pulls surgery/radiation detail for a treatment's tooltip, but only when the
+        // treatment_type calls for it and a matching linked object actually exists.
+        // Anything missing is simply omitted so nothing errors or shows blank.
+        const treatmentTypeIncludes = (treatment, keyword) =>
+            (Array.isArray(treatment?.treatment_type) ? treatment.treatment_type : [treatment?.treatment_type]).some(
+                (type) => typeof type === 'string' && type.toLowerCase().includes(keyword)
+            );
+
+        const getSurgeryDetails = (treatment) =>
+            treatmentTypeIncludes(treatment, 'surgery') && Array.isArray(treatment?.surgeries)
+                ? treatment.surgeries
+                      .map((surgery) => ({ type: surgery?.surgery_type, site: surgery?.surgery_site }))
+                      .filter((surgery) => surgery.type || surgery.site)
+                : [];
+
+        const getRadiationDetails = (treatment) =>
+            treatmentTypeIncludes(treatment, 'radiation') && Array.isArray(treatment?.radiations)
+                ? treatment.radiations.map((radiation) => radiation?.radiation_therapy_modality).filter(Boolean)
+                : [];
+
+        // The parent "Treatments" summary bar spans the full treatment range, so
+        // compute that range from the raw dates regardless of collapse state.
+        const treatmentTimes = [];
         data.primary_diagnoses?.forEach((diagnosis) =>
             diagnosis.treatments?.forEach((treatment) => {
-                const treatmentStart = treatment.treatment_start_date?.month_interval;
-                const treatmentEnd = treatment.treatment_end_date?.month_interval;
-
-                if (treatmentStart !== null && treatmentStart !== undefined && treatmentEnd !== null && treatmentEnd !== undefined) {
-                    treatmentIntervals.push({
-                        name: treatment.submitter_treatment_id,
-                        start: treatmentStart - birthMonthInterval,
-                        end: treatmentEnd - birthMonthInterval,
-                        treatment_type: treatment?.treatment_type,
-                        y: (yIndex += 1),
-                        color: theme.palette.primary.main,
-                        customGroupId: 'treatments'
-                    });
-                } else if (
-                    (treatmentStart !== null && treatmentStart !== undefined) ||
-                    (treatmentEnd !== null && treatmentEnd !== undefined)
-                ) {
-                    treatmentPoints.push({
-                        x: treatmentStart - birthMonthInterval,
-                        name: treatment.submitter_treatment_id,
-                        y: (yIndex += 1),
-                        color: theme.palette.primary.light,
-                        treatment_type: treatment?.treatment_type,
-                        extra_info: treatmentStart !== null ? 'Start' : 'End',
-                        missing_info: treatmentStart !== null ? 'End' : 'Start',
-                        customGroupId: 'treatments'
-                    });
-                }
+                const start = treatment.treatment_start_date?.month_interval;
+                const end = treatment.treatment_end_date?.month_interval;
+                if (start != null) treatmentTimes.push(start - birthMonthInterval);
+                if (end != null) treatmentTimes.push(end - birthMonthInterval);
             })
         );
+        const maxTime = treatmentTimes.length > 0 ? Math.max(...treatmentTimes) : undefined;
+        const minTime = treatmentTimes.length > 0 ? Math.min(...treatmentTimes) : undefined;
 
-        const startTimes = treatmentIntervals.map((interval) => interval.start);
-        const endTimes = treatmentIntervals.map((interval) => interval.end);
-        const xValues = treatmentPoints.map((point) => point.x);
-        const allValues = [...startTimes, ...endTimes, ...xValues];
-        const maxTime = allValues ? Math.max(...allValues) : 'undefined';
-        const minTime = allValues ? Math.min(...allValues) : 'undefined';
+        // Build the individual treatment (and expanded sub-treatment) rows only when the
+        // Treatments group is expanded. When collapsed we keep just the parent summary
+        // row so it — and its expand toggle — stay visible instead of scrolling off.
+        if (!isTreatmentsCollapsed) {
+            data.primary_diagnoses?.forEach((diagnosis) =>
+                diagnosis.treatments?.forEach((treatment) => {
+                    const treatmentId = treatment.submitter_treatment_id;
+                    const treatmentStart = treatment.treatment_start_date?.month_interval;
+                    const treatmentEnd = treatment.treatment_end_date?.month_interval;
 
-        const treatmentParentSeries = {
+                    // Treatments with no dates at all can't be placed on the timeline.
+                    if (treatmentStart == null && treatmentEnd == null) {
+                        return;
+                    }
+
+                    pushDatedRow({
+                        name: treatmentId,
+                        start: treatmentStart,
+                        end: treatmentEnd,
+                        treatment_type: treatment?.treatment_type,
+                        intervalColour: theme.palette.primary.main,
+                        pointColour: theme.palette.primary.light,
+                        isSubTreatment: false,
+                        surgeries: getSurgeryDetails(treatment),
+                        radiations: getRadiationDetails(treatment)
+                    });
+
+                    // Only systemic therapies carry their own dates in the data model;
+                    // radiations and surgeries have none, so they are not shown here.
+                    const datedTherapies = (treatment.systemic_therapies || []).filter(
+                        (therapy) => therapy?.start_date?.month_interval != null || therapy?.end_date?.month_interval != null
+                    );
+                    if (datedTherapies.length === 0) {
+                        return;
+                    }
+
+                    subTreatmentParents.push({ name: treatmentId, expanded: expandedTreatments.has(treatmentId) });
+                    if (!expandedTreatments.has(treatmentId)) {
+                        return;
+                    }
+
+                    datedTherapies.forEach((therapy) => {
+                        const label = therapy.drug_name || therapy.systemic_therapy_type || 'Systemic therapy';
+                        const rowName = `↳ ${treatmentId}: ${label}`;
+                        pushDatedRow({
+                            name: rowName,
+                            start: therapy.start_date?.month_interval,
+                            end: therapy.end_date?.month_interval,
+                            treatment_type: therapy.systemic_therapy_type,
+                            intervalColour: theme.palette.secondary.main,
+                            pointColour: theme.palette.secondary.light,
+                            isSubTreatment: true
+                        });
+                    });
+                })
+            );
+        }
+
+        // All treatment rows (parent summary bar, each treatment, and each expanded
+        // sub-treatment) live in ONE gantt series. Highcharts does not reliably place
+        // many single-point gantt series on a category axis, so a single multi-point
+        // series is required for the y (row) of every point to be respected.
+        const treatmentData = [
+            {
+                start: minTime,
+                end: maxTime,
+                y: yIndexParent,
+                color: theme.palette.primary.dark,
+                name: 'Treatments',
+                customGroupId: 'treatments'
+            },
+            ...treatmentIntervals,
+            // Treatments with a single date render as gantt milestones.
+            ...treatmentPoints.map((point) => ({ ...point, start: point.x, end: point.x, milestone: true }))
+        ];
+
+        const treatmentsSeries = {
             type: 'gantt',
-            data: [
-                {
-                    start: minTime,
-                    end: maxTime,
-                    y: yIndexParent,
-                    color: theme.palette.primary.dark,
-                    name: 'Treatments',
-                    customGroupId: 'treatments'
-                }
-            ],
+            name: 'Treatments',
+            customGroupId: 'treatments',
+            data: treatmentData,
             marker: {
                 enabled: true,
                 symbol: 'circle',
                 radius: 4
             },
             tooltip,
-            name: 'Treatments'
+            // Always visible: collapsing is handled by omitting the detail rows above,
+            // so the parent summary row (and its toggle) stay on the chart.
+            visible: true
         };
 
-        adjustedSeries.push(...treatmentIntervals, ...treatmentPoints);
-
         const Updatedseries = adjustedSeries.map((s) => ({
-            type: typeof s?.start !== 'undefined' ? 'gantt' : 'scatter',
+            type: 'scatter',
             data: [s],
             name: s.name,
             marker: {
@@ -426,63 +574,82 @@ function Timeline({ data, onEventClick }) {
                 radius: 4
             },
             tooltip,
-            visible: s?.customGroupId === 'treatments' ? !isTreatmentsCollapsed : true
+            visible: true
         }));
 
-        Updatedseries.push(treatmentParentSeries);
+        Updatedseries.push(treatmentsSeries);
 
-        const newCategories = activeCategories.concat(
-            treatmentIntervals.map((t) => t.name),
-            treatmentPoints.map((t) => t.name)
-        );
+        const newCategories = activeCategories.concat(orderedTreatmentNames);
 
-        const toggleTreatmentsCollapse = () => {
-            setIsTreatmentsCollapsed((current) => {
-                const newVisibility = !current;
-                Highcharts.charts.forEach((chart) => {
-                    if (chart) {
-                        chart.series.forEach((series) => {
-                            if (series.userOptions.customGroupId === 'treatments') {
-                                series.setVisible(newVisibility);
-                            }
-                        });
-                        chart.redraw();
-                    }
-                });
-                return newVisibility;
-            });
-        };
+        // Initial view: zoom to the span between the first day of diagnosis and the
+        // last displayed event. Earlier events (e.g. birth) remain reachable via the
+        // navigator/scrollbar.
+        const diagnosisX = -birthMonthInterval;
+        const displayedTimes = [
+            ...adjustedSeries.flatMap((s) => [s?.x, s?.start, s?.end]),
+            ...treatmentData.flatMap((s) => [s?.start, s?.end])
+        ].filter((v) => typeof v === 'number' && Number.isFinite(v));
+        const lastDisplayed = displayedTimes.length > 0 ? Math.max(...displayedTimes) : diagnosisX;
+        const zoomPadding = 2;
+        const initialMin = diagnosisX - zoomPadding;
+        const initialMax = Math.max(lastDisplayed + zoomPadding, initialMin + 12);
+
+        // Grow the chart with the number of rows so expanded sub-treatments always
+        // fit; a fixed height overflows and Highcharts clamps extra rows to the top.
+        const chartHeight = Math.max(600, 200 + newCategories.length * 45);
+
+        // Collapsing/expanding just flips the flag; the effect rebuilds the chart with
+        // or without the detail rows (the parent summary row always stays).
+        const toggleTreatmentsCollapse = () => setIsTreatmentsCollapsed((current) => !current);
 
         // Handles setup of the Highcharts chart with the patient data
         setChartOptions({
             chart: {
-                height: 600,
+                height: chartHeight,
                 marginRight: 50,
                 events: {
                     render() {
                         const chart = this;
 
-                        if (chart.customButton) {
-                            chart.customButton.destroy();
-                        }
+                        // Redraw all collapse/expand toggles from scratch each render.
+                        (chart.customButtons || []).forEach((button) => button?.destroy());
+                        chart.customButtons = [];
 
-                        const treatmentCategoryIndex = chart.yAxis[0].categories.indexOf('Treatments');
-                        const yPosition = chart.yAxis[0].toPixels(treatmentCategoryIndex) - 5;
-                        chart.customButton = chart.renderer
-                            .symbol('triangle', chart.plotLeft - 15, yPosition, 10, 10)
-                            .attr({
-                                fill: '#7cb5ec',
-                                cursor: 'pointer'
-                            })
-                            .add()
-                            .on('click', () => {
-                                toggleTreatmentsCollapse();
+                        // Draws a triangle toggle beside the row for `categoryName`.
+                        // `collapsed` controls its rotation (pointing up when collapsed).
+                        const drawToggle = (categoryName, collapsed, onClick) => {
+                            const categoryIndex = chart.yAxis[0].categories.indexOf(categoryName);
+                            if (categoryIndex < 0) {
+                                return;
+                            }
+                            const yPosition = chart.yAxis[0].toPixels(categoryIndex) - 5;
+                            const button = chart.renderer
+                                .symbol('triangle', chart.plotLeft - 15, yPosition, 10, 10)
+                                .attr({
+                                    fill: '#7cb5ec',
+                                    cursor: 'pointer',
+                                    zIndex: 6
+                                })
+                                .add()
+                                .on('click', onClick);
+
+                            if (collapsed) {
+                                button.attr({
+                                    transform: `rotate(180 ${button.x + 5} ${button.y + 5})`
+                                });
+                            }
+                            chart.customButtons.push(button);
+                        };
+
+                        // Parent toggle collapses/expands the whole Treatments group.
+                        drawToggle('Treatments', isTreatmentsCollapsed, () => toggleTreatmentsCollapse());
+
+                        // Per-treatment toggles reveal each treatment's dated sub-treatments.
+                        if (!isTreatmentsCollapsed) {
+                            subTreatmentParents.forEach(({ name, expanded }) => {
+                                drawToggle(name, !expanded, () => toggleTreatmentExpand(name));
                             });
-
-                        const rotationDeg = isTreatmentsCollapsed ? 180 : 0;
-                        chart.customButton.attr({
-                            transform: `rotate(${rotationDeg} ${chart.customButton.x + 5} ${chart.customButton.y + 5})`
-                        });
+                        }
                     }
                 }
             },
@@ -494,7 +661,9 @@ function Timeline({ data, onEventClick }) {
                 }
             },
             yAxis: {
-                uniqueNames: true,
+                // Place points by their explicit y (row index) rather than by point
+                // name, so the interleaved sub-treatment rows stay in the right order.
+                uniqueNames: false,
                 labels: {
                     style: {
                         fontFamily: 'Arial, sans-serif',
@@ -511,6 +680,8 @@ function Timeline({ data, onEventClick }) {
                     type: 'linear',
                     tickInterval: 1,
                     minRange: 12,
+                    min: initialMin,
+                    max: initialMax,
                     labels: {
                         align: 'center',
                         formatter: formatHeader('Month'),
@@ -629,6 +800,8 @@ function Timeline({ data, onEventClick }) {
     }, [
         data,
         isTreatmentsCollapsed,
+        expandedTreatments,
+        toggleTreatmentExpand,
         birthMonthInterval,
         onEventClick,
         theme.palette.primary.dark,


### PR DESCRIPTION
## Summary

Enhancements to the patient info page (timeline + sidebar + clinical table + guided tour).

### Timeline
- Each treatment's dated sub-treatments (systemic therapies) now appear as **expandable rows** beneath it, each treatment with its own expand/collapse toggle.
- Expanded rows are now **indented as a tree**: each individual treatment sits under the overall **Treatments** bar, and each dated drug row sits indented under its treatment (y-axis labels indent by depth).
- Treatment row labels show the **treatment type next to the id** (e.g. `TR_001: Systemic therapy`, `TR_002: Radiation therapy`, `TR_003: Surgery`), joined with commas for multi-type treatments. Drug rows show just the drug/therapy name, since the indentation conveys the parent. Point names are unchanged, so tooltips are unaffected.
- All treatment bars are rendered in a **single gantt series** so every row's placement is respected (previously, many single-point series caused rows to be misplaced). Same-day treatments render as **milestones**.
- The initial view is **zoomed to the span from first-day-of-diagnosis to the last displayed event**.
- Collapsing the overall **Treatments** group now keeps its summary row (and toggle) visible instead of dropping off-screen.
- Tooltips: **disease status** added to followup points; **surgery type/site** and **radiation modality** added to the relevant treatment tooltips (pulled from linked objects only when the `treatment_type` calls for it; missing fields are omitted, never errored). The trailing blank line under the start/end dates was removed so these detail lines sit directly beneath the dates.

### Sidebar — "Look up donor by ID"
New form beneath the metadata folders that jumps to a specific donor. **Node** and **Program** are dropdowns limited to the programs the user is authorized for (`v3/authorized/programs`). Once a program is selected, the **Donor ID** field is a **searchable dropdown of the donors the user may read in that program** (`v3/authorized/donors/?program_id=`), so a valid ID under the wrong program is impossible and only accessible donors appear. Donor lists are cached per node+program.

Because the donor is chosen from the authorized list, it is guaranteed to exist and be accessible, so selection **navigates straight to the patient view without a re-fetch**.

Both the program and donor fetches pass a very large `page_size` so the dropdowns list **every** authorized program/donor rather than being silently truncated by katsu's default 100-per-page pagination. (The `page_size` "max 1000" in katsu's pagination docstring is not enforced in code, so a large value returns the full set in one request — the same approach the query service already uses.)

> **Fix (why the earlier free-text version failed on a real deployment):** katsu returns **404** for a not-found/inaccessible donor, federation's `merge_status` collapses that to an aggregate **404**, and `fetchFederation` **throws** on any non-2xx. The previous free-text field assumed a `200` with a nested `{error}` body (what the mock returns) to show a friendly "no donor found" message — so on a production-style backend that branch never ran and the lookup surfaced a generic error / 404. The dropdown approach removes the whole wrong-program/typo failure mode and the aggregate-404 path.

### Guided tour
- The **"Take a tour"** button now lives in the **header next to the profile menu** on the patient page (matching the search page), instead of an inline button in the page body. First-visit auto-start is unchanged.
- The **"Browse clinical categories"** step now highlights only the clinical category folders (not the donor lookup form).
- Timeline coverage is split into an overview step and an **"Expand treatment details"** step that **live-demonstrates** a systemic-therapy treatment expanding into its per-drug rows (then resets on exit).
- The **"Look up another donor"** step is now the **final** step, closing the tour.

### Clinical table
- `specimen_collection_date` is now labelled **"Diagnosis to specimen collection date"**, since the displayed value is relative to the date of diagnosis.

## Testing
Verified against the `candig-mock-server`: sub-treatment expand/collapse, tree indentation of treatments/drug rows, treatment-type row labels, initial zoom, tooltip additions + blank-line removal, the global Treatments collapse fix, the donor lookup (authorized-only node/program dropdowns, donor dropdown populated from `v3/authorized/donors/`, navigation to a working patient view on selection), and the full patient tour (header button, category-only highlight, live treatment-expansion demo, donor lookup as the final step). The mock server gained a `v3/authorized/donors/` handler to support the dropdown locally. No console errors; lint clean.

## Notes
- Portal-only change — no backend service changes required (`v3/authorized/donors/` already exists in katsu).
- Submodule pointer in CanDIGv2 not updated yet (per branching convention, after this merges/tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
