### PR TITLE
Add site admin, site curator, and user management dashboards

### DIFF
--- a/src/hooks/useAdminAction.jsx
+++ b/src/hooks/useAdminAction.jsx
@@ -1,0 +1,43 @@
+import { useCallback, useState } from 'react';
+
+// ===========================|| ADMIN ACTION HOOK ||=========================== //
+
+/*
+ * Shared busy/feedback state and a runAction helper for the admin dashboard
+ * sections. Consolidates the repeated pattern of: set busy, clear feedback, run
+ * an async action, then surface a success or error Alert.
+ *
+ * runAction resolves to { ok, result, error } (it never rejects) so callers can
+ * refresh their data and clear inputs ONLY on success:
+ *
+ *   runAction(() => approveUser(id), `Approved ${id}.`).then((r) => r.ok && reload());
+ *
+ * setBusy/setFeedback are also exposed for bespoke flows (e.g. batch operations
+ * that report partial success themselves).
+ *
+ * @returns {{ busy, setBusy, feedback, setFeedback, runAction }}
+ */
+export default function useAdminAction() {
+    const [busy, setBusy] = useState(false);
+    const [feedback, setFeedback] = useState(null);
+
+    const runAction = useCallback(
+        (action, successText) => {
+            setBusy(true);
+            setFeedback(null);
+            return action()
+                .then((result) => {
+                    setFeedback({ severity: 'success', text: successText });
+                    return { ok: true, result };
+                })
+                .catch((error) => {
+                    setFeedback({ severity: 'error', text: `${error}` });
+                    return { ok: false, error };
+                })
+                .finally(() => setBusy(false));
+        },
+        []
+    );
+
+    return { busy, setBusy, feedback, setFeedback, runAction };
+}

--- a/src/hooks/useSiteAdmin.jsx
+++ b/src/hooks/useSiteAdmin.jsx
@@ -1,0 +1,14 @@
+import useSiteRoles from './useSiteRoles';
+
+// ===========================|| SITE ADMIN HOOK ||=========================== //
+
+/*
+ * Convenience wrapper around useSiteRoles for callers that only care whether the
+ * current user is a site administrator.
+ *
+ * @returns {{ loading: boolean, isSiteAdmin: boolean, userId: string|undefined }}
+ */
+export default function useSiteAdmin() {
+    const { loading, isSiteAdmin, userId } = useSiteRoles();
+    return { loading, isSiteAdmin, userId };
+}

--- a/src/hooks/useSiteAdmin.jsx
+++ b/src/hooks/useSiteAdmin.jsx
@@ -4,11 +4,11 @@ import useSiteRoles from './useSiteRoles';
 
 /*
  * Convenience wrapper around useSiteRoles for callers that only care whether the
- * current user is a site administrator.
+ * current user is a site administrator. Shares the same cached /user/me request.
  *
- * @returns {{ loading: boolean, isSiteAdmin: boolean, userId: string|undefined }}
+ * @returns {{ loading: boolean, error: string|null, isSiteAdmin: boolean, userId: string|undefined }}
  */
 export default function useSiteAdmin() {
-    const { loading, isSiteAdmin, userId } = useSiteRoles();
-    return { loading, isSiteAdmin, userId };
+    const { loading, error, isSiteAdmin, userId } = useSiteRoles();
+    return { loading, error, isSiteAdmin, userId };
 }

--- a/src/hooks/useSiteRoles.jsx
+++ b/src/hooks/useSiteRoles.jsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+import { fetchCurrentUserAuthorization } from '../store/api';
+
+// Default site role names, as defined in the OPA site_roles store.
+const SITE_ADMIN_ROLE = 'admin';
+const SITE_CURATOR_ROLE = 'curator';
+
+// ===========================|| SITE ROLES HOOK ||=========================== //
+
+/*
+ * Fetch the currently logged-in user's site roles from the ingest service's
+ * /user/me endpoint and expose convenient booleans. Used to gate the site
+ * admin / site curator dashboards and their menu entries.
+ *
+ * @returns {{ loading: boolean, roles: string[], isSiteAdmin: boolean, isSiteCurator: boolean, userId: string|undefined }}
+ */
+export default function useSiteRoles() {
+    const [state, setState] = useState({ loading: true, roles: [], userId: undefined });
+
+    useEffect(() => {
+        let active = true;
+        fetchCurrentUserAuthorization()
+            .then((authorization) => {
+                if (!active) {
+                    return;
+                }
+                setState({
+                    loading: false,
+                    roles: authorization?.site_roles || [],
+                    userId: authorization?.userinfo?.user_name
+                });
+            })
+            .catch((error) => {
+                console.log(`Could not determine site roles: ${error}`);
+                if (active) {
+                    setState({ loading: false, roles: [], userId: undefined });
+                }
+            });
+        return () => {
+            active = false;
+        };
+    }, []);
+
+    return {
+        ...state,
+        isSiteAdmin: state.roles.includes(SITE_ADMIN_ROLE),
+        isSiteCurator: state.roles.includes(SITE_CURATOR_ROLE)
+    };
+}

--- a/src/hooks/useSiteRoles.jsx
+++ b/src/hooks/useSiteRoles.jsx
@@ -1,22 +1,24 @@
 import { useEffect, useState } from 'react';
 
 import { fetchCurrentUserAuthorization } from '../store/api';
-
-// Default site role names, as defined in the OPA site_roles store.
-const SITE_ADMIN_ROLE = 'admin';
-const SITE_CURATOR_ROLE = 'curator';
+import { SITE_ROLES } from '../store/constant';
 
 // ===========================|| SITE ROLES HOOK ||=========================== //
 
 /*
- * Fetch the currently logged-in user's site roles from the ingest service's
- * /user/me endpoint and expose convenient booleans. Used to gate the site
- * admin / site curator dashboards and their menu entries.
+ * Fetch the currently logged-in user's authorization from the ingest service's
+ * /user/me endpoint (shared/cached — see fetchCurrentUserAuthorization) and
+ * expose convenient role booleans. Used to gate the site admin / site curator
+ * dashboards and their menu entries.
  *
- * @returns {{ loading: boolean, roles: string[], isSiteAdmin: boolean, isSiteCurator: boolean, userId: string|undefined }}
+ * Distinguishes a genuine "not authorized" (roles resolved, but empty) from a
+ * fetch failure via the `error` field, so callers can show an error state
+ * separate from the unauthorized state.
+ *
+ * @returns {{ loading, error, roles, userinfo, userId, isSiteAdmin, isSiteCurator }}
  */
 export default function useSiteRoles() {
-    const [state, setState] = useState({ loading: true, roles: [], userId: undefined });
+    const [state, setState] = useState({ loading: true, error: null, roles: [], userinfo: undefined });
 
     useEffect(() => {
         let active = true;
@@ -27,14 +29,15 @@ export default function useSiteRoles() {
                 }
                 setState({
                     loading: false,
+                    error: null,
                     roles: authorization?.site_roles || [],
-                    userId: authorization?.userinfo?.user_name
+                    userinfo: authorization?.userinfo
                 });
             })
             .catch((error) => {
                 console.log(`Could not determine site roles: ${error}`);
                 if (active) {
-                    setState({ loading: false, roles: [], userId: undefined });
+                    setState({ loading: false, error: `${error}`, roles: [], userinfo: undefined });
                 }
             });
         return () => {
@@ -44,7 +47,8 @@ export default function useSiteRoles() {
 
     return {
         ...state,
-        isSiteAdmin: state.roles.includes(SITE_ADMIN_ROLE),
-        isSiteCurator: state.roles.includes(SITE_CURATOR_ROLE)
+        userId: state.userinfo?.user_name,
+        isSiteAdmin: state.roles.includes(SITE_ROLES.ADMIN),
+        isSiteCurator: state.roles.includes(SITE_ROLES.CURATOR)
     };
 }

--- a/src/layout/MainLayout/Header/ProfileSection/index.jsx
+++ b/src/layout/MainLayout/Header/ProfileSection/index.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { styled } from '@mui/material/styles';
 import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 
 import { useTheme } from '@mui/system';
 import {
@@ -23,9 +24,11 @@ import {
 import MainCard from '../../../../ui-component/cards/MainCard';
 import Transitions from '../../../../ui-component/extended/Transitions';
 import { SITE } from '../../../../store/constant';
+import config from '../../../../config';
+import useSiteRoles from '../../../../hooks/useSiteRoles';
 
 // assets
-import { IconLogout, IconSettings } from '@tabler/icons-react';
+import { IconLogout, IconSettings, IconUser, IconUserShield, IconUsersGroup } from '@tabler/icons-react';
 import siteLogo from '../../../../assets/images/users/siteLogo.png';
 import APITokenButton from './apiTokenbutton';
 
@@ -176,6 +179,8 @@ const PopperRoot = styled(Popper)(({ theme }) => ({
 function ProfileSection() {
     const theme = useTheme();
     const customization = useSelector((state) => state.customization);
+    const navigate = useNavigate();
+    const { isSiteAdmin, isSiteCurator } = useSiteRoles();
 
     const [open, setOpen] = useState(false);
 
@@ -185,6 +190,11 @@ function ProfileSection() {
 
     const handleToggle = () => {
         setOpen((prevOpen) => !prevOpen);
+    };
+
+    const handleNavigate = (path) => {
+        setOpen(false);
+        navigate(path);
     };
     const handleClose = (event) => {
         if (anchorEl?.current?.contains(event.target)) {
@@ -287,6 +297,42 @@ function ProfileSection() {
                                         <Divider />
                                         <List component="nav" className={classes.navContainer}>
                                             <APITokenButton classes={classes} customization={customization} />
+                                            {!isSiteAdmin && !isSiteCurator && (
+                                                <ListItemButton
+                                                    className={classes.listItem}
+                                                    sx={{ borderRadius: `${customization.borderRadius}px` }}
+                                                    onClick={() => handleNavigate(`${config.basename}/userDashboard`)}
+                                                >
+                                                    <ListItemIcon>
+                                                        <IconUser stroke={1.5} size="1.3rem" />
+                                                    </ListItemIcon>
+                                                    <ListItemText primary={<Typography variant="body2">User Dashboard</Typography>} />
+                                                </ListItemButton>
+                                            )}
+                                            {isSiteAdmin && (
+                                                <ListItemButton
+                                                    className={classes.listItem}
+                                                    sx={{ borderRadius: `${customization.borderRadius}px` }}
+                                                    onClick={() => handleNavigate(`${config.basename}/siteAdmin`)}
+                                                >
+                                                    <ListItemIcon>
+                                                        <IconUserShield stroke={1.5} size="1.3rem" />
+                                                    </ListItemIcon>
+                                                    <ListItemText primary={<Typography variant="body2">Site Admin Dashboard</Typography>} />
+                                                </ListItemButton>
+                                            )}
+                                            {isSiteCurator && (
+                                                <ListItemButton
+                                                    className={classes.listItem}
+                                                    sx={{ borderRadius: `${customization.borderRadius}px` }}
+                                                    onClick={() => handleNavigate(`${config.basename}/siteCurator`)}
+                                                >
+                                                    <ListItemIcon>
+                                                        <IconUsersGroup stroke={1.5} size="1.3rem" />
+                                                    </ListItemIcon>
+                                                    <ListItemText primary={<Typography variant="body2">Site Curator Dashboard</Typography>} />
+                                                </ListItemButton>
+                                            )}
                                             <ListItemButton
                                                 className={classes.listItem}
                                                 sx={{ borderRadius: `${customization.borderRadius}px` }}

--- a/src/layout/MainLayout/Header/ProfileSection/index.jsx
+++ b/src/layout/MainLayout/Header/ProfileSection/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { styled } from '@mui/material/styles';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
@@ -180,11 +180,14 @@ function ProfileSection() {
     const theme = useTheme();
     const customization = useSelector((state) => state.customization);
     const navigate = useNavigate();
-    const { isSiteAdmin, isSiteCurator } = useSiteRoles();
+    const { isSiteAdmin, isSiteCurator, userinfo } = useSiteRoles();
 
     const [open, setOpen] = useState(false);
 
-    const [username, setUsername] = useState('');
+    // Displayed identity comes from the shared (cached) /user/me authorization —
+    // prefer the configured user key (preferred_username) to match the previous
+    // /query/whoami value, falling back to the user_name.
+    const username = userinfo?.preferred_username || userinfo?.user_name || '';
 
     const anchorEl = React.useRef(null);
 
@@ -203,25 +206,6 @@ function ProfileSection() {
 
         setOpen(false);
     };
-
-    // Grab the user key for the logged in user
-    useEffect(() => {
-        fetch(`/query/whoami`)
-            .then((response) => {
-                if (response.ok) {
-                    return response.json();
-                }
-                console.log(`whoami could not determine logged in user: ${response}`);
-                throw new Error(`${response}`);
-            })
-            .then((response) => {
-                setUsername(response?.key);
-            })
-            .catch((error) => {
-                console.log(`Whoami error: ${error}`);
-                return '';
-            });
-    }, []);
 
     return (
         <>

--- a/src/layout/MainLayout/Header/index.jsx
+++ b/src/layout/MainLayout/Header/index.jsx
@@ -7,6 +7,7 @@ import LogoSection from '../LogoSection';
 // import SearchSection from './SearchSection';
 import ProfileSection from './ProfileSection';
 import TourButton from './TourButton';
+import PendingUsersNotification from '../../../ui-component/PendingUsersNotification';
 // import NotificationSection from './NotificationSection';
 import MenuList from '../../../MenuList';
 
@@ -81,6 +82,7 @@ function Header({ handleLeftDrawerToggle }) {
 
             {/* notification & profile */}
             {/* <NotificationSection /> */}
+            <PendingUsersNotification />
             <ProfileSection />
         </>
     );

--- a/src/routes/MainRoutes.jsx
+++ b/src/routes/MainRoutes.jsx
@@ -26,6 +26,15 @@ const IngestPortal = Loadable(lazy(() => import('../views/ingest/ingest')));
 // Completeness
 const CompletenessStats = Loadable(lazy(() => import('../views/completeness/completeness')));
 
+// Site Admin Dashboard
+const SiteAdmin = Loadable(lazy(() => import('../views/siteAdmin/siteAdmin')));
+
+// Site Curator Dashboard
+const SiteCurator = Loadable(lazy(() => import('../views/siteCurator/siteCurator')));
+
+// User Dashboard
+const UserDashboard = Loadable(lazy(() => import('../views/userDashboard/userDashboard')));
+
 // Error Pages
 const ErrorNotFoundPage = Loadable(lazy(() => import('../views/errorPages/ErrorNotFoundPage')));
 
@@ -70,6 +79,18 @@ const MainRoutes = {
         {
             path: `${basename}/requestAccess`,
             element: <RequestDataAccessForm />
+        },
+        {
+            path: `${basename}/siteAdmin`,
+            element: <SiteAdmin />
+        },
+        {
+            path: `${basename}/siteCurator`,
+            element: <SiteCurator />
+        },
+        {
+            path: `${basename}/userDashboard`,
+            element: <UserDashboard />
         },
         {
             path: '*',

--- a/src/store/api.jsx
+++ b/src/store/api.jsx
@@ -418,3 +418,89 @@ export function removeUserFromSiteRole(roleType, userId) {
         method: 'delete'
     }).then(ingestJson);
 }
+
+/* ============================================================================
+ * Federation node management (federation service)
+ *
+ * Site administrators can register, list, and unregister peer CanDIG nodes.
+ * These endpoints live on the federation service (same base as /fanout) and
+ * are gated to site admins by the gateway, so — as with the ingest calls above
+ * — no Authorization header is set here. There is no dedicated node-liveness
+ * endpoint, so status is derived from an (unsafe) fanout probe; see
+ * fetchNodeStatus below.
+ * ========================================================================== */
+
+// Unwrap a federation JSON response, throwing a useful error (including the
+// server-supplied message when present) on failure.
+async function federationJson(response) {
+    let body;
+    try {
+        body = await response.json();
+    } catch (e) {
+        body = undefined;
+    }
+    if (!response.ok) {
+        const detail = body?.error || body?.message || body?.result || response.statusText;
+        throw new Error(`${response.status}: ${detail}`);
+    }
+    return body;
+}
+
+/*
+ * List the peer nodes registered with this node's federation service. Resolves
+ * to an array of { id, url, location: { name, province, province-code } }.
+ */
+export function fetchFederatedServers() {
+    return fetchOrRelogin(`${federation}/servers`)
+        .then(federationJson)
+        .then((data) => (Array.isArray(data) ? data : []));
+}
+
+/*
+ * Register a peer CanDIG node. `payload` is the full { server, authentication }
+ * body expected by POST /servers (assembled in AddFederatedServer).
+ */
+export function addFederatedServer(payload) {
+    return fetchOrRelogin(`${federation}/servers`, {
+        method: 'post',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+    }).then(federationJson);
+}
+
+/*
+ * Unregister a peer node by its server id.
+ */
+export function deleteFederatedServer(serverId) {
+    return fetchOrRelogin(`${federation}/servers/${encodeURIComponent(serverId)}`, {
+        method: 'delete'
+    }).then(federationJson);
+}
+
+/*
+ * Probe the reachability of every registered node. The federation service has
+ * no dedicated status endpoint, so we fan a lightweight discovery request out
+ * to all nodes with `unsafe` set: this bypasses the heartbeat's live-server
+ * filter so unreachable nodes are still contacted (and time out / error) rather
+ * than being silently skipped. Resolves to the raw fanout array, one entry per
+ * node: { location: { name, province }, status, message }. This is the same
+ * signal the Summary page uses for its node counts.
+ */
+export function fetchNodeStatus() {
+    return fetchOrRelogin(`${federation}/fanout`, {
+        method: 'post',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            method: 'GET',
+            path: 'query/discovery',
+            service: 'query',
+            payload: { targetService: 'katsu', targetPath: 'v3/discovery/overview/individual_count' },
+            unsafe: true
+        })
+    }).then((response) => {
+        if (response.ok) {
+            return response.json();
+        }
+        throw new Error(`Error probing node status: ${response.status} ${response.statusText}`);
+    });
+}

--- a/src/store/api.jsx
+++ b/src/store/api.jsx
@@ -221,3 +221,200 @@ export function fetchRefreshToken() {
             return error;
         });
 }
+
+/* ============================================================================
+ * Site administration (ingest service)
+ *
+ * All of the endpoints below are served by the ingest service and are only
+ * accessible to site administrators. They are consumed by the Site Admin
+ * Dashboard (src/views/siteAdmin). Authentication is handled by the Tyk
+ * gateway via the session cookie, exactly as with the other ingest calls
+ * above, so no Authorization header is set here.
+ * ========================================================================== */
+
+/*
+ * Small helper that unwraps an ingest response as JSON and throws a useful
+ * error (including the server-supplied message when present) on failure.
+ */
+async function ingestJson(response) {
+    let body;
+    try {
+        body = await response.json();
+    } catch (e) {
+        body = undefined;
+    }
+    if (!response.ok) {
+        const detail = body?.error || body?.message || body?.result || response.statusText;
+        throw new Error(`${response.status}: ${detail}`);
+    }
+    return body;
+}
+
+/*
+ * Return authorization information for the currently logged-in user, including
+ * their site_roles (e.g. "admin", "curator"). Used to gate the admin dashboard.
+ */
+export function fetchCurrentUserAuthorization() {
+    return fetchOrRelogin(`${INGEST_URL}/user/me`).then(ingestJson);
+}
+
+/* ---- Pending users ---- */
+
+export function fetchPendingUsers() {
+    return fetchOrRelogin(`${INGEST_URL}/user/pending`)
+        .then(ingestJson)
+        .then((data) => data?.results || []);
+}
+
+export function approvePendingUser(userId) {
+    return fetchOrRelogin(`${INGEST_URL}/user/pending/${encodeURIComponent(userId)}`, {
+        method: 'post'
+    }).then(ingestJson);
+}
+
+export function rejectPendingUser(userId) {
+    return fetchOrRelogin(`${INGEST_URL}/user/pending/${encodeURIComponent(userId)}`, {
+        method: 'delete'
+    }).then(ingestJson);
+}
+
+export function approvePendingUsers(userIds) {
+    return fetchOrRelogin(`${INGEST_URL}/user/pending`, {
+        method: 'post',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(userIds)
+    }).then(ingestJson);
+}
+
+/* ---- Preapproved users ---- */
+
+export function fetchPreapprovedUsers() {
+    return fetchOrRelogin(`${INGEST_URL}/user/preapproved`)
+        .then(ingestJson)
+        .then((data) => data?.results || []);
+}
+
+export function addPreapprovedUsers(userIds) {
+    return fetchOrRelogin(`${INGEST_URL}/user/preapproved`, {
+        method: 'post',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(userIds)
+    }).then(ingestJson);
+}
+
+export function removePreapprovedUser(userId) {
+    return fetchOrRelogin(`${INGEST_URL}/user/preapproved/${encodeURIComponent(userId)}`, {
+        method: 'delete'
+    }).then(ingestJson);
+}
+
+/* ---- Programs ---- */
+
+export function fetchPrograms() {
+    return fetchOrRelogin(`${INGEST_URL}/program`).then(ingestJson);
+}
+
+export function addProgram(program) {
+    return fetchOrRelogin(`${INGEST_URL}/program`, {
+        method: 'post',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(program)
+    }).then(ingestJson);
+}
+
+/*
+ * Fetch a single program's authorization info (program_curators, team_members).
+ * Resolves to { ok, status, data } so callers can distinguish "not found" (404)
+ * from other errors without throwing. Note the ingest service strips
+ * dac_authorizations from this response; use fetchProgramDacs for those.
+ */
+export function fetchProgram(programId) {
+    return fetchOrRelogin(`${INGEST_URL}/program/${encodeURIComponent(programId)}`).then(async (response) => {
+        let data;
+        try {
+            data = await response.json();
+        } catch (e) {
+            data = undefined;
+        }
+        return { ok: response.ok, status: response.status, data };
+    });
+}
+
+/*
+ * Get the DAC authorizations for a single program. The ingest service returns
+ * an object keyed by user id: { <user_id>: { program_id, start_date, end_date } }
+ */
+export function fetchProgramDacs(programId) {
+    return fetchOrRelogin(`${INGEST_URL}/program/${encodeURIComponent(programId)}/dac_authorization`).then(ingestJson);
+}
+
+/*
+ * Aggregate every DAC authorization across all programs into a flat list of
+ * { program_id, user_id, start_date, end_date } rows, suitable for a table.
+ */
+export function fetchAllDacAuthorizations() {
+    return fetchPrograms().then((programs) => {
+        const programIds = Array.isArray(programs) ? programs : [];
+        return Promise.all(
+            programIds.map((programId) =>
+                fetchProgramDacs(programId)
+                    .then((dacs) =>
+                        Object.entries(dacs || {}).map(([userId, dac]) => ({
+                            program_id: dac?.program_id || programId,
+                            user_id: userId,
+                            dac_id: dac?.dac_id || '',
+                            start_date: dac?.start_date || '',
+                            end_date: dac?.end_date || ''
+                        }))
+                    )
+                    .catch((error) => {
+                        console.log(`Could not fetch DAC authorizations for ${programId}: ${error}`);
+                        return [];
+                    })
+            )
+        ).then((nested) => nested.flat());
+    });
+}
+
+/* ---- DAC authorizations ---- */
+
+export function addDacAuthorization(userId, authorizations) {
+    return fetchOrRelogin(`${INGEST_URL}/user/${encodeURIComponent(userId)}/dac_authorization`, {
+        method: 'post',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(authorizations)
+    }).then(ingestJson);
+}
+
+/* ---- Site roles ---- */
+
+/*
+ * List the users assigned to a given site role (e.g. "curator", "admin"). The
+ * ingest service returns an object keyed by role type: { <role_type>: [...] },
+ * so we normalise it down to a plain array of user ids.
+ */
+export function fetchSiteRoleUsers(roleType) {
+    return fetchOrRelogin(`${INGEST_URL}/site-role/${encodeURIComponent(roleType)}`)
+        .then(ingestJson)
+        .then((data) => {
+            if (Array.isArray(data)) {
+                return data;
+            }
+            if (data && Array.isArray(data[roleType])) {
+                return data[roleType];
+            }
+            return [];
+        });
+}
+
+export function addUserToSiteRole(roleType, userId) {
+    return fetchOrRelogin(`${INGEST_URL}/site-role/${encodeURIComponent(roleType)}/user_id/${encodeURIComponent(userId)}`, {
+        method: 'post'
+    }).then(ingestJson);
+}
+
+export function removeUserFromSiteRole(roleType, userId) {
+    return fetchOrRelogin(`${INGEST_URL}/site-role/${encodeURIComponent(roleType)}/user_id/${encodeURIComponent(userId)}`, {
+        method: 'delete'
+    }).then(ingestJson);
+}

--- a/src/store/api.jsx
+++ b/src/store/api.jsx
@@ -38,7 +38,7 @@ export function fetchOrRelogin(...args) {
 /*
 Generic querying for federation
 */
-export function fetchFederation(path, service, payload = {}, fetchMethod = fetchOrRelogin) {
+export function fetchFederation(path, service, payload = {}, fetchMethod = fetchOrRelogin, extraBody = {}) {
     return fetchMethod(`${federation}/fanout`, {
         method: 'post',
         headers: { 'Content-Type': 'application/json' },
@@ -46,7 +46,9 @@ export function fetchFederation(path, service, payload = {}, fetchMethod = fetch
             method: 'GET',
             path,
             payload: payload || {},
-            service
+            service,
+            // Extra top-level fanout options (e.g. { unsafe: true }).
+            ...extraBody
         })
     })
         .then((response) => {
@@ -233,10 +235,11 @@ export function fetchRefreshToken() {
  * ========================================================================== */
 
 /*
- * Small helper that unwraps an ingest response as JSON and throws a useful
- * error (including the server-supplied message when present) on failure.
+ * Small helper that unwraps an ingest or federation response as JSON and throws
+ * a useful error (including the server-supplied message when present) on
+ * failure. Shared by every admin helper below.
  */
-async function ingestJson(response) {
+async function unwrapJson(response) {
     let body;
     try {
         body = await response.json();
@@ -252,30 +255,46 @@ async function ingestJson(response) {
 
 /*
  * Return authorization information for the currently logged-in user, including
- * their site_roles (e.g. "admin", "curator"). Used to gate the admin dashboard.
+ * their site_roles (e.g. "admin", "curator"). Used to gate the dashboards.
+ *
+ * The result is cached at module scope: the user's authorization does not change
+ * within a page load (a re-login reloads the page), and several independent
+ * consumers (useSiteRoles, useSiteAdmin, ProfileSection, the notification badge,
+ * the user dashboard) request it. Caching the promise means they all share a
+ * single /user/me request. A failed request clears the cache so it can be
+ * retried, and `force` bypasses the cache when a fresh read is required.
  */
-export function fetchCurrentUserAuthorization() {
-    return fetchOrRelogin(`${INGEST_URL}/user/me`).then(ingestJson);
+let currentUserAuthorizationPromise = null;
+export function fetchCurrentUserAuthorization({ force = false } = {}) {
+    if (!currentUserAuthorizationPromise || force) {
+        currentUserAuthorizationPromise = fetchOrRelogin(`${INGEST_URL}/user/me`)
+            .then(unwrapJson)
+            .catch((error) => {
+                currentUserAuthorizationPromise = null;
+                throw error;
+            });
+    }
+    return currentUserAuthorizationPromise;
 }
 
 /* ---- Pending users ---- */
 
 export function fetchPendingUsers() {
     return fetchOrRelogin(`${INGEST_URL}/user/pending`)
-        .then(ingestJson)
+        .then(unwrapJson)
         .then((data) => data?.results || []);
 }
 
 export function approvePendingUser(userId) {
     return fetchOrRelogin(`${INGEST_URL}/user/pending/${encodeURIComponent(userId)}`, {
         method: 'post'
-    }).then(ingestJson);
+    }).then(unwrapJson);
 }
 
 export function rejectPendingUser(userId) {
     return fetchOrRelogin(`${INGEST_URL}/user/pending/${encodeURIComponent(userId)}`, {
         method: 'delete'
-    }).then(ingestJson);
+    }).then(unwrapJson);
 }
 
 export function approvePendingUsers(userIds) {
@@ -283,14 +302,14 @@ export function approvePendingUsers(userIds) {
         method: 'post',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(userIds)
-    }).then(ingestJson);
+    }).then(unwrapJson);
 }
 
 /* ---- Preapproved users ---- */
 
 export function fetchPreapprovedUsers() {
     return fetchOrRelogin(`${INGEST_URL}/user/preapproved`)
-        .then(ingestJson)
+        .then(unwrapJson)
         .then((data) => data?.results || []);
 }
 
@@ -299,19 +318,19 @@ export function addPreapprovedUsers(userIds) {
         method: 'post',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(userIds)
-    }).then(ingestJson);
+    }).then(unwrapJson);
 }
 
 export function removePreapprovedUser(userId) {
     return fetchOrRelogin(`${INGEST_URL}/user/preapproved/${encodeURIComponent(userId)}`, {
         method: 'delete'
-    }).then(ingestJson);
+    }).then(unwrapJson);
 }
 
 /* ---- Programs ---- */
 
 export function fetchPrograms() {
-    return fetchOrRelogin(`${INGEST_URL}/program`).then(ingestJson);
+    return fetchOrRelogin(`${INGEST_URL}/program`).then(unwrapJson);
 }
 
 export function addProgram(program) {
@@ -319,7 +338,7 @@ export function addProgram(program) {
         method: 'post',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(program)
-    }).then(ingestJson);
+    }).then(unwrapJson);
 }
 
 /*
@@ -345,12 +364,17 @@ export function fetchProgram(programId) {
  * an object keyed by user id: { <user_id>: { program_id, start_date, end_date } }
  */
 export function fetchProgramDacs(programId) {
-    return fetchOrRelogin(`${INGEST_URL}/program/${encodeURIComponent(programId)}/dac_authorization`).then(ingestJson);
+    return fetchOrRelogin(`${INGEST_URL}/program/${encodeURIComponent(programId)}/dac_authorization`).then(unwrapJson);
 }
 
 /*
  * Aggregate every DAC authorization across all programs into a flat list of
  * { program_id, user_id, start_date, end_date } rows, suitable for a table.
+ *
+ * Note: this is a fan-out of one request per program (an N+1 pattern). It is
+ * parallelised and per-program failures are isolated, so it is fine at current
+ * program counts; a bulk "all DAC authorizations" ingest endpoint would be the
+ * fix if program counts grow large (mirrors the query-service PAGE_SIZE caveat).
  */
 export function fetchAllDacAuthorizations() {
     return fetchPrograms().then((programs) => {
@@ -383,7 +407,7 @@ export function addDacAuthorization(userId, authorizations) {
         method: 'post',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(authorizations)
-    }).then(ingestJson);
+    }).then(unwrapJson);
 }
 
 /* ---- Site roles ---- */
@@ -395,7 +419,7 @@ export function addDacAuthorization(userId, authorizations) {
  */
 export function fetchSiteRoleUsers(roleType) {
     return fetchOrRelogin(`${INGEST_URL}/site-role/${encodeURIComponent(roleType)}`)
-        .then(ingestJson)
+        .then(unwrapJson)
         .then((data) => {
             if (Array.isArray(data)) {
                 return data;
@@ -410,13 +434,13 @@ export function fetchSiteRoleUsers(roleType) {
 export function addUserToSiteRole(roleType, userId) {
     return fetchOrRelogin(`${INGEST_URL}/site-role/${encodeURIComponent(roleType)}/user_id/${encodeURIComponent(userId)}`, {
         method: 'post'
-    }).then(ingestJson);
+    }).then(unwrapJson);
 }
 
 export function removeUserFromSiteRole(roleType, userId) {
     return fetchOrRelogin(`${INGEST_URL}/site-role/${encodeURIComponent(roleType)}/user_id/${encodeURIComponent(userId)}`, {
         method: 'delete'
-    }).then(ingestJson);
+    }).then(unwrapJson);
 }
 
 /* ============================================================================
@@ -427,24 +451,9 @@ export function removeUserFromSiteRole(roleType, userId) {
  * are gated to site admins by the gateway, so — as with the ingest calls above
  * — no Authorization header is set here. There is no dedicated node-liveness
  * endpoint, so status is derived from an (unsafe) fanout probe; see
- * fetchNodeStatus below.
+ * fetchNodeStatus below. JSON responses are unwrapped by the shared unwrapJson
+ * helper defined above.
  * ========================================================================== */
-
-// Unwrap a federation JSON response, throwing a useful error (including the
-// server-supplied message when present) on failure.
-async function federationJson(response) {
-    let body;
-    try {
-        body = await response.json();
-    } catch (e) {
-        body = undefined;
-    }
-    if (!response.ok) {
-        const detail = body?.error || body?.message || body?.result || response.statusText;
-        throw new Error(`${response.status}: ${detail}`);
-    }
-    return body;
-}
 
 /*
  * List the peer nodes registered with this node's federation service. Resolves
@@ -452,7 +461,7 @@ async function federationJson(response) {
  */
 export function fetchFederatedServers() {
     return fetchOrRelogin(`${federation}/servers`)
-        .then(federationJson)
+        .then(unwrapJson)
         .then((data) => (Array.isArray(data) ? data : []));
 }
 
@@ -465,7 +474,7 @@ export function addFederatedServer(payload) {
         method: 'post',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
-    }).then(federationJson);
+    }).then(unwrapJson);
 }
 
 /*
@@ -474,7 +483,7 @@ export function addFederatedServer(payload) {
 export function deleteFederatedServer(serverId) {
     return fetchOrRelogin(`${federation}/servers/${encodeURIComponent(serverId)}`, {
         method: 'delete'
-    }).then(federationJson);
+    }).then(unwrapJson);
 }
 
 /*
@@ -484,23 +493,14 @@ export function deleteFederatedServer(serverId) {
  * filter so unreachable nodes are still contacted (and time out / error) rather
  * than being silently skipped. Resolves to the raw fanout array, one entry per
  * node: { location: { name, province }, status, message }. This is the same
- * signal the Summary page uses for its node counts.
+ * signal the Summary page uses for its node counts (reusing fetchFederation).
  */
 export function fetchNodeStatus() {
-    return fetchOrRelogin(`${federation}/fanout`, {
-        method: 'post',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            method: 'GET',
-            path: 'query/discovery',
-            service: 'query',
-            payload: { targetService: 'katsu', targetPath: 'v3/discovery/overview/individual_count' },
-            unsafe: true
-        })
-    }).then((response) => {
-        if (response.ok) {
-            return response.json();
-        }
-        throw new Error(`Error probing node status: ${response.status} ${response.statusText}`);
-    });
+    return fetchFederation(
+        'query/discovery',
+        'query',
+        { targetService: 'katsu', targetPath: 'v3/discovery/overview/individual_count' },
+        fetchOrRelogin,
+        { unsafe: true }
+    );
 }

--- a/src/store/constant.jsx
+++ b/src/store/constant.jsx
@@ -110,6 +110,11 @@ export const CLIN_METADATA = [
 // Roles
 export const SITE = import.meta.env.VITE_SITE_LOCATION;
 
+// Global site roles, as defined in the OPA site_roles store. Kept here so the
+// role strings and their display labels live in exactly one place.
+export const SITE_ROLES = { ADMIN: 'admin', CURATOR: 'curator' };
+export const SITE_ROLE_LABELS = { [SITE_ROLES.ADMIN]: 'Site Admin', [SITE_ROLES.CURATOR]: 'Site Curator' };
+
 // API URL where the Dashboard get all the data
 export const BASE_URL = import.meta.env.VITE_CANDIG_SERVER;
 

--- a/src/ui-component/DashboardShell.jsx
+++ b/src/ui-component/DashboardShell.jsx
@@ -1,0 +1,88 @@
+import PropTypes from 'prop-types';
+
+// mui
+import { Alert, Box, CircularProgress, Divider, List, ListItemButton, ListItemIcon, ListItemText, useMediaQuery } from '@mui/material';
+
+// project imports
+import MainCard from './cards/MainCard';
+import DefaultErrorBoundary from './DefaultErrorBoundary';
+
+// ===========================|| DASHBOARD SHELL ||=========================== //
+
+/*
+ * Shared layout for the site admin / site curator / user dashboards: a titled
+ * MainCard containing an optional header, a left-hand section navigation list,
+ * and the active section body. Handles the loading spinner and a single
+ * "notice" state (used for both the unauthorized alert and load errors) so the
+ * three dashboards stay visually in sync.
+ *
+ * - loading: show a centered spinner
+ * - notice: { severity, message } — render this alert instead of the body
+ * - header: optional node rendered above the nav/body split (e.g. a username)
+ * - sections: [{ id, label, icon }]
+ * - renderSection(): the active section's content
+ */
+function DashboardShell({ title, loading, notice, header, sections, activeSection, onSelectSection, renderSection }) {
+    const isSmall = useMediaQuery((theme) => theme.breakpoints.down('md'));
+
+    if (loading) {
+        return (
+            <Box display="flex" justifyContent="center" alignItems="center" sx={{ minHeight: 300 }}>
+                <CircularProgress />
+            </Box>
+        );
+    }
+
+    if (notice) {
+        return (
+            <MainCard title={title}>
+                <Alert severity={notice.severity || 'error'}>{notice.message}</Alert>
+            </MainCard>
+        );
+    }
+
+    return (
+        <MainCard title={title}>
+            {header}
+            <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2 }}>
+                <Box sx={{ width: { xs: '100%', md: 260 }, flexShrink: 0 }}>
+                    <List component="nav" sx={{ p: 0 }}>
+                        {sections.map((section) => {
+                            const SectionIcon = section.icon;
+                            return (
+                                <ListItemButton
+                                    key={section.id}
+                                    selected={activeSection === section.id}
+                                    onClick={() => onSelectSection(section.id)}
+                                    sx={{ borderRadius: 2, mb: 0.5 }}
+                                >
+                                    <ListItemIcon sx={{ minWidth: 36 }}>
+                                        <SectionIcon size="1.3rem" stroke={1.5} />
+                                    </ListItemIcon>
+                                    <ListItemText primary={section.label} />
+                                </ListItemButton>
+                            );
+                        })}
+                    </List>
+                </Box>
+                {isSmall ? <Divider /> : <Divider orientation="vertical" flexItem />}
+                <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                    <DefaultErrorBoundary>{renderSection()}</DefaultErrorBoundary>
+                </Box>
+            </Box>
+        </MainCard>
+    );
+}
+
+DashboardShell.propTypes = {
+    title: PropTypes.string.isRequired,
+    loading: PropTypes.bool,
+    notice: PropTypes.shape({ severity: PropTypes.string, message: PropTypes.node }),
+    header: PropTypes.node,
+    sections: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.string, label: PropTypes.string, icon: PropTypes.elementType })),
+    activeSection: PropTypes.string,
+    onSelectSection: PropTypes.func,
+    renderSection: PropTypes.func
+};
+
+export default DashboardShell;

--- a/src/ui-component/PendingUsersNotification.jsx
+++ b/src/ui-component/PendingUsersNotification.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+// mui
+import { Chip, Tooltip } from '@mui/material';
+import { IconAlertTriangle } from '@tabler/icons-react';
+
+// project imports
+import config from '../config';
+import useSiteAdmin from '../hooks/useSiteAdmin';
+import { fetchPendingUsers } from '../store/api';
+
+// Show the notification at most once per browser session (per login).
+const SESSION_KEY = 'candig.pendingUsersNotified';
+
+// ===========================|| PENDING USERS NOTIFICATION ||=========================== //
+
+/*
+ * When a site administrator loads the portal, check whether there are any users
+ * awaiting approval and, if so, surface a compact indicator in the header (just
+ * left of the user menu) that links to the pending users section of the Site
+ * Admin Dashboard. It appears once per session and can be dismissed.
+ */
+function PendingUsersNotification() {
+    const { loading, isSiteAdmin } = useSiteAdmin();
+    const navigate = useNavigate();
+    const [open, setOpen] = useState(false);
+    const [count, setCount] = useState(0);
+
+    useEffect(() => {
+        if (loading || !isSiteAdmin) {
+            return;
+        }
+        if (sessionStorage.getItem(SESSION_KEY)) {
+            return;
+        }
+        fetchPendingUsers()
+            .then((users) => {
+                sessionStorage.setItem(SESSION_KEY, 'true');
+                if (users.length > 0) {
+                    setCount(users.length);
+                    setOpen(true);
+                }
+            })
+            .catch((error) => console.log(`Could not check pending users: ${error}`));
+    }, [loading, isSiteAdmin]);
+
+    if (!open) {
+        return null;
+    }
+
+    const handleReview = () => {
+        setOpen(false);
+        navigate(`${config.basename}/siteAdmin?section=pending`);
+    };
+
+    return (
+        <Tooltip title="Review pending users">
+            <Chip
+                color="warning"
+                variant="filled"
+                icon={<IconAlertTriangle size="1.1rem" stroke={1.5} />}
+                label={`${count} pending user${count === 1 ? '' : 's'}`}
+                onClick={handleReview}
+                onDelete={() => setOpen(false)}
+                sx={{ mr: 1.5, height: '48px', borderRadius: '27px', fontWeight: 500, fontSize: '0.875rem' }}
+            />
+        </Tooltip>
+    );
+}
+
+export default PendingUsersNotification;

--- a/src/ui-component/PendingUsersNotification.jsx
+++ b/src/ui-component/PendingUsersNotification.jsx
@@ -34,9 +34,13 @@ function PendingUsersNotification() {
         if (sessionStorage.getItem(SESSION_KEY)) {
             return;
         }
+        // Claim the once-per-session sentinel up front so a concurrent mount
+        // (or React 18 StrictMode's double-invoke in dev) can't both fetch and
+        // double-notify. Trade-off: if this check fails there is no retry this
+        // session, which is fine for a best-effort notification.
+        sessionStorage.setItem(SESSION_KEY, 'true');
         fetchPendingUsers()
             .then((users) => {
-                sessionStorage.setItem(SESSION_KEY, 'true');
                 if (users.length > 0) {
                     setCount(users.length);
                     setOpen(true);

--- a/src/utils/adminHelpers.jsx
+++ b/src/utils/adminHelpers.jsx
@@ -1,0 +1,34 @@
+// Shared helpers for the site admin / site curator / user dashboards.
+
+import { GridToolbar } from '@mui/x-data-grid';
+
+/*
+ * Split a free-text field of user ids into a trimmed, de-duplicated, lower-cased
+ * list. User identities are treated case-insensitively and the ingest service
+ * stores curators/team members lower-cased, so every admin input is normalised
+ * the same way here (commas, semicolons, and any whitespace are separators).
+ */
+export function parseUserList(value) {
+    return [
+        ...new Set(
+            String(value || '')
+                .split(/[\s,;]+/)
+                .map((item) => item.trim().toLowerCase())
+                .filter(Boolean)
+        )
+    ];
+}
+
+/*
+ * Common MUI DataGrid props shared by the admin tables so their toolbars,
+ * quick-filter, selection behaviour, and page-size options stay in sync. Spread
+ * this first, then override per-table (e.g. pageSizeOptions/initialState) as
+ * needed.
+ */
+export const adminDataGridProps = {
+    slots: { toolbar: GridToolbar },
+    slotProps: { toolbar: { showQuickFilter: true } },
+    disableRowSelectionOnClick: true,
+    pageSizeOptions: [10, 25, 50],
+    initialState: { pagination: { paginationModel: { pageSize: 10 } } }
+};

--- a/src/views/siteAdmin/AddDacAuthorization.jsx
+++ b/src/views/siteAdmin/AddDacAuthorization.jsx
@@ -7,6 +7,7 @@ import { IconShieldPlus } from '@tabler/icons-react';
 
 // project imports
 import { addDacAuthorization, fetchPrograms } from '../../store/api';
+import { parseUserList } from '../../utils/adminHelpers';
 
 // ===========================|| ADD DAC AUTHORIZATION ||=========================== //
 
@@ -33,16 +34,6 @@ function AddDacAuthorization({ onSuccess }) {
             .catch((error) => setFeedback({ severity: 'error', text: `Could not load programs. ${error}` }));
     }, []);
 
-    // Split the user id field on commas / semicolons / whitespace, de-duplicated.
-    const parseUserIds = () => [
-        ...new Set(
-            userIds
-                .split(/[\s,;]+/)
-                .map((value) => value.trim())
-                .filter(Boolean)
-        )
-    ];
-
     const validate = (parsedUserIds) => {
         if (parsedUserIds.length === 0 || programIds.length === 0 || !startDate || !endDate) {
             return 'User id(s), at least one program, start date, and end date are required.';
@@ -54,7 +45,7 @@ function AddDacAuthorization({ onSuccess }) {
     };
 
     const handleSubmit = () => {
-        const parsedUserIds = parseUserIds();
+        const parsedUserIds = parseUserList(userIds);
         const validationError = validate(parsedUserIds);
         if (validationError) {
             setFeedback({ severity: 'warning', text: validationError });

--- a/src/views/siteAdmin/AddDacAuthorization.jsx
+++ b/src/views/siteAdmin/AddDacAuthorization.jsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+// mui
+import { Alert, Autocomplete, Box, Button, Grid, Stack, TextField, Typography } from '@mui/material';
+import { IconShieldPlus } from '@tabler/icons-react';
+
+// project imports
+import { addDacAuthorization, fetchPrograms } from '../../store/api';
+
+// ===========================|| ADD DAC AUTHORIZATION ||=========================== //
+
+/*
+ * Grant one or more users a time-bounded DAC authorization for one or more
+ * programs. A separate authorization is submitted for every user/program
+ * combination. Programs are chosen from a multi-select autocomplete populated
+ * from the ingest service; dates are validated before submission (the ingest
+ * service performs the authoritative validation).
+ */
+function AddDacAuthorization({ onSuccess }) {
+    const [programs, setPrograms] = useState([]);
+    const [userIds, setUserIds] = useState('');
+    const [programIds, setProgramIds] = useState([]);
+    const [dacId, setDacId] = useState('');
+    const [startDate, setStartDate] = useState('');
+    const [endDate, setEndDate] = useState('');
+    const [busy, setBusy] = useState(false);
+    const [feedback, setFeedback] = useState(null);
+
+    useEffect(() => {
+        fetchPrograms()
+            .then((results) => setPrograms(Array.isArray(results) ? results : []))
+            .catch((error) => setFeedback({ severity: 'error', text: `Could not load programs. ${error}` }));
+    }, []);
+
+    // Split the user id field on commas / semicolons / whitespace, de-duplicated.
+    const parseUserIds = () => [
+        ...new Set(
+            userIds
+                .split(/[\s,;]+/)
+                .map((value) => value.trim())
+                .filter(Boolean)
+        )
+    ];
+
+    const validate = (parsedUserIds) => {
+        if (parsedUserIds.length === 0 || programIds.length === 0 || !startDate || !endDate) {
+            return 'User id(s), at least one program, start date, and end date are required.';
+        }
+        if (endDate <= startDate) {
+            return 'End date must be after the start date.';
+        }
+        return null;
+    };
+
+    const handleSubmit = () => {
+        const parsedUserIds = parseUserIds();
+        const validationError = validate(parsedUserIds);
+        if (validationError) {
+            setFeedback({ severity: 'warning', text: validationError });
+            return;
+        }
+
+        const baseAuthorization = { start_date: startDate, end_date: endDate };
+        if (dacId.trim()) {
+            baseAuthorization.dac_id = dacId.trim();
+        }
+
+        // One authorization per user/program combination.
+        const pairs = [];
+        parsedUserIds.forEach((userId) => {
+            programIds.forEach((programId) => pairs.push({ userId, programId }));
+        });
+
+        setBusy(true);
+        setFeedback(null);
+        Promise.allSettled(
+            pairs.map(({ userId, programId }) => addDacAuthorization(userId, { ...baseAuthorization, program_id: programId }))
+        )
+            .then((results) => {
+                const failed = [];
+                results.forEach((result, index) => {
+                    if (result.status === 'rejected') {
+                        const { userId, programId } = pairs[index];
+                        failed.push(`${userId}/${programId} (${result.reason})`);
+                    }
+                });
+                const succeededCount = pairs.length - failed.length;
+
+                if (failed.length === 0) {
+                    setFeedback({
+                        severity: 'success',
+                        text: `Created ${succeededCount} authorization(s) for ${parsedUserIds.length} user(s) across ${programIds.length} program(s).`
+                    });
+                    setUserIds('');
+                    setProgramIds([]);
+                    setDacId('');
+                    setStartDate('');
+                    setEndDate('');
+                    if (onSuccess) {
+                        onSuccess();
+                    }
+                } else if (succeededCount === 0) {
+                    setFeedback({ severity: 'error', text: `Failed to authorize: ${failed.join('; ')}` });
+                } else {
+                    setFeedback({
+                        severity: 'warning',
+                        text: `Created ${succeededCount} authorization(s). Failed: ${failed.join('; ')}`
+                    });
+                }
+            })
+            .finally(() => setBusy(false));
+    };
+
+    return (
+        <Box>
+            <Typography variant="h4" mb={2}>
+                Add DAC Authorization
+            </Typography>
+
+            {feedback && (
+                <Alert severity={feedback.severity} onClose={() => setFeedback(null)} sx={{ mb: 2 }}>
+                    {feedback.text}
+                </Alert>
+            )}
+
+            <Grid container spacing={2} sx={{ maxWidth: 720 }}>
+                <Grid item xs={12}>
+                    <TextField
+                        label="User id(s)"
+                        placeholder="user1@example.com, user2@example.com …"
+                        helperText="Add one or many users, separated by commas, spaces, or new lines. A separate authorization is created for each user/program combination."
+                        value={userIds}
+                        onChange={(event) => setUserIds(event.target.value)}
+                        multiline
+                        minRows={2}
+                        fullWidth
+                        required
+                    />
+                </Grid>
+                <Grid item xs={12}>
+                    <Autocomplete
+                        multiple
+                        options={programs}
+                        value={programIds}
+                        onChange={(event, newValue) => setProgramIds(newValue)}
+                        filterSelectedOptions
+                        disableCloseOnSelect
+                        renderInput={(params) => (
+                            <TextField
+                                {...params}
+                                label="Program(s)"
+                                placeholder={programIds.length === 0 ? 'Select one or more programs' : ''}
+                                required
+                            />
+                        )}
+                    />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                    <TextField
+                        label="DAC id"
+                        value={dacId}
+                        onChange={(event) => setDacId(event.target.value)}
+                        helperText="Optional — identifier of the authorizing Data Access Committee."
+                        fullWidth
+                    />
+                </Grid>
+                <Grid item xs={12} md={6} />
+                <Grid item xs={12} md={6}>
+                    <TextField
+                        label="Start date"
+                        type="date"
+                        value={startDate}
+                        onChange={(event) => setStartDate(event.target.value)}
+                        InputLabelProps={{ shrink: true }}
+                        fullWidth
+                        required
+                    />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                    <TextField
+                        label="End date"
+                        type="date"
+                        value={endDate}
+                        onChange={(event) => setEndDate(event.target.value)}
+                        InputLabelProps={{ shrink: true }}
+                        fullWidth
+                        required
+                    />
+                </Grid>
+                <Grid item xs={12}>
+                    <Stack direction="row" justifyContent="flex-end">
+                        <Button variant="contained" startIcon={<IconShieldPlus size="1rem" />} disabled={busy} onClick={handleSubmit}>
+                            Add Authorization
+                        </Button>
+                    </Stack>
+                </Grid>
+            </Grid>
+        </Box>
+    );
+}
+
+AddDacAuthorization.propTypes = {
+    onSuccess: PropTypes.func
+};
+
+export default AddDacAuthorization;

--- a/src/views/siteAdmin/AddFederatedServer.jsx
+++ b/src/views/siteAdmin/AddFederatedServer.jsx
@@ -1,0 +1,331 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+
+// mui
+import { Alert, Box, Button, Grid, MenuItem, Stack, TextField, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
+import { IconClipboardCheck, IconServerBolt } from '@tabler/icons-react';
+
+// project imports
+import { addFederatedServer } from '../../store/api';
+
+// Canonical Canadian provinces/territories and their CanDIG province codes. The
+// province is chosen from this list and the code is derived from it, so the two
+// can never disagree.
+const PROVINCES = [
+    { name: 'Alberta', code: 'ca-ab' },
+    { name: 'British Columbia', code: 'ca-bc' },
+    { name: 'Manitoba', code: 'ca-mb' },
+    { name: 'New Brunswick', code: 'ca-nb' },
+    { name: 'Newfoundland and Labrador', code: 'ca-nl' },
+    { name: 'Northwest Territories', code: 'ca-nt' },
+    { name: 'Nova Scotia', code: 'ca-ns' },
+    { name: 'Nunavut', code: 'ca-nu' },
+    { name: 'Ontario', code: 'ca-on' },
+    { name: 'Prince Edward Island', code: 'ca-pe' },
+    { name: 'Quebec', code: 'ca-qc' },
+    { name: 'Saskatchewan', code: 'ca-sk' },
+    { name: 'Yukon', code: 'ca-yt' }
+];
+
+const provinceCodeFor = (name) => PROVINCES.find((p) => p.name === name)?.code || '';
+
+// Resolve a free-form province/code (e.g. from pasted JSON) to a canonical
+// province name, matching on either the name or the code. Returns '' if neither
+// matches, so the user is prompted to pick one.
+function resolveProvince(province, code) {
+    const byName = PROVINCES.find((p) => p.name.toLowerCase() === String(province || '').toLowerCase());
+    if (byName) {
+        return byName.name;
+    }
+    const byCode = PROVINCES.find((p) => p.code.toLowerCase() === String(code || '').toLowerCase());
+    return byCode ? byCode.name : '';
+}
+
+// Parse a pasted JSON blob into flat form fields. Accepts the full POST /servers
+// body ({ server, authentication }) or just the inner server object.
+function parseServerJson(text) {
+    const data = JSON.parse(text);
+    const server = data.server || data;
+    if (!server || typeof server !== 'object') {
+        throw new Error('Expected an object with a "server" property.');
+    }
+    const auth = data.authentication || {};
+    const location = server.location || {};
+    return {
+        id: server.id || '',
+        url: server.url || '',
+        name: location.name || '',
+        province: resolveProvince(location.province, location['province-code']),
+        issuer: auth.issuer || '',
+        token: auth.token || ''
+    };
+}
+
+const JSON_PLACEHOLDER = `{
+  "server": {
+    "id": "uhn-federation-1",
+    "url": "https://candig.example.ca",
+    "location": { "name": "UHN", "province": "Ontario", "province-code": "ca-on" }
+  },
+  "authentication": {
+    "issuer": "https://candig.example.ca/auth/realms/candig",
+    "token": "<access token from the peer node>"
+  }
+}`;
+
+// ===========================|| ADD FEDERATED SERVER ||=========================== //
+
+/*
+ * Register a peer CanDIG node with this node's federation service. The admin can
+ * either fill in the form directly or paste the JSON body produced by the
+ * add_federated_server tooling; pasting populates the form so the details can be
+ * confirmed (and edited) before submitting. On success the federation service
+ * also wires the peer's issuer into Tyk and OPA automatically.
+ */
+function AddFederatedServer({ onSuccess }) {
+    const [mode, setMode] = useState('form'); // 'form' | 'json'
+    const [id, setId] = useState('');
+    const [url, setUrl] = useState('');
+    const [name, setName] = useState('');
+    const [province, setProvince] = useState('');
+    const [issuer, setIssuer] = useState('');
+    const [token, setToken] = useState('');
+    const [jsonText, setJsonText] = useState('');
+    const [busy, setBusy] = useState(false);
+    const [feedback, setFeedback] = useState(null);
+
+    const provinceCode = provinceCodeFor(province);
+
+    // Every field maps directly onto a required part of the POST /servers body.
+    const requiredFilled = id.trim() && url.trim() && name.trim() && province && issuer.trim() && token.trim();
+
+    // Parse the pasted JSON into the form fields, then switch to the form so the
+    // admin can confirm/adjust before submitting.
+    const handlePopulateFromJson = () => {
+        setFeedback(null);
+        try {
+            const parsed = parseServerJson(jsonText);
+            setId(parsed.id);
+            setUrl(parsed.url);
+            setName(parsed.name);
+            setProvince(parsed.province);
+            setIssuer(parsed.issuer);
+            setToken(parsed.token);
+            setMode('form');
+            const warnings = [];
+            if (!parsed.province) {
+                warnings.push('province was not recognised — please pick one');
+            }
+            setFeedback({
+                severity: warnings.length ? 'warning' : 'success',
+                text: `Form populated from JSON${warnings.length ? ` (${warnings.join('; ')})` : '. Review the details and submit.'}`
+            });
+        } catch (error) {
+            setFeedback({ severity: 'error', text: `Could not parse JSON. ${error.message}` });
+        }
+    };
+
+    const handleSubmit = () => {
+        if (!requiredFilled) {
+            setFeedback({ severity: 'warning', text: 'All fields are required to register a node.' });
+            return;
+        }
+
+        const payload = {
+            server: {
+                id: id.trim(),
+                url: url.trim(),
+                location: {
+                    name: name.trim(),
+                    province,
+                    'province-code': provinceCode
+                }
+            },
+            authentication: {
+                issuer: issuer.trim(),
+                token: token.trim()
+            }
+        };
+
+        setBusy(true);
+        setFeedback(null);
+        addFederatedServer(payload)
+            .then(() => {
+                setFeedback({ severity: 'success', text: `Registered node "${id.trim()}".` });
+                setId('');
+                setUrl('');
+                setName('');
+                setProvince('');
+                setIssuer('');
+                setToken('');
+                setJsonText('');
+                if (onSuccess) {
+                    onSuccess();
+                }
+            })
+            .catch((error) => setFeedback({ severity: 'error', text: `Could not register node. ${error}` }))
+            .finally(() => setBusy(false));
+    };
+
+    return (
+        <Box>
+            <Typography variant="h4" mb={1}>
+                Add Federated Node
+            </Typography>
+            <Typography variant="body2" color="textSecondary" mb={2}>
+                Register a peer CanDIG node so its data is included in federated queries. Fill in the form, or paste a JSON blob to
+                populate it. You will need the peer&apos;s Keycloak issuer URL and a valid access token issued by that peer.
+            </Typography>
+
+            <ToggleButtonGroup
+                value={mode}
+                exclusive
+                size="small"
+                onChange={(_event, next) => next && setMode(next)}
+                sx={{ mb: 2 }}
+            >
+                <ToggleButton value="form">Form</ToggleButton>
+                <ToggleButton value="json">Paste JSON</ToggleButton>
+            </ToggleButtonGroup>
+
+            {feedback && (
+                <Alert severity={feedback.severity} onClose={() => setFeedback(null)} sx={{ mb: 2 }}>
+                    {feedback.text}
+                </Alert>
+            )}
+
+            {mode === 'json' ? (
+                <Grid container spacing={2} sx={{ maxWidth: 820 }}>
+                    <Grid item xs={12}>
+                        <TextField
+                            label="Server JSON"
+                            placeholder={JSON_PLACEHOLDER}
+                            helperText="Paste the { server, authentication } body. Populating the form lets you confirm the details before submitting."
+                            value={jsonText}
+                            onChange={(event) => setJsonText(event.target.value)}
+                            multiline
+                            minRows={10}
+                            fullWidth
+                            InputProps={{ sx: { fontFamily: 'monospace', fontSize: '0.85rem' } }}
+                        />
+                    </Grid>
+                    <Grid item xs={12}>
+                        <Stack direction="row" justifyContent="flex-end">
+                            <Button
+                                variant="contained"
+                                startIcon={<IconClipboardCheck size="1rem" />}
+                                disabled={busy || jsonText.trim().length === 0}
+                                onClick={handlePopulateFromJson}
+                            >
+                                Populate Form
+                            </Button>
+                        </Stack>
+                    </Grid>
+                </Grid>
+            ) : (
+                <Grid container spacing={2} sx={{ maxWidth: 820 }}>
+                    <Grid item xs={12} md={6}>
+                        <TextField
+                            label="Server id"
+                            placeholder="uhn-federation-1"
+                            helperText="Unique identifier for this node."
+                            value={id}
+                            onChange={(event) => setId(event.target.value)}
+                            fullWidth
+                            required
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <TextField
+                            label="Server URL"
+                            placeholder="https://candig.example.ca"
+                            helperText="Base URL of the peer node."
+                            value={url}
+                            onChange={(event) => setUrl(event.target.value)}
+                            fullWidth
+                            required
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={4}>
+                        <TextField
+                            label="Location name"
+                            placeholder="UHN"
+                            helperText="Display name for the node."
+                            value={name}
+                            onChange={(event) => setName(event.target.value)}
+                            fullWidth
+                            required
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={4}>
+                        <TextField
+                            select
+                            label="Province"
+                            value={province}
+                            onChange={(event) => setProvince(event.target.value)}
+                            fullWidth
+                            required
+                        >
+                            {PROVINCES.map((p) => (
+                                <MenuItem key={p.code} value={p.name}>
+                                    {p.name}
+                                </MenuItem>
+                            ))}
+                        </TextField>
+                    </Grid>
+                    <Grid item xs={12} md={4}>
+                        <TextField
+                            label="Province code"
+                            value={provinceCode}
+                            helperText="Set automatically from the province."
+                            fullWidth
+                            disabled
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <TextField
+                            label="Keycloak issuer URL"
+                            placeholder="https://candig.example.ca/auth/realms/candig"
+                            helperText="The peer's OIDC issuer."
+                            value={issuer}
+                            onChange={(event) => setIssuer(event.target.value)}
+                            fullWidth
+                            required
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <TextField
+                            label="Access token"
+                            placeholder="Access token issued by the peer node"
+                            helperText="Used once at registration to validate and authorize the peer."
+                            value={token}
+                            onChange={(event) => setToken(event.target.value)}
+                            multiline
+                            minRows={2}
+                            fullWidth
+                            required
+                        />
+                    </Grid>
+                    <Grid item xs={12}>
+                        <Stack direction="row" justifyContent="flex-end">
+                            <Button
+                                variant="contained"
+                                startIcon={<IconServerBolt size="1rem" />}
+                                disabled={busy || !requiredFilled}
+                                onClick={handleSubmit}
+                            >
+                                Register Node
+                            </Button>
+                        </Stack>
+                    </Grid>
+                </Grid>
+            )}
+        </Box>
+    );
+}
+
+AddFederatedServer.propTypes = {
+    onSuccess: PropTypes.func
+};
+
+export default AddFederatedServer;

--- a/src/views/siteAdmin/AddFederatedServer.jsx
+++ b/src/views/siteAdmin/AddFederatedServer.jsx
@@ -7,25 +7,13 @@ import { IconClipboardCheck, IconServerBolt } from '@tabler/icons-react';
 
 // project imports
 import { addFederatedServer } from '../../store/api';
+import { hcProvCodes, provFullNames } from '../../store/constant';
 
-// Canonical Canadian provinces/territories and their CanDIG province codes. The
-// province is chosen from this list and the code is derived from it, so the two
-// can never disagree.
-const PROVINCES = [
-    { name: 'Alberta', code: 'ca-ab' },
-    { name: 'British Columbia', code: 'ca-bc' },
-    { name: 'Manitoba', code: 'ca-mb' },
-    { name: 'New Brunswick', code: 'ca-nb' },
-    { name: 'Newfoundland and Labrador', code: 'ca-nl' },
-    { name: 'Northwest Territories', code: 'ca-nt' },
-    { name: 'Nova Scotia', code: 'ca-ns' },
-    { name: 'Nunavut', code: 'ca-nu' },
-    { name: 'Ontario', code: 'ca-on' },
-    { name: 'Prince Edward Island', code: 'ca-pe' },
-    { name: 'Quebec', code: 'ca-qc' },
-    { name: 'Saskatchewan', code: 'ca-sk' },
-    { name: 'Yukon', code: 'ca-yt' }
-];
+// Canonical Canadian provinces/territories and their CanDIG province codes,
+// derived from the shared constants (name/code aligned by index). The province
+// is chosen from this list and the code is derived from it, so the two can never
+// disagree.
+const PROVINCES = provFullNames.map((name, index) => ({ name, code: hcProvCodes[index] }));
 
 const provinceCodeFor = (name) => PROVINCES.find((p) => p.name === name)?.code || '';
 

--- a/src/views/siteAdmin/DacAuthorizationsTable.jsx
+++ b/src/views/siteAdmin/DacAuthorizationsTable.jsx
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+// mui
+import { Alert, Box, Button, Chip, Stack, Tooltip, Typography } from '@mui/material';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { IconRefresh, IconShieldPlus } from '@tabler/icons-react';
+
+// project imports
+import { fetchAllDacAuthorizations } from '../../store/api';
+
+// Collapse authorizations that share the same program, DAC id, and date range
+// into a single row, listing all their users as a comma-delimited string.
+function groupDacAuthorizations(authorizations) {
+    const groups = new Map();
+    authorizations.forEach((dac) => {
+        const key = [dac.program_id, dac.dac_id, dac.start_date, dac.end_date].join('||');
+        if (!groups.has(key)) {
+            groups.set(key, {
+                program_id: dac.program_id,
+                dac_id: dac.dac_id,
+                start_date: dac.start_date,
+                end_date: dac.end_date,
+                userSet: new Set()
+            });
+        }
+        if (dac.user_id) {
+            groups.get(key).userSet.add(dac.user_id);
+        }
+    });
+    return [...groups.values()].map((group, index) => {
+        const users = [...group.userSet].sort();
+        return {
+            id: index,
+            program_id: group.program_id,
+            dac_id: group.dac_id,
+            start_date: group.start_date,
+            end_date: group.end_date,
+            user_count: users.length,
+            users: users.join(', ')
+        };
+    });
+}
+
+// ===========================|| DAC AUTHORIZATIONS TABLE ||=========================== //
+
+/*
+ * A read-only, filterable view of every DAC (Data Access Committee) authorization
+ * across all programs. Authorizations that share the same program, DAC id, and
+ * date range are collapsed into a single row with their users listed together.
+ * The DataGrid toolbar provides quick search, per-column filtering, sorting, and
+ * CSV export.
+ */
+function DacAuthorizationsTable({ onNavigate }) {
+    const [rows, setRows] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    const loadDacs = useCallback(() => {
+        setLoading(true);
+        setError(null);
+        return fetchAllDacAuthorizations()
+            .then((authorizations) => setRows(groupDacAuthorizations(authorizations)))
+            .catch((err) => setError(`Could not load DAC authorizations. ${err}`))
+            .finally(() => setLoading(false));
+    }, []);
+
+    useEffect(() => {
+        loadDacs();
+    }, [loadDacs]);
+
+    const columns = [
+        { field: 'program_id', headerName: 'Program', flex: 1, minWidth: 150 },
+        {
+            field: 'users',
+            headerName: 'Users',
+            flex: 2,
+            minWidth: 280,
+            renderCell: (params) => (
+                <Tooltip title={params.value || ''} placement="top-start">
+                    <span>{params.value}</span>
+                </Tooltip>
+            )
+        },
+        { field: 'user_count', headerName: '# Users', width: 90, type: 'number' },
+        { field: 'dac_id', headerName: 'DAC ID', flex: 1, minWidth: 130 },
+        { field: 'start_date', headerName: 'Start Date', flex: 1, minWidth: 120 },
+        { field: 'end_date', headerName: 'End Date', flex: 1, minWidth: 120 }
+    ];
+
+    return (
+        <Box>
+            <Stack direction="row" alignItems="center" spacing={1} mb={2}>
+                <Typography variant="h4">DAC Authorizations</Typography>
+                <Chip label={rows.length} size="small" color="primary" />
+                <Box flexGrow={1} />
+                <Button
+                    variant="contained"
+                    startIcon={<IconShieldPlus size="1rem" />}
+                    onClick={() => onNavigate && onNavigate('add-dac')}
+                    disabled={!onNavigate}
+                >
+                    Add a DAC Authorization
+                </Button>
+                <Button startIcon={<IconRefresh size="1rem" />} onClick={loadDacs} disabled={loading}>
+                    Refresh
+                </Button>
+            </Stack>
+
+            {error && (
+                <Alert severity="error" onClose={() => setError(null)} sx={{ mb: 2 }}>
+                    {error}
+                </Alert>
+            )}
+
+            <Box sx={{ height: 560, width: '100%' }}>
+                <DataGrid
+                    rows={rows}
+                    columns={columns}
+                    loading={loading}
+                    slots={{ toolbar: GridToolbar }}
+                    slotProps={{ toolbar: { showQuickFilter: true } }}
+                    pageSizeOptions={[10, 25, 50, 100]}
+                    initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
+                    localeText={{ noRowsLabel: 'No DAC authorizations found' }}
+                    disableRowSelectionOnClick
+                />
+            </Box>
+        </Box>
+    );
+}
+
+DacAuthorizationsTable.propTypes = {
+    onNavigate: PropTypes.func
+};
+
+export default DacAuthorizationsTable;

--- a/src/views/siteAdmin/DacAuthorizationsTable.jsx
+++ b/src/views/siteAdmin/DacAuthorizationsTable.jsx
@@ -3,11 +3,12 @@ import PropTypes from 'prop-types';
 
 // mui
 import { Alert, Box, Button, Chip, Stack, Tooltip, Typography } from '@mui/material';
-import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { DataGrid } from '@mui/x-data-grid';
 import { IconRefresh, IconShieldPlus } from '@tabler/icons-react';
 
 // project imports
 import { fetchAllDacAuthorizations } from '../../store/api';
+import { adminDataGridProps } from '../../utils/adminHelpers';
 
 // Collapse authorizations that share the same program, DAC id, and date range
 // into a single row, listing all their users as a comma-delimited string.
@@ -28,10 +29,11 @@ function groupDacAuthorizations(authorizations) {
             groups.get(key).userSet.add(dac.user_id);
         }
     });
-    return [...groups.values()].map((group, index) => {
+    return [...groups.entries()].map(([key, group]) => {
         const users = [...group.userSet].sort();
         return {
-            id: index,
+            // Stable composite id (program/DAC/date range) rather than an index.
+            id: key,
             program_id: group.program_id,
             dac_id: group.dac_id,
             start_date: group.start_date,
@@ -54,14 +56,14 @@ function groupDacAuthorizations(authorizations) {
 function DacAuthorizationsTable({ onNavigate }) {
     const [rows, setRows] = useState([]);
     const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(null);
+    const [feedback, setFeedback] = useState(null);
 
     const loadDacs = useCallback(() => {
         setLoading(true);
-        setError(null);
+        setFeedback(null);
         return fetchAllDacAuthorizations()
             .then((authorizations) => setRows(groupDacAuthorizations(authorizations)))
-            .catch((err) => setError(`Could not load DAC authorizations. ${err}`))
+            .catch((err) => setFeedback({ severity: 'error', text: `Could not load DAC authorizations. ${err}` }))
             .finally(() => setLoading(false));
     }, []);
 
@@ -107,9 +109,9 @@ function DacAuthorizationsTable({ onNavigate }) {
                 </Button>
             </Stack>
 
-            {error && (
-                <Alert severity="error" onClose={() => setError(null)} sx={{ mb: 2 }}>
-                    {error}
+            {feedback && (
+                <Alert severity={feedback.severity} onClose={() => setFeedback(null)} sx={{ mb: 2 }}>
+                    {feedback.text}
                 </Alert>
             )}
 
@@ -118,12 +120,10 @@ function DacAuthorizationsTable({ onNavigate }) {
                     rows={rows}
                     columns={columns}
                     loading={loading}
-                    slots={{ toolbar: GridToolbar }}
-                    slotProps={{ toolbar: { showQuickFilter: true } }}
+                    {...adminDataGridProps}
                     pageSizeOptions={[10, 25, 50, 100]}
                     initialState={{ pagination: { paginationModel: { pageSize: 25 } } }}
                     localeText={{ noRowsLabel: 'No DAC authorizations found' }}
-                    disableRowSelectionOnClick
                 />
             </Box>
         </Box>

--- a/src/views/siteAdmin/FederatedNodes.jsx
+++ b/src/views/siteAdmin/FederatedNodes.jsx
@@ -1,0 +1,223 @@
+import { useCallback, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+// mui
+import {
+    Alert,
+    Box,
+    Button,
+    Chip,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
+    Stack,
+    Tooltip,
+    Typography
+} from '@mui/material';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { IconRefresh, IconServerBolt, IconTrash } from '@tabler/icons-react';
+
+// project imports
+import { deleteFederatedServer, fetchFederatedServers, fetchNodeStatus } from '../../store/api';
+
+// Build a lookup of node status keyed by (lower-cased) location name. The status
+// probe returns one entry per registered node: { location: { name }, status }.
+function indexStatusByLocation(statusArray) {
+    const byName = new Map();
+    (Array.isArray(statusArray) ? statusArray : []).forEach((entry) => {
+        const name = entry?.location?.name;
+        if (name) {
+            byName.set(name.toLowerCase(), entry);
+        }
+    });
+    return byName;
+}
+
+// Classify a raw fanout status code into a display state. A missing probe entry
+// means the node was never contacted, so its reachability is unknown.
+function classifyStatus(entry) {
+    if (!entry || entry.status === undefined) {
+        return { label: 'Unknown', color: 'default', message: 'No status returned for this node.' };
+    }
+    if (entry.status === 200) {
+        return { label: 'Connected', color: 'success', message: '' };
+    }
+    return { label: 'Unreachable', color: 'error', message: entry.message || `Status ${entry.status}` };
+}
+
+// ===========================|| FEDERATED NODES ||=========================== //
+
+/*
+ * Show every peer node registered with this node's federation service, annotated
+ * with a live Connected / Unreachable status derived from a fanout probe. A site
+ * admin can select one or more nodes and unregister them (behind a confirmation
+ * dialog), or jump to the Add Federated Node form.
+ */
+function FederatedNodes({ onNavigate }) {
+    const [rows, setRows] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [busy, setBusy] = useState(false);
+    const [selection, setSelection] = useState([]);
+    const [feedback, setFeedback] = useState(null);
+    const [confirmOpen, setConfirmOpen] = useState(false);
+
+    const loadNodes = useCallback(() => {
+        setLoading(true);
+        // The registry is the source of truth for which nodes exist; the probe
+        // only annotates them, so a failed probe should still show the nodes.
+        return Promise.all([fetchFederatedServers(), fetchNodeStatus().catch(() => [])])
+            .then(([servers, statusArray]) => {
+                const statusByName = indexStatusByLocation(statusArray);
+                const nextRows = servers.map((server) => {
+                    const location = server?.location || {};
+                    const status = classifyStatus(location.name ? statusByName.get(location.name.toLowerCase()) : undefined);
+                    return {
+                        id: server.id,
+                        name: location.name || '',
+                        province: location.province || '',
+                        url: server.url || '',
+                        statusLabel: status.label,
+                        statusColor: status.color,
+                        statusMessage: status.message
+                    };
+                });
+                setRows(nextRows);
+                setSelection([]);
+            })
+            .catch((error) => setFeedback({ severity: 'error', text: `Could not load federated nodes. ${error}` }))
+            .finally(() => setLoading(false));
+    }, []);
+
+    useEffect(() => {
+        loadNodes();
+    }, [loadNodes]);
+
+    const handleDeleteSelected = () => {
+        setConfirmOpen(false);
+        setBusy(true);
+        setFeedback(null);
+        // The federation service deletes a single server per call, so chain them.
+        selection
+            .reduce((chain, serverId) => chain.then(() => deleteFederatedServer(serverId)), Promise.resolve())
+            .then(() => {
+                setFeedback({ severity: 'success', text: `Unregistered ${selection.length} node(s).` });
+                return loadNodes();
+            })
+            .catch((error) => setFeedback({ severity: 'error', text: `Could not unregister node(s). ${error}` }))
+            .finally(() => setBusy(false));
+    };
+
+    const columns = [
+        { field: 'name', headerName: 'Name', flex: 1, minWidth: 150 },
+        { field: 'province', headerName: 'Province', flex: 1, minWidth: 120 },
+        { field: 'id', headerName: 'Server ID', flex: 1, minWidth: 160 },
+        {
+            field: 'url',
+            headerName: 'URL',
+            flex: 2,
+            minWidth: 240,
+            renderCell: (params) => (
+                <Tooltip title={params.value || ''} placement="top-start">
+                    <span>{params.value}</span>
+                </Tooltip>
+            )
+        },
+        {
+            field: 'statusLabel',
+            headerName: 'Status',
+            width: 150,
+            renderCell: (params) => (
+                <Tooltip title={params.row.statusMessage || ''} placement="top">
+                    <Chip label={params.value} size="small" color={params.row.statusColor} variant="outlined" />
+                </Tooltip>
+            )
+        }
+    ];
+
+    const selectedNames = rows.filter((row) => selection.includes(row.id)).map((row) => row.id);
+
+    return (
+        <Box>
+            <Stack direction="row" alignItems="center" spacing={1} mb={2} flexWrap="wrap" useFlexGap>
+                <Typography variant="h4">Federated Nodes</Typography>
+                <Chip label={rows.length} size="small" color="primary" />
+                <Box flexGrow={1} />
+                <Button
+                    variant="contained"
+                    startIcon={<IconServerBolt size="1rem" />}
+                    onClick={() => onNavigate && onNavigate('add-node')}
+                    disabled={!onNavigate}
+                >
+                    Add Node
+                </Button>
+                <Button
+                    variant="outlined"
+                    color="error"
+                    startIcon={<IconTrash size="1rem" />}
+                    disabled={busy || selection.length === 0}
+                    onClick={() => setConfirmOpen(true)}
+                >
+                    Unregister Selected ({selection.length})
+                </Button>
+                <Button startIcon={<IconRefresh size="1rem" />} onClick={loadNodes} disabled={loading || busy}>
+                    Refresh
+                </Button>
+            </Stack>
+
+            <Typography variant="body2" color="textSecondary" mb={2}>
+                Registered peer nodes and their current reachability. Status is derived from a live query fanned out to every node.
+            </Typography>
+
+            {feedback && (
+                <Alert severity={feedback.severity} onClose={() => setFeedback(null)} sx={{ mb: 2 }}>
+                    {feedback.text}
+                </Alert>
+            )}
+
+            <Box sx={{ height: 520, width: '100%' }}>
+                <DataGrid
+                    rows={rows}
+                    columns={columns}
+                    loading={loading}
+                    checkboxSelection
+                    disableRowSelectionOnClick
+                    rowSelectionModel={selection}
+                    onRowSelectionModelChange={(model) => setSelection(model)}
+                    slots={{ toolbar: GridToolbar }}
+                    slotProps={{ toolbar: { showQuickFilter: true } }}
+                    pageSizeOptions={[10, 25, 50]}
+                    initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+                    localeText={{ noRowsLabel: 'No federated nodes registered' }}
+                />
+            </Box>
+
+            <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
+                <DialogTitle>Unregister node(s)?</DialogTitle>
+                <DialogContent>
+                    <DialogContentText component="div">
+                        This will remove the following node(s) from federation. They will no longer be included in federated queries.
+                        <Box component="ul" sx={{ mt: 1, mb: 0 }}>
+                            {selectedNames.map((name) => (
+                                <li key={name}>{name}</li>
+                            ))}
+                        </Box>
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setConfirmOpen(false)}>Cancel</Button>
+                    <Button color="error" variant="contained" onClick={handleDeleteSelected} startIcon={<IconTrash size="1rem" />}>
+                        Unregister
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </Box>
+    );
+}
+
+FederatedNodes.propTypes = {
+    onNavigate: PropTypes.func
+};
+
+export default FederatedNodes;

--- a/src/views/siteAdmin/FederatedNodes.jsx
+++ b/src/views/siteAdmin/FederatedNodes.jsx
@@ -22,17 +22,20 @@ import { IconRefresh, IconServerBolt, IconTrash } from '@tabler/icons-react';
 // project imports
 import { deleteFederatedServer, fetchFederatedServers, fetchNodeStatus } from '../../store/api';
 
-// Build a lookup of node status keyed by (lower-cased) location name. The status
-// probe returns one entry per registered node: { location: { name }, status }.
+// Key a node by location name + province so two nodes sharing a name (but in
+// different provinces) don't collide when merging live status onto the registry.
+const locationKey = (location) => `${(location?.name || '').toLowerCase()}||${(location?.province || '').toLowerCase()}`;
+
+// Build a lookup of node status keyed by location. The status probe returns one
+// entry per registered node: { location: { name, province }, status }.
 function indexStatusByLocation(statusArray) {
-    const byName = new Map();
+    const byLocation = new Map();
     (Array.isArray(statusArray) ? statusArray : []).forEach((entry) => {
-        const name = entry?.location?.name;
-        if (name) {
-            byName.set(name.toLowerCase(), entry);
+        if (entry?.location?.name) {
+            byLocation.set(locationKey(entry.location), entry);
         }
     });
-    return byName;
+    return byLocation;
 }
 
 // Classify a raw fanout status code into a display state. A missing probe entry
@@ -72,7 +75,7 @@ function FederatedNodes({ onNavigate }) {
                 const statusByName = indexStatusByLocation(statusArray);
                 const nextRows = servers.map((server) => {
                     const location = server?.location || {};
-                    const status = classifyStatus(location.name ? statusByName.get(location.name.toLowerCase()) : undefined);
+                    const status = classifyStatus(location.name ? statusByName.get(locationKey(location)) : undefined);
                     return {
                         id: server.id,
                         name: location.name || '',
@@ -98,14 +101,28 @@ function FederatedNodes({ onNavigate }) {
         setConfirmOpen(false);
         setBusy(true);
         setFeedback(null);
-        // The federation service deletes a single server per call, so chain them.
-        selection
-            .reduce((chain, serverId) => chain.then(() => deleteFederatedServer(serverId)), Promise.resolve())
-            .then(() => {
-                setFeedback({ severity: 'success', text: `Unregistered ${selection.length} node(s).` });
+        // The federation service deletes a single server per call. Run them
+        // independently so one failure doesn't abort the rest, report per-node
+        // outcomes, and always refresh so partial deletions are reflected.
+        const ids = [...selection];
+        Promise.allSettled(ids.map((serverId) => deleteFederatedServer(serverId)))
+            .then((results) => {
+                const failed = [];
+                results.forEach((result, index) => {
+                    if (result.status === 'rejected') {
+                        failed.push(`${ids[index]} (${result.reason})`);
+                    }
+                });
+                const succeeded = ids.length - failed.length;
+                if (failed.length === 0) {
+                    setFeedback({ severity: 'success', text: `Unregistered ${succeeded} node(s).` });
+                } else if (succeeded === 0) {
+                    setFeedback({ severity: 'error', text: `Could not unregister: ${failed.join('; ')}` });
+                } else {
+                    setFeedback({ severity: 'warning', text: `Unregistered ${succeeded} node(s). Failed: ${failed.join('; ')}` });
+                }
                 return loadNodes();
             })
-            .catch((error) => setFeedback({ severity: 'error', text: `Could not unregister node(s). ${error}` }))
             .finally(() => setBusy(false));
     };
 

--- a/src/views/siteAdmin/ManagePrograms.jsx
+++ b/src/views/siteAdmin/ManagePrograms.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 
 // mui
@@ -21,19 +21,7 @@ import { IconDeviceFloppy, IconSearch } from '@tabler/icons-react';
 
 // project imports
 import { addProgram, fetchProgram, fetchProgramDacs, fetchPrograms } from '../../store/api';
-
-// Split a free-text field into a lower-cased, de-duplicated list of user ids
-// (the ingest service stores curators/team members lower-cased).
-function parseUserList(value) {
-    return [
-        ...new Set(
-            value
-                .split(/[\s,;]+/)
-                .map((item) => item.trim().toLowerCase())
-                .filter(Boolean)
-        )
-    ];
-}
+import { parseUserList } from '../../utils/adminHelpers';
 
 // Case-insensitive union of two user id lists.
 function unionUsers(existing, added) {
@@ -63,6 +51,9 @@ function ManagePrograms({ onNavigate, allowedPrograms, showHeading }) {
 
     const [busy, setBusy] = useState(false);
     const [feedback, setFeedback] = useState(null);
+    // Monotonic id so out-of-order lookup responses (look up A then B quickly)
+    // are ignored — only the latest request's result is applied.
+    const lookupSeq = useRef(0);
 
     const loadProgramOptions = useCallback(() => {
         // When restricted to a set of programs (e.g. a program curator managing
@@ -93,6 +84,7 @@ function ManagePrograms({ onNavigate, allowedPrograms, showHeading }) {
                 setResult(null);
                 return;
             }
+            const requestId = (lookupSeq.current += 1);
             setLooking(true);
             setFeedback(null);
             setCuratorsInput('');
@@ -100,6 +92,10 @@ function ManagePrograms({ onNavigate, allowedPrograms, showHeading }) {
             setMode('add');
             Promise.all([fetchProgram(programId), fetchProgramDacs(programId).catch(() => ({}))])
                 .then(([programResponse, dacs]) => {
+                    // Ignore this response if a newer lookup has since started.
+                    if (lookupSeq.current !== requestId) {
+                        return;
+                    }
                     if (programResponse.ok && programResponse.data) {
                         setResult({
                             programId,
@@ -118,10 +114,17 @@ function ManagePrograms({ onNavigate, allowedPrograms, showHeading }) {
                     }
                 })
                 .catch((error) => {
+                    if (lookupSeq.current !== requestId) {
+                        return;
+                    }
                     setFeedback({ severity: 'error', text: `Could not look up ${programId}. ${error}` });
                     setResult(null);
                 })
-                .finally(() => setLooking(false));
+                .finally(() => {
+                    if (lookupSeq.current === requestId) {
+                        setLooking(false);
+                    }
+                });
         },
         [lookupInput, allowedPrograms]
     );

--- a/src/views/siteAdmin/ManagePrograms.jsx
+++ b/src/views/siteAdmin/ManagePrograms.jsx
@@ -1,0 +1,327 @@
+import { useCallback, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+// mui
+import {
+    Alert,
+    Autocomplete,
+    Box,
+    Button,
+    Chip,
+    Divider,
+    FormControlLabel,
+    Grid,
+    Radio,
+    RadioGroup,
+    Stack,
+    TextField,
+    Typography
+} from '@mui/material';
+import { IconDeviceFloppy, IconSearch } from '@tabler/icons-react';
+
+// project imports
+import { addProgram, fetchProgram, fetchProgramDacs, fetchPrograms } from '../../store/api';
+
+// Split a free-text field into a lower-cased, de-duplicated list of user ids
+// (the ingest service stores curators/team members lower-cased).
+function parseUserList(value) {
+    return [
+        ...new Set(
+            value
+                .split(/[\s,;]+/)
+                .map((item) => item.trim().toLowerCase())
+                .filter(Boolean)
+        )
+    ];
+}
+
+// Case-insensitive union of two user id lists.
+function unionUsers(existing, added) {
+    return [...new Set([...existing.map((u) => u.toLowerCase()), ...added])];
+}
+
+// ===========================|| MANAGE PROGRAMS ||=========================== //
+
+/*
+ * Look up an existing program to see its curators and team members, then either
+ * ADD users to those lists or REPLACE them. Because the ingest service fully
+ * overwrites a program on POST, the "add" path merges with the existing lists
+ * and both paths preserve the program's existing DAC authorizations and other
+ * stored fields. Registering brand-new programs is handled by the Register
+ * Program section, so a lookup that finds nothing points the user there.
+ */
+function ManagePrograms({ onNavigate, allowedPrograms, showHeading }) {
+    const [programOptions, setProgramOptions] = useState([]);
+    const [lookupInput, setLookupInput] = useState('');
+    const [looking, setLooking] = useState(false);
+    // result of the last lookup: { programId, exists, curators, team, dacs, existing }
+    const [result, setResult] = useState(null);
+
+    const [curatorsInput, setCuratorsInput] = useState('');
+    const [teamInput, setTeamInput] = useState('');
+    const [mode, setMode] = useState('add'); // 'add' | 'replace'
+
+    const [busy, setBusy] = useState(false);
+    const [feedback, setFeedback] = useState(null);
+
+    const loadProgramOptions = useCallback(() => {
+        // When restricted to a set of programs (e.g. a program curator managing
+        // only their own), use that list directly — a plain program curator is
+        // not authorized to list all programs via GET /program.
+        if (allowedPrograms) {
+            setProgramOptions(allowedPrograms);
+            return;
+        }
+        fetchPrograms()
+            .then((programs) => setProgramOptions(Array.isArray(programs) ? programs : []))
+            .catch((error) => setFeedback({ severity: 'error', text: `Could not load programs. ${error}` }));
+    }, [allowedPrograms]);
+
+    useEffect(() => {
+        loadProgramOptions();
+    }, [loadProgramOptions]);
+
+    const handleLookup = useCallback(
+        (rawId) => {
+            const programId = (rawId ?? lookupInput).trim();
+            if (!programId) {
+                setFeedback({ severity: 'warning', text: 'Enter a program id to look up.' });
+                return;
+            }
+            if (allowedPrograms && !allowedPrograms.includes(programId)) {
+                setFeedback({ severity: 'warning', text: 'You can only manage programs you are a curator of.' });
+                setResult(null);
+                return;
+            }
+            setLooking(true);
+            setFeedback(null);
+            setCuratorsInput('');
+            setTeamInput('');
+            setMode('add');
+            Promise.all([fetchProgram(programId), fetchProgramDacs(programId).catch(() => ({}))])
+                .then(([programResponse, dacs]) => {
+                    if (programResponse.ok && programResponse.data) {
+                        setResult({
+                            programId,
+                            exists: true,
+                            curators: programResponse.data.program_curators || [],
+                            team: programResponse.data.team_members || [],
+                            dacs: dacs || {},
+                            existing: programResponse.data
+                        });
+                    } else if (programResponse.status === 404) {
+                        setResult({ programId, exists: false });
+                    } else {
+                        const detail = programResponse.data?.error || programResponse.data?.message || programResponse.status;
+                        setFeedback({ severity: 'error', text: `Could not look up ${programId}. ${detail}` });
+                        setResult(null);
+                    }
+                })
+                .catch((error) => {
+                    setFeedback({ severity: 'error', text: `Could not look up ${programId}. ${error}` });
+                    setResult(null);
+                })
+                .finally(() => setLooking(false));
+        },
+        [lookupInput, allowedPrograms]
+    );
+
+    const handleSave = () => {
+        if (!result || !result.exists) {
+            return;
+        }
+        const newCurators = parseUserList(curatorsInput);
+        const newTeam = parseUserList(teamInput);
+
+        const curators = mode === 'add' ? unionUsers(result.curators, newCurators) : newCurators;
+        const team = mode === 'add' ? unionUsers(result.team, newTeam) : newTeam;
+        // Preserve existing fields (creation date) and DAC authorizations, which
+        // are stored inside the same program record and would otherwise be
+        // dropped by the overwriting POST.
+        const program = {
+            ...result.existing,
+            program_id: result.programId,
+            program_curators: curators,
+            team_members: team,
+            dac_authorizations: result.dacs || {}
+        };
+
+        setBusy(true);
+        setFeedback(null);
+        addProgram(program)
+            .then(() => {
+                setFeedback({
+                    severity: 'success',
+                    text: `${mode === 'add' ? 'Added users to' : 'Replaced users on'} program ${result.programId}.`
+                });
+                handleLookup(result.programId); // refresh the displayed lists
+            })
+            .catch((error) => setFeedback({ severity: 'error', text: `${error}` }))
+            .finally(() => setBusy(false));
+    };
+
+    const renderUserChips = (users) =>
+        users.length > 0 ? (
+            <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                {users.map((user) => (
+                    <Chip key={user} label={user} size="small" />
+                ))}
+            </Stack>
+        ) : (
+            <Typography variant="body2" color="textSecondary">
+                None
+            </Typography>
+        );
+
+    return (
+        <Box>
+            {showHeading && (
+                <Typography variant="h4" mb={2}>
+                    Manage Programs
+                </Typography>
+            )}
+
+            {/* Lookup */}
+            <Typography variant="subtitle1" mb={1}>
+                Look up program
+            </Typography>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ sm: 'center' }} mb={2}>
+                <Autocomplete
+                    freeSolo
+                    options={programOptions}
+                    inputValue={lookupInput}
+                    onInputChange={(event, value) => setLookupInput(value)}
+                    onChange={(event, value) => value && handleLookup(value)}
+                    sx={{ width: { xs: '100%', sm: 360 } }}
+                    renderInput={(params) => <TextField {...params} label="Program id" placeholder="Enter or select a program id" />}
+                />
+                <Button
+                    variant="contained"
+                    startIcon={<IconSearch size="1rem" />}
+                    onClick={() => handleLookup()}
+                    disabled={looking || lookupInput.trim().length === 0}
+                >
+                    Look Up
+                </Button>
+            </Stack>
+
+            {feedback && (
+                <Alert severity={feedback.severity} onClose={() => setFeedback(null)} sx={{ mb: 2 }}>
+                    {feedback.text}
+                </Alert>
+            )}
+
+            {result && !result.exists && (
+                <Alert
+                    severity="info"
+                    sx={{ mb: 2 }}
+                    action={
+                        onNavigate ? (
+                            <Button color="inherit" size="small" onClick={() => onNavigate('register')}>
+                                Go to Register Program
+                            </Button>
+                        ) : undefined
+                    }
+                >
+                    Program <strong>{result.programId}</strong> does not exist. Use Register Program to create it.
+                </Alert>
+            )}
+
+            {result && result.exists && (
+                <>
+                    <Divider sx={{ my: 2 }} />
+                    <Box mb={2}>
+                        <Typography variant="h5" mb={1}>
+                            {result.programId}
+                        </Typography>
+                        <Grid container spacing={2}>
+                            <Grid item xs={12} md={6}>
+                                <Typography variant="subtitle2" gutterBottom>
+                                    Current program curators
+                                </Typography>
+                                {renderUserChips(result.curators)}
+                            </Grid>
+                            <Grid item xs={12} md={6}>
+                                <Typography variant="subtitle2" gutterBottom>
+                                    Current team members
+                                </Typography>
+                                {renderUserChips(result.team)}
+                            </Grid>
+                        </Grid>
+                    </Box>
+
+                    <Box mb={1}>
+                        <Typography variant="subtitle2" gutterBottom>
+                            When saving
+                        </Typography>
+                        <RadioGroup row value={mode} onChange={(event) => setMode(event.target.value)}>
+                            <FormControlLabel value="add" control={<Radio />} label="Add to existing users" />
+                            <FormControlLabel value="replace" control={<Radio />} label="Replace existing users" />
+                        </RadioGroup>
+                    </Box>
+
+                    <Grid container spacing={2} sx={{ maxWidth: 720 }}>
+                        <Grid item xs={12} md={6}>
+                            <TextField
+                                label="Program curators"
+                                placeholder="curator1@example.com, curator2@example.com …"
+                                helperText={
+                                    mode === 'add'
+                                        ? 'These users are merged with the current curators.'
+                                        : 'These users replace the current curators (leave blank to clear).'
+                                }
+                                value={curatorsInput}
+                                onChange={(event) => setCuratorsInput(event.target.value)}
+                                multiline
+                                minRows={3}
+                                fullWidth
+                            />
+                        </Grid>
+                        <Grid item xs={12} md={6}>
+                            <TextField
+                                label="Team members"
+                                placeholder="member1@example.com, member2@example.com …"
+                                helperText={
+                                    mode === 'add'
+                                        ? 'These users are merged with the current team members.'
+                                        : 'These users replace the current team members (leave blank to clear).'
+                                }
+                                value={teamInput}
+                                onChange={(event) => setTeamInput(event.target.value)}
+                                multiline
+                                minRows={3}
+                                fullWidth
+                            />
+                        </Grid>
+                        <Grid item xs={12}>
+                            <Stack direction="row" justifyContent="flex-end">
+                                <Button
+                                    variant="contained"
+                                    startIcon={<IconDeviceFloppy size="1rem" />}
+                                    disabled={busy}
+                                    onClick={handleSave}
+                                >
+                                    Save Changes
+                                </Button>
+                            </Stack>
+                        </Grid>
+                    </Grid>
+                </>
+            )}
+        </Box>
+    );
+}
+
+ManagePrograms.propTypes = {
+    onNavigate: PropTypes.func,
+    // When provided, restricts lookup to this set of program ids (e.g. a program
+    // curator managing only programs they curate) and skips the list-all call.
+    allowedPrograms: PropTypes.arrayOf(PropTypes.string),
+    showHeading: PropTypes.bool
+};
+
+ManagePrograms.defaultProps = {
+    showHeading: true
+};
+
+export default ManagePrograms;

--- a/src/views/siteAdmin/PendingUsers.jsx
+++ b/src/views/siteAdmin/PendingUsers.jsx
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useState } from 'react';
+
+// mui
+import { Alert, Box, Button, Chip, Stack, Typography } from '@mui/material';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { IconCheck, IconRefresh, IconX } from '@tabler/icons-react';
+
+// project imports
+import { approvePendingUser, approvePendingUsers, fetchPendingUsers, rejectPendingUser } from '../../store/api';
+
+// ===========================|| PENDING USERS ||=========================== //
+
+/*
+ * Lists users awaiting CanDIG authorization. A site admin can approve or reject
+ * individual users, approve the current selection, or approve everyone at once.
+ */
+function PendingUsers() {
+    const [users, setUsers] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [busy, setBusy] = useState(false);
+    const [selection, setSelection] = useState([]);
+    const [feedback, setFeedback] = useState(null);
+
+    const loadUsers = useCallback(() => {
+        setLoading(true);
+        return fetchPendingUsers()
+            .then((results) => {
+                setUsers(results);
+                setSelection([]);
+            })
+            .catch((error) => setFeedback({ severity: 'error', text: `Could not load pending users. ${error}` }))
+            .finally(() => setLoading(false));
+    }, []);
+
+    useEffect(() => {
+        loadUsers();
+    }, [loadUsers]);
+
+    // Run an action, refresh the list, and surface a success/error message.
+    const runAction = (action, successText) => {
+        setBusy(true);
+        setFeedback(null);
+        return action()
+            .then(() => {
+                setFeedback({ severity: 'success', text: successText });
+                return loadUsers();
+            })
+            .catch((error) => setFeedback({ severity: 'error', text: `${error}` }))
+            .finally(() => setBusy(false));
+    };
+
+    const handleApprove = (userId) => runAction(() => approvePendingUser(userId), `Approved ${userId}.`);
+    const handleReject = (userId) => runAction(() => rejectPendingUser(userId), `Rejected ${userId}.`);
+    const handleApproveSelected = () =>
+        runAction(() => approvePendingUsers(selection), `Approved ${selection.length} user(s).`);
+    const handleApproveAll = () =>
+        runAction(() => approvePendingUsers(users.map((u) => u.user_name)), `Approved all ${users.length} pending user(s).`);
+
+    const rows = users.map((user) => ({ id: user.user_name, user_name: user.user_name }));
+
+    const columns = [
+        { field: 'user_name', headerName: 'User', flex: 1, minWidth: 260 },
+        {
+            field: 'actions',
+            headerName: 'Actions',
+            sortable: false,
+            filterable: false,
+            minWidth: 220,
+            renderCell: (params) => (
+                <Stack direction="row" spacing={1}>
+                    <Button
+                        size="small"
+                        variant="contained"
+                        color="success"
+                        startIcon={<IconCheck size="1rem" />}
+                        disabled={busy}
+                        onClick={() => handleApprove(params.row.user_name)}
+                    >
+                        Approve
+                    </Button>
+                    <Button
+                        size="small"
+                        variant="outlined"
+                        color="error"
+                        startIcon={<IconX size="1rem" />}
+                        disabled={busy}
+                        onClick={() => handleReject(params.row.user_name)}
+                    >
+                        Reject
+                    </Button>
+                </Stack>
+            )
+        }
+    ];
+
+    return (
+        <Box>
+            <Stack direction="row" alignItems="center" spacing={1} mb={2} flexWrap="wrap" useFlexGap>
+                <Typography variant="h4">Pending Users</Typography>
+                <Chip label={users.length} size="small" color="primary" />
+                <Box flexGrow={1} />
+                <Button startIcon={<IconRefresh size="1rem" />} onClick={loadUsers} disabled={loading || busy}>
+                    Refresh
+                </Button>
+                <Button variant="outlined" disabled={busy || selection.length === 0} onClick={handleApproveSelected}>
+                    Approve Selected ({selection.length})
+                </Button>
+                <Button variant="contained" disabled={busy || users.length === 0} onClick={handleApproveAll}>
+                    Approve All
+                </Button>
+            </Stack>
+
+            {feedback && (
+                <Alert severity={feedback.severity} onClose={() => setFeedback(null)} sx={{ mb: 2 }}>
+                    {feedback.text}
+                </Alert>
+            )}
+
+            <Box sx={{ height: 460, width: '100%' }}>
+                <DataGrid
+                    rows={rows}
+                    columns={columns}
+                    loading={loading}
+                    checkboxSelection
+                    disableRowSelectionOnClick
+                    rowSelectionModel={selection}
+                    onRowSelectionModelChange={(model) => setSelection(model)}
+                    slots={{ toolbar: GridToolbar }}
+                    slotProps={{ toolbar: { showQuickFilter: true } }}
+                    pageSizeOptions={[10, 25, 50]}
+                    initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+                    localeText={{ noRowsLabel: 'No pending users' }}
+                />
+            </Box>
+        </Box>
+    );
+}
+
+export default PendingUsers;

--- a/src/views/siteAdmin/PendingUsers.jsx
+++ b/src/views/siteAdmin/PendingUsers.jsx
@@ -2,11 +2,13 @@ import { useCallback, useEffect, useState } from 'react';
 
 // mui
 import { Alert, Box, Button, Chip, Stack, Typography } from '@mui/material';
-import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { DataGrid } from '@mui/x-data-grid';
 import { IconCheck, IconRefresh, IconX } from '@tabler/icons-react';
 
 // project imports
 import { approvePendingUser, approvePendingUsers, fetchPendingUsers, rejectPendingUser } from '../../store/api';
+import useAdminAction from '../../hooks/useAdminAction';
+import { adminDataGridProps } from '../../utils/adminHelpers';
 
 // ===========================|| PENDING USERS ||=========================== //
 
@@ -17,9 +19,8 @@ import { approvePendingUser, approvePendingUsers, fetchPendingUsers, rejectPendi
 function PendingUsers() {
     const [users, setUsers] = useState([]);
     const [loading, setLoading] = useState(true);
-    const [busy, setBusy] = useState(false);
     const [selection, setSelection] = useState([]);
-    const [feedback, setFeedback] = useState(null);
+    const { busy, feedback, setFeedback, runAction } = useAdminAction();
 
     const loadUsers = useCallback(() => {
         setLoading(true);
@@ -30,31 +31,20 @@ function PendingUsers() {
             })
             .catch((error) => setFeedback({ severity: 'error', text: `Could not load pending users. ${error}` }))
             .finally(() => setLoading(false));
-    }, []);
+    }, [setFeedback]);
 
     useEffect(() => {
         loadUsers();
     }, [loadUsers]);
 
-    // Run an action, refresh the list, and surface a success/error message.
-    const runAction = (action, successText) => {
-        setBusy(true);
-        setFeedback(null);
-        return action()
-            .then(() => {
-                setFeedback({ severity: 'success', text: successText });
-                return loadUsers();
-            })
-            .catch((error) => setFeedback({ severity: 'error', text: `${error}` }))
-            .finally(() => setBusy(false));
-    };
+    // Run an action and refresh the list only if it succeeded.
+    const run = (action, successText) => runAction(action, successText).then((result) => result.ok && loadUsers());
 
-    const handleApprove = (userId) => runAction(() => approvePendingUser(userId), `Approved ${userId}.`);
-    const handleReject = (userId) => runAction(() => rejectPendingUser(userId), `Rejected ${userId}.`);
-    const handleApproveSelected = () =>
-        runAction(() => approvePendingUsers(selection), `Approved ${selection.length} user(s).`);
+    const handleApprove = (userId) => run(() => approvePendingUser(userId), `Approved ${userId}.`);
+    const handleReject = (userId) => run(() => rejectPendingUser(userId), `Rejected ${userId}.`);
+    const handleApproveSelected = () => run(() => approvePendingUsers(selection), `Approved ${selection.length} user(s).`);
     const handleApproveAll = () =>
-        runAction(() => approvePendingUsers(users.map((u) => u.user_name)), `Approved all ${users.length} pending user(s).`);
+        run(() => approvePendingUsers(users.map((u) => u.user_name)), `Approved all ${users.length} pending user(s).`);
 
     const rows = users.map((user) => ({ id: user.user_name, user_name: user.user_name }));
 
@@ -122,13 +112,9 @@ function PendingUsers() {
                     columns={columns}
                     loading={loading}
                     checkboxSelection
-                    disableRowSelectionOnClick
                     rowSelectionModel={selection}
                     onRowSelectionModelChange={(model) => setSelection(model)}
-                    slots={{ toolbar: GridToolbar }}
-                    slotProps={{ toolbar: { showQuickFilter: true } }}
-                    pageSizeOptions={[10, 25, 50]}
-                    initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+                    {...adminDataGridProps}
                     localeText={{ noRowsLabel: 'No pending users' }}
                 />
             </Box>

--- a/src/views/siteAdmin/PreapprovedUsers.jsx
+++ b/src/views/siteAdmin/PreapprovedUsers.jsx
@@ -2,11 +2,13 @@ import { useCallback, useEffect, useState } from 'react';
 
 // mui
 import { Alert, Box, Button, Chip, Stack, TextField, Typography } from '@mui/material';
-import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { DataGrid } from '@mui/x-data-grid';
 import { IconRefresh, IconTrash, IconUserPlus } from '@tabler/icons-react';
 
 // project imports
 import { addPreapprovedUsers, fetchPreapprovedUsers, removePreapprovedUser } from '../../store/api';
+import useAdminAction from '../../hooks/useAdminAction';
+import { adminDataGridProps, parseUserList } from '../../utils/adminHelpers';
 
 // ===========================|| PREAPPROVED USERS ||=========================== //
 
@@ -18,9 +20,8 @@ import { addPreapprovedUsers, fetchPreapprovedUsers, removePreapprovedUser } fro
 function PreapprovedUsers() {
     const [users, setUsers] = useState([]);
     const [loading, setLoading] = useState(true);
-    const [busy, setBusy] = useState(false);
     const [input, setInput] = useState('');
-    const [feedback, setFeedback] = useState(null);
+    const { busy, feedback, setFeedback, runAction } = useAdminAction();
 
     const loadUsers = useCallback(() => {
         setLoading(true);
@@ -28,38 +29,28 @@ function PreapprovedUsers() {
             .then((results) => setUsers(results))
             .catch((error) => setFeedback({ severity: 'error', text: `Could not load preapproved users. ${error}` }))
             .finally(() => setLoading(false));
-    }, []);
+    }, [setFeedback]);
 
     useEffect(() => {
         loadUsers();
     }, [loadUsers]);
 
-    const runAction = (action, successText) => {
-        setBusy(true);
-        setFeedback(null);
-        return action()
-            .then(() => {
-                setFeedback({ severity: 'success', text: successText });
-                return loadUsers();
-            })
-            .catch((error) => setFeedback({ severity: 'error', text: `${error}` }))
-            .finally(() => setBusy(false));
-    };
-
     const handleAdd = () => {
-        // Accept commas, semicolons, and any whitespace as separators.
-        const userIds = input
-            .split(/[\s,;]+/)
-            .map((value) => value.trim())
-            .filter(Boolean);
+        const userIds = parseUserList(input);
         if (userIds.length === 0) {
             setFeedback({ severity: 'warning', text: 'Enter at least one user id to add.' });
             return;
         }
-        runAction(() => addPreapprovedUsers(userIds), `Added ${userIds.length} preapproved user(s).`).then(() => setInput(''));
+        runAction(() => addPreapprovedUsers(userIds), `Added ${userIds.length} preapproved user(s).`).then((result) => {
+            if (result.ok) {
+                setInput('');
+                loadUsers();
+            }
+        });
     };
 
-    const handleRemove = (userId) => runAction(() => removePreapprovedUser(userId), `Removed ${userId}.`);
+    const handleRemove = (userId) =>
+        runAction(() => removePreapprovedUser(userId), `Removed ${userId}.`).then((result) => result.ok && loadUsers());
 
     const rows = users.map((user) => ({ id: user.user_name, user_name: user.user_name }));
 
@@ -130,12 +121,8 @@ function PreapprovedUsers() {
                     rows={rows}
                     columns={columns}
                     loading={loading}
-                    slots={{ toolbar: GridToolbar }}
-                    slotProps={{ toolbar: { showQuickFilter: true } }}
-                    pageSizeOptions={[10, 25, 50]}
-                    initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+                    {...adminDataGridProps}
                     localeText={{ noRowsLabel: 'No preapproved users' }}
-                    disableRowSelectionOnClick
                 />
             </Box>
         </Box>

--- a/src/views/siteAdmin/PreapprovedUsers.jsx
+++ b/src/views/siteAdmin/PreapprovedUsers.jsx
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useState } from 'react';
+
+// mui
+import { Alert, Box, Button, Chip, Stack, TextField, Typography } from '@mui/material';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { IconRefresh, IconTrash, IconUserPlus } from '@tabler/icons-react';
+
+// project imports
+import { addPreapprovedUsers, fetchPreapprovedUsers, removePreapprovedUser } from '../../store/api';
+
+// ===========================|| PREAPPROVED USERS ||=========================== //
+
+/*
+ * Preapproved users are automatically authorized when they first request access.
+ * A site admin can view the current list, add one or many users at once
+ * (comma / whitespace / newline separated), and remove entries.
+ */
+function PreapprovedUsers() {
+    const [users, setUsers] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [busy, setBusy] = useState(false);
+    const [input, setInput] = useState('');
+    const [feedback, setFeedback] = useState(null);
+
+    const loadUsers = useCallback(() => {
+        setLoading(true);
+        return fetchPreapprovedUsers()
+            .then((results) => setUsers(results))
+            .catch((error) => setFeedback({ severity: 'error', text: `Could not load preapproved users. ${error}` }))
+            .finally(() => setLoading(false));
+    }, []);
+
+    useEffect(() => {
+        loadUsers();
+    }, [loadUsers]);
+
+    const runAction = (action, successText) => {
+        setBusy(true);
+        setFeedback(null);
+        return action()
+            .then(() => {
+                setFeedback({ severity: 'success', text: successText });
+                return loadUsers();
+            })
+            .catch((error) => setFeedback({ severity: 'error', text: `${error}` }))
+            .finally(() => setBusy(false));
+    };
+
+    const handleAdd = () => {
+        // Accept commas, semicolons, and any whitespace as separators.
+        const userIds = input
+            .split(/[\s,;]+/)
+            .map((value) => value.trim())
+            .filter(Boolean);
+        if (userIds.length === 0) {
+            setFeedback({ severity: 'warning', text: 'Enter at least one user id to add.' });
+            return;
+        }
+        runAction(() => addPreapprovedUsers(userIds), `Added ${userIds.length} preapproved user(s).`).then(() => setInput(''));
+    };
+
+    const handleRemove = (userId) => runAction(() => removePreapprovedUser(userId), `Removed ${userId}.`);
+
+    const rows = users.map((user) => ({ id: user.user_name, user_name: user.user_name }));
+
+    const columns = [
+        { field: 'user_name', headerName: 'User', flex: 1, minWidth: 260 },
+        {
+            field: 'actions',
+            headerName: 'Actions',
+            sortable: false,
+            filterable: false,
+            minWidth: 140,
+            renderCell: (params) => (
+                <Button
+                    size="small"
+                    variant="outlined"
+                    color="error"
+                    startIcon={<IconTrash size="1rem" />}
+                    disabled={busy}
+                    onClick={() => handleRemove(params.row.user_name)}
+                >
+                    Remove
+                </Button>
+            )
+        }
+    ];
+
+    return (
+        <Box>
+            <Stack direction="row" alignItems="center" spacing={1} mb={2}>
+                <Typography variant="h4">Preapproved Users</Typography>
+                <Chip label={users.length} size="small" color="primary" />
+                <Box flexGrow={1} />
+                <Button startIcon={<IconRefresh size="1rem" />} onClick={loadUsers} disabled={loading || busy}>
+                    Refresh
+                </Button>
+            </Stack>
+
+            <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'flex-start' }} mb={2}>
+                <TextField
+                    label="Add users"
+                    placeholder="user1@example.com, user2@example.com …"
+                    helperText="Add one or many users, separated by commas, spaces, or new lines."
+                    value={input}
+                    onChange={(event) => setInput(event.target.value)}
+                    multiline
+                    minRows={2}
+                    fullWidth
+                />
+                <Button
+                    variant="contained"
+                    startIcon={<IconUserPlus size="1rem" />}
+                    disabled={busy || input.trim().length === 0}
+                    onClick={handleAdd}
+                    sx={{ minWidth: 140, mt: { xs: 0, md: 0.5 } }}
+                >
+                    Add
+                </Button>
+            </Stack>
+
+            {feedback && (
+                <Alert severity={feedback.severity} onClose={() => setFeedback(null)} sx={{ mb: 2 }}>
+                    {feedback.text}
+                </Alert>
+            )}
+
+            <Box sx={{ height: 420, width: '100%' }}>
+                <DataGrid
+                    rows={rows}
+                    columns={columns}
+                    loading={loading}
+                    slots={{ toolbar: GridToolbar }}
+                    slotProps={{ toolbar: { showQuickFilter: true } }}
+                    pageSizeOptions={[10, 25, 50]}
+                    initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+                    localeText={{ noRowsLabel: 'No preapproved users' }}
+                    disableRowSelectionOnClick
+                />
+            </Box>
+        </Box>
+    );
+}
+
+export default PreapprovedUsers;

--- a/src/views/siteAdmin/RegisterProgram.jsx
+++ b/src/views/siteAdmin/RegisterProgram.jsx
@@ -1,0 +1,175 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+
+// mui
+import { Alert, Box, Button, Grid, Stack, TextField, Typography } from '@mui/material';
+import { IconLibraryPlus } from '@tabler/icons-react';
+
+// project imports
+import { addProgram, fetchProgram } from '../../store/api';
+
+// Split a free-text field into a lower-cased, de-duplicated list of user ids.
+function parseUserList(value) {
+    return [
+        ...new Set(
+            value
+                .split(/[\s,;]+/)
+                .map((item) => item.trim().toLowerCase())
+                .filter(Boolean)
+        )
+    ];
+}
+
+// ===========================|| REGISTER PROGRAM ||=========================== //
+
+/*
+ * Register a brand-new program. If a program with the same id already exists the
+ * portal rejects the request (rather than overwriting it) and points the user to
+ * the Manage Programs section to edit it instead.
+ */
+function RegisterProgram({ onNavigate }) {
+    const [programId, setProgramId] = useState('');
+    const [curators, setCurators] = useState('');
+    const [teamMembers, setTeamMembers] = useState('');
+    const [creationDate, setCreationDate] = useState('');
+    const [busy, setBusy] = useState(false);
+    const [feedback, setFeedback] = useState(null);
+    const [duplicate, setDuplicate] = useState(false);
+
+    const handleSubmit = () => {
+        const id = programId.trim();
+        if (!id) {
+            setFeedback({ severity: 'warning', text: 'A program id is required.' });
+            return;
+        }
+
+        setBusy(true);
+        setFeedback(null);
+        setDuplicate(false);
+
+        // Reject registration if the program already exists.
+        fetchProgram(id)
+            .then((response) => {
+                if (response.ok) {
+                    setDuplicate(true);
+                    setFeedback({
+                        severity: 'error',
+                        text: `Program "${id}" already exists. Use Manage Programs to edit its curators and team members.`
+                    });
+                    return undefined;
+                }
+                if (response.status !== 404) {
+                    const detail = response.data?.error || response.data?.message || response.status;
+                    setFeedback({ severity: 'error', text: `Could not verify program "${id}". ${detail}` });
+                    return undefined;
+                }
+
+                // 404 => safe to create.
+                const program = {
+                    program_id: id,
+                    program_curators: parseUserList(curators),
+                    team_members: parseUserList(teamMembers)
+                };
+                if (creationDate) {
+                    program.creation_date = creationDate;
+                }
+                return addProgram(program).then(() => {
+                    setFeedback({ severity: 'success', text: `Registered program ${id}.` });
+                    setProgramId('');
+                    setCurators('');
+                    setTeamMembers('');
+                    setCreationDate('');
+                });
+            })
+            .catch((error) => setFeedback({ severity: 'error', text: `${error}` }))
+            .finally(() => setBusy(false));
+    };
+
+    return (
+        <Box>
+            <Typography variant="h4" mb={2}>
+                Register Program
+            </Typography>
+
+            {feedback && (
+                <Alert
+                    severity={feedback.severity}
+                    onClose={() => setFeedback(null)}
+                    sx={{ mb: 2 }}
+                    action={
+                        duplicate && onNavigate ? (
+                            <Button color="inherit" size="small" onClick={() => onNavigate('program')}>
+                                Go to Manage Programs
+                            </Button>
+                        ) : undefined
+                    }
+                >
+                    {feedback.text}
+                </Alert>
+            )}
+
+            <Grid container spacing={2} sx={{ maxWidth: 720 }}>
+                <Grid item xs={12} md={6}>
+                    <TextField
+                        label="Program id"
+                        value={programId}
+                        onChange={(event) => {
+                            setProgramId(event.target.value);
+                            setDuplicate(false);
+                        }}
+                        fullWidth
+                        required
+                    />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                    <TextField
+                        label="Creation date"
+                        type="date"
+                        value={creationDate}
+                        onChange={(event) => setCreationDate(event.target.value)}
+                        InputLabelProps={{ shrink: true }}
+                        helperText="Optional — used for data embargo purposes."
+                        fullWidth
+                    />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                    <TextField
+                        label="Program curators"
+                        placeholder="curator1@example.com, curator2@example.com …"
+                        helperText="Users who can curate and manage this program."
+                        value={curators}
+                        onChange={(event) => setCurators(event.target.value)}
+                        multiline
+                        minRows={3}
+                        fullWidth
+                    />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                    <TextField
+                        label="Team members"
+                        placeholder="member1@example.com, member2@example.com …"
+                        helperText="Users who can read this program's data."
+                        value={teamMembers}
+                        onChange={(event) => setTeamMembers(event.target.value)}
+                        multiline
+                        minRows={3}
+                        fullWidth
+                    />
+                </Grid>
+                <Grid item xs={12}>
+                    <Stack direction="row" justifyContent="flex-end">
+                        <Button variant="contained" startIcon={<IconLibraryPlus size="1rem" />} disabled={busy} onClick={handleSubmit}>
+                            Register Program
+                        </Button>
+                    </Stack>
+                </Grid>
+            </Grid>
+        </Box>
+    );
+}
+
+RegisterProgram.propTypes = {
+    onNavigate: PropTypes.func
+};
+
+export default RegisterProgram;

--- a/src/views/siteAdmin/RegisterProgram.jsx
+++ b/src/views/siteAdmin/RegisterProgram.jsx
@@ -7,18 +7,7 @@ import { IconLibraryPlus } from '@tabler/icons-react';
 
 // project imports
 import { addProgram, fetchProgram } from '../../store/api';
-
-// Split a free-text field into a lower-cased, de-duplicated list of user ids.
-function parseUserList(value) {
-    return [
-        ...new Set(
-            value
-                .split(/[\s,;]+/)
-                .map((item) => item.trim().toLowerCase())
-                .filter(Boolean)
-        )
-    ];
-}
+import { parseUserList } from '../../utils/adminHelpers';
 
 // ===========================|| REGISTER PROGRAM ||=========================== //
 

--- a/src/views/siteAdmin/SiteRoleManager.jsx
+++ b/src/views/siteAdmin/SiteRoleManager.jsx
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+// mui
+import { Alert, Box, Button, Chip, Stack, TextField, Typography } from '@mui/material';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { IconRefresh, IconTrash, IconUserPlus } from '@tabler/icons-react';
+
+// project imports
+import { addUserToSiteRole, fetchSiteRoleUsers, removeUserFromSiteRole } from '../../store/api';
+
+// ===========================|| SITE ROLE MANAGER ||=========================== //
+
+/*
+ * View and manage the users assigned to a given site role (e.g. "curator" or
+ * "admin"). A site admin can add one or many users at once and remove existing
+ * ones. Parameterised by role so it can back both the Site Curators and Site
+ * Admins sections.
+ */
+function SiteRoleManager({ roleType, title, description, addLabel, columnHeader, emptyLabel }) {
+    const [members, setMembers] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [busy, setBusy] = useState(false);
+    const [input, setInput] = useState('');
+    const [feedback, setFeedback] = useState(null);
+
+    const loadMembers = useCallback(() => {
+        setLoading(true);
+        return fetchSiteRoleUsers(roleType)
+            .then((users) => setMembers(users))
+            .catch((error) => setFeedback({ severity: 'error', text: `Could not load ${title.toLowerCase()}. ${error}` }))
+            .finally(() => setLoading(false));
+    }, [roleType, title]);
+
+    useEffect(() => {
+        loadMembers();
+    }, [loadMembers]);
+
+    const runAction = (action, successText) => {
+        setBusy(true);
+        setFeedback(null);
+        return action()
+            .then(() => {
+                setFeedback({ severity: 'success', text: successText });
+                return loadMembers();
+            })
+            .catch((error) => setFeedback({ severity: 'error', text: `${error}` }))
+            .finally(() => setBusy(false));
+    };
+
+    const handleAdd = () => {
+        const userIds = input
+            .split(/[\s,;]+/)
+            .map((value) => value.trim())
+            .filter(Boolean);
+        if (userIds.length === 0) {
+            setFeedback({ severity: 'warning', text: 'Enter at least one user id to add.' });
+            return;
+        }
+        // The ingest service adds a single user per call, so chain the requests.
+        runAction(
+            () => userIds.reduce((chain, userId) => chain.then(() => addUserToSiteRole(roleType, userId)), Promise.resolve()),
+            `Added ${userIds.length} ${addLabel}.`
+        ).then(() => setInput(''));
+    };
+
+    const handleRemove = (userId) => runAction(() => removeUserFromSiteRole(roleType, userId), `Removed ${userId}.`);
+
+    const rows = members.map((userId) => ({ id: userId, user_id: userId }));
+
+    const columns = [
+        { field: 'user_id', headerName: columnHeader, flex: 1, minWidth: 260 },
+        {
+            field: 'actions',
+            headerName: 'Actions',
+            sortable: false,
+            filterable: false,
+            minWidth: 140,
+            renderCell: (params) => (
+                <Button
+                    size="small"
+                    variant="outlined"
+                    color="error"
+                    startIcon={<IconTrash size="1rem" />}
+                    disabled={busy}
+                    onClick={() => handleRemove(params.row.user_id)}
+                >
+                    Remove
+                </Button>
+            )
+        }
+    ];
+
+    return (
+        <Box>
+            <Stack direction="row" alignItems="center" spacing={1} mb={2}>
+                <Typography variant="h4">{title}</Typography>
+                <Chip label={members.length} size="small" color="primary" />
+                <Box flexGrow={1} />
+                <Button startIcon={<IconRefresh size="1rem" />} onClick={loadMembers} disabled={loading || busy}>
+                    Refresh
+                </Button>
+            </Stack>
+
+            {description && (
+                <Typography variant="body2" color="textSecondary" mb={2}>
+                    {description}
+                </Typography>
+            )}
+
+            <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ md: 'flex-start' }} mb={2}>
+                <TextField
+                    label={`Add ${addLabel}`}
+                    placeholder="user1@example.com, user2@example.com …"
+                    helperText="Add one or many users, separated by commas, spaces, or new lines."
+                    value={input}
+                    onChange={(event) => setInput(event.target.value)}
+                    multiline
+                    minRows={2}
+                    fullWidth
+                />
+                <Button
+                    variant="contained"
+                    startIcon={<IconUserPlus size="1rem" />}
+                    disabled={busy || input.trim().length === 0}
+                    onClick={handleAdd}
+                    sx={{ minWidth: 140, mt: { xs: 0, md: 0.5 } }}
+                >
+                    Add
+                </Button>
+            </Stack>
+
+            {feedback && (
+                <Alert severity={feedback.severity} onClose={() => setFeedback(null)} sx={{ mb: 2 }}>
+                    {feedback.text}
+                </Alert>
+            )}
+
+            <Box sx={{ height: 420, width: '100%' }}>
+                <DataGrid
+                    rows={rows}
+                    columns={columns}
+                    loading={loading}
+                    slots={{ toolbar: GridToolbar }}
+                    slotProps={{ toolbar: { showQuickFilter: true } }}
+                    pageSizeOptions={[10, 25, 50]}
+                    initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+                    localeText={{ noRowsLabel: emptyLabel }}
+                    disableRowSelectionOnClick
+                />
+            </Box>
+        </Box>
+    );
+}
+
+SiteRoleManager.propTypes = {
+    roleType: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    addLabel: PropTypes.string.isRequired,
+    columnHeader: PropTypes.string.isRequired,
+    emptyLabel: PropTypes.string.isRequired
+};
+
+export default SiteRoleManager;

--- a/src/views/siteAdmin/SiteRoleManager.jsx
+++ b/src/views/siteAdmin/SiteRoleManager.jsx
@@ -3,11 +3,13 @@ import PropTypes from 'prop-types';
 
 // mui
 import { Alert, Box, Button, Chip, Stack, TextField, Typography } from '@mui/material';
-import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { DataGrid } from '@mui/x-data-grid';
 import { IconRefresh, IconTrash, IconUserPlus } from '@tabler/icons-react';
 
 // project imports
 import { addUserToSiteRole, fetchSiteRoleUsers, removeUserFromSiteRole } from '../../store/api';
+import useAdminAction from '../../hooks/useAdminAction';
+import { adminDataGridProps, parseUserList } from '../../utils/adminHelpers';
 
 // ===========================|| SITE ROLE MANAGER ||=========================== //
 
@@ -20,9 +22,8 @@ import { addUserToSiteRole, fetchSiteRoleUsers, removeUserFromSiteRole } from '.
 function SiteRoleManager({ roleType, title, description, addLabel, columnHeader, emptyLabel }) {
     const [members, setMembers] = useState([]);
     const [loading, setLoading] = useState(true);
-    const [busy, setBusy] = useState(false);
     const [input, setInput] = useState('');
-    const [feedback, setFeedback] = useState(null);
+    const { busy, setBusy, feedback, setFeedback, runAction } = useAdminAction();
 
     const loadMembers = useCallback(() => {
         setLoading(true);
@@ -30,41 +31,46 @@ function SiteRoleManager({ roleType, title, description, addLabel, columnHeader,
             .then((users) => setMembers(users))
             .catch((error) => setFeedback({ severity: 'error', text: `Could not load ${title.toLowerCase()}. ${error}` }))
             .finally(() => setLoading(false));
-    }, [roleType, title]);
+    }, [roleType, title, setFeedback]);
 
     useEffect(() => {
         loadMembers();
     }, [loadMembers]);
 
-    const runAction = (action, successText) => {
-        setBusy(true);
-        setFeedback(null);
-        return action()
-            .then(() => {
-                setFeedback({ severity: 'success', text: successText });
-                return loadMembers();
-            })
-            .catch((error) => setFeedback({ severity: 'error', text: `${error}` }))
-            .finally(() => setBusy(false));
-    };
-
     const handleAdd = () => {
-        const userIds = input
-            .split(/[\s,;]+/)
-            .map((value) => value.trim())
-            .filter(Boolean);
+        const userIds = parseUserList(input);
         if (userIds.length === 0) {
             setFeedback({ severity: 'warning', text: 'Enter at least one user id to add.' });
             return;
         }
-        // The ingest service adds a single user per call, so chain the requests.
-        runAction(
-            () => userIds.reduce((chain, userId) => chain.then(() => addUserToSiteRole(roleType, userId)), Promise.resolve()),
-            `Added ${userIds.length} ${addLabel}.`
-        ).then(() => setInput(''));
+        // The ingest service adds a single user per call. Run them independently
+        // so one failure doesn't abort the rest, and report per-user outcomes.
+        setBusy(true);
+        setFeedback(null);
+        Promise.allSettled(userIds.map((userId) => addUserToSiteRole(roleType, userId)))
+            .then((results) => {
+                const failed = [];
+                results.forEach((result, index) => {
+                    if (result.status === 'rejected') {
+                        failed.push(`${userIds[index]} (${result.reason})`);
+                    }
+                });
+                const succeeded = userIds.length - failed.length;
+                if (failed.length === 0) {
+                    setFeedback({ severity: 'success', text: `Added ${succeeded} ${addLabel}.` });
+                    setInput('');
+                } else if (succeeded === 0) {
+                    setFeedback({ severity: 'error', text: `Failed to add: ${failed.join('; ')}` });
+                } else {
+                    setFeedback({ severity: 'warning', text: `Added ${succeeded} ${addLabel}. Failed: ${failed.join('; ')}` });
+                }
+                return loadMembers();
+            })
+            .finally(() => setBusy(false));
     };
 
-    const handleRemove = (userId) => runAction(() => removeUserFromSiteRole(roleType, userId), `Removed ${userId}.`);
+    const handleRemove = (userId) =>
+        runAction(() => removeUserFromSiteRole(roleType, userId), `Removed ${userId}.`).then((result) => result.ok && loadMembers());
 
     const rows = members.map((userId) => ({ id: userId, user_id: userId }));
 
@@ -141,12 +147,8 @@ function SiteRoleManager({ roleType, title, description, addLabel, columnHeader,
                     rows={rows}
                     columns={columns}
                     loading={loading}
-                    slots={{ toolbar: GridToolbar }}
-                    slotProps={{ toolbar: { showQuickFilter: true } }}
-                    pageSizeOptions={[10, 25, 50]}
-                    initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+                    {...adminDataGridProps}
                     localeText={{ noRowsLabel: emptyLabel }}
-                    disableRowSelectionOnClick
                 />
             </Box>
         </Box>

--- a/src/views/siteAdmin/siteAdmin.jsx
+++ b/src/views/siteAdmin/siteAdmin.jsx
@@ -1,0 +1,150 @@
+import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+// mui
+import {
+    Alert,
+    Box,
+    CircularProgress,
+    Divider,
+    List,
+    ListItemButton,
+    ListItemIcon,
+    ListItemText,
+    useMediaQuery
+} from '@mui/material';
+import {
+    IconLibraryPlus,
+    IconListDetails,
+    IconShieldPlus,
+    IconUserCheck,
+    IconUserCog,
+    IconUserExclamation,
+    IconUserShield,
+    IconUsersGroup
+} from '@tabler/icons-react';
+
+// project imports
+import MainCard from '../../ui-component/cards/MainCard';
+import DefaultErrorBoundary from '../../ui-component/DefaultErrorBoundary';
+import useSiteAdmin from '../../hooks/useSiteAdmin';
+import PendingUsers from './PendingUsers';
+import PreapprovedUsers from './PreapprovedUsers';
+import DacAuthorizationsTable from './DacAuthorizationsTable';
+import AddDacAuthorization from './AddDacAuthorization';
+import RegisterProgram from './RegisterProgram';
+import ManagePrograms from './ManagePrograms';
+import SiteRoleManager from './SiteRoleManager';
+
+// ===========================|| SITE ADMIN DASHBOARD ||=========================== //
+
+// Section ids used both for the sidebar and for cross-section navigation.
+const SECTIONS = [
+    { id: 'pending', label: 'Pending Users', icon: IconUserExclamation },
+    { id: 'preapproved', label: 'Preapproved Users', icon: IconUserCheck },
+    { id: 'dac', label: 'DAC Authorizations', icon: IconListDetails },
+    { id: 'add-dac', label: 'Add DAC Authorization', icon: IconShieldPlus },
+    { id: 'register', label: 'Register Program', icon: IconLibraryPlus },
+    { id: 'program', label: 'Manage Programs', icon: IconUserCog },
+    { id: 'curators', label: 'Site Curators', icon: IconUsersGroup },
+    { id: 'admins', label: 'Site Admins', icon: IconUserShield }
+];
+
+function SiteAdmin() {
+    const { loading, isSiteAdmin } = useSiteAdmin();
+    const [searchParams] = useSearchParams();
+    // Allow deep-linking to a section, e.g. /siteAdmin?section=pending
+    const requestedSection = SECTIONS.find((section) => section.id === searchParams.get('section'));
+    const [activeSection, setActiveSection] = useState(requestedSection ? requestedSection.id : SECTIONS[0].id);
+    const isSmall = useMediaQuery((theme) => theme.breakpoints.down('md'));
+
+    if (loading) {
+        return (
+            <Box display="flex" justifyContent="center" alignItems="center" sx={{ minHeight: 300 }}>
+                <CircularProgress />
+            </Box>
+        );
+    }
+
+    if (!isSiteAdmin) {
+        return (
+            <MainCard title="Site Admin Dashboard">
+                <Alert severity="error">You must be a site administrator to view this page.</Alert>
+            </MainCard>
+        );
+    }
+
+    const renderSection = () => {
+        switch (activeSection) {
+            case 'pending':
+                return <PendingUsers />;
+            case 'preapproved':
+                return <PreapprovedUsers />;
+            case 'dac':
+                return <DacAuthorizationsTable onNavigate={setActiveSection} />;
+            case 'add-dac':
+                return <AddDacAuthorization onSuccess={() => setActiveSection('dac')} />;
+            case 'register':
+                return <RegisterProgram onNavigate={setActiveSection} />;
+            case 'program':
+                return <ManagePrograms onNavigate={setActiveSection} />;
+            case 'curators':
+                return (
+                    <SiteRoleManager
+                        roleType="curator"
+                        title="Site Curators"
+                        description="Site curators can curate and manage data for any program on this node."
+                        addLabel="site curator(s)"
+                        columnHeader="Curator"
+                        emptyLabel="No site curators"
+                    />
+                );
+            case 'admins':
+                return (
+                    <SiteRoleManager
+                        roleType="admin"
+                        title="Site Admins"
+                        description="Site admins have full access to this node, including approving users and managing all programs. The last remaining site admin cannot be removed."
+                        addLabel="site admin(s)"
+                        columnHeader="Admin"
+                        emptyLabel="No site admins"
+                    />
+                );
+            default:
+                return null;
+        }
+    };
+
+    return (
+        <MainCard title="Site Admin Dashboard">
+            <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2 }}>
+                <Box sx={{ width: { xs: '100%', md: 260 }, flexShrink: 0 }}>
+                    <List component="nav" sx={{ p: 0 }}>
+                        {SECTIONS.map((section) => {
+                            const SectionIcon = section.icon;
+                            return (
+                                <ListItemButton
+                                    key={section.id}
+                                    selected={activeSection === section.id}
+                                    onClick={() => setActiveSection(section.id)}
+                                    sx={{ borderRadius: 2, mb: 0.5 }}
+                                >
+                                    <ListItemIcon sx={{ minWidth: 36 }}>
+                                        <SectionIcon size="1.3rem" stroke={1.5} />
+                                    </ListItemIcon>
+                                    <ListItemText primary={section.label} />
+                                </ListItemButton>
+                            );
+                        })}
+                    </List>
+                </Box>
+                {isSmall ? <Divider /> : <Divider orientation="vertical" flexItem />}
+                <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                    <DefaultErrorBoundary>{renderSection()}</DefaultErrorBoundary>
+                </Box>
+            </Box>
+        </MainCard>
+    );
+}
+
+export default SiteAdmin;

--- a/src/views/siteAdmin/siteAdmin.jsx
+++ b/src/views/siteAdmin/siteAdmin.jsx
@@ -3,17 +3,6 @@ import { useSearchParams } from 'react-router-dom';
 
 // mui
 import {
-    Alert,
-    Box,
-    CircularProgress,
-    Divider,
-    List,
-    ListItemButton,
-    ListItemIcon,
-    ListItemText,
-    useMediaQuery
-} from '@mui/material';
-import {
     IconLibraryPlus,
     IconListDetails,
     IconNetwork,
@@ -27,9 +16,8 @@ import {
 } from '@tabler/icons-react';
 
 // project imports
-import MainCard from '../../ui-component/cards/MainCard';
-import DefaultErrorBoundary from '../../ui-component/DefaultErrorBoundary';
-import useSiteAdmin from '../../hooks/useSiteAdmin';
+import DashboardShell from '../../ui-component/DashboardShell';
+import useSiteRoles from '../../hooks/useSiteRoles';
 import PendingUsers from './PendingUsers';
 import PreapprovedUsers from './PreapprovedUsers';
 import DacAuthorizationsTable from './DacAuthorizationsTable';
@@ -57,28 +45,11 @@ const SECTIONS = [
 ];
 
 function SiteAdmin() {
-    const { loading, isSiteAdmin } = useSiteAdmin();
+    const { loading, error, isSiteAdmin } = useSiteRoles();
     const [searchParams] = useSearchParams();
     // Allow deep-linking to a section, e.g. /siteAdmin?section=pending
     const requestedSection = SECTIONS.find((section) => section.id === searchParams.get('section'));
     const [activeSection, setActiveSection] = useState(requestedSection ? requestedSection.id : SECTIONS[0].id);
-    const isSmall = useMediaQuery((theme) => theme.breakpoints.down('md'));
-
-    if (loading) {
-        return (
-            <Box display="flex" justifyContent="center" alignItems="center" sx={{ minHeight: 300 }}>
-                <CircularProgress />
-            </Box>
-        );
-    }
-
-    if (!isSiteAdmin) {
-        return (
-            <MainCard title="Site Admin Dashboard">
-                <Alert severity="error">You must be a site administrator to view this page.</Alert>
-            </MainCard>
-        );
-    }
 
     const renderSection = () => {
         switch (activeSection) {
@@ -125,35 +96,23 @@ function SiteAdmin() {
         }
     };
 
+    // Distinguish a failed authorization check from a genuine lack of access.
+    const notice = error
+        ? { severity: 'error', message: `Could not verify your access. ${error}` }
+        : !isSiteAdmin
+        ? { severity: 'error', message: 'You must be a site administrator to view this page.' }
+        : null;
+
     return (
-        <MainCard title="Site Admin Dashboard">
-            <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2 }}>
-                <Box sx={{ width: { xs: '100%', md: 260 }, flexShrink: 0 }}>
-                    <List component="nav" sx={{ p: 0 }}>
-                        {SECTIONS.map((section) => {
-                            const SectionIcon = section.icon;
-                            return (
-                                <ListItemButton
-                                    key={section.id}
-                                    selected={activeSection === section.id}
-                                    onClick={() => setActiveSection(section.id)}
-                                    sx={{ borderRadius: 2, mb: 0.5 }}
-                                >
-                                    <ListItemIcon sx={{ minWidth: 36 }}>
-                                        <SectionIcon size="1.3rem" stroke={1.5} />
-                                    </ListItemIcon>
-                                    <ListItemText primary={section.label} />
-                                </ListItemButton>
-                            );
-                        })}
-                    </List>
-                </Box>
-                {isSmall ? <Divider /> : <Divider orientation="vertical" flexItem />}
-                <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-                    <DefaultErrorBoundary>{renderSection()}</DefaultErrorBoundary>
-                </Box>
-            </Box>
-        </MainCard>
+        <DashboardShell
+            title="Site Admin Dashboard"
+            loading={loading}
+            notice={notice}
+            sections={SECTIONS}
+            activeSection={activeSection}
+            onSelectSection={setActiveSection}
+            renderSection={renderSection}
+        />
     );
 }
 

--- a/src/views/siteAdmin/siteAdmin.jsx
+++ b/src/views/siteAdmin/siteAdmin.jsx
@@ -16,7 +16,9 @@ import {
 import {
     IconLibraryPlus,
     IconListDetails,
+    IconNetwork,
     IconShieldPlus,
+    IconTopologyStarRing3,
     IconUserCheck,
     IconUserCog,
     IconUserExclamation,
@@ -35,6 +37,8 @@ import AddDacAuthorization from './AddDacAuthorization';
 import RegisterProgram from './RegisterProgram';
 import ManagePrograms from './ManagePrograms';
 import SiteRoleManager from './SiteRoleManager';
+import FederatedNodes from './FederatedNodes';
+import AddFederatedServer from './AddFederatedServer';
 
 // ===========================|| SITE ADMIN DASHBOARD ||=========================== //
 
@@ -47,7 +51,9 @@ const SECTIONS = [
     { id: 'register', label: 'Register Program', icon: IconLibraryPlus },
     { id: 'program', label: 'Manage Programs', icon: IconUserCog },
     { id: 'curators', label: 'Site Curators', icon: IconUsersGroup },
-    { id: 'admins', label: 'Site Admins', icon: IconUserShield }
+    { id: 'admins', label: 'Site Admins', icon: IconUserShield },
+    { id: 'nodes', label: 'Federated Nodes', icon: IconTopologyStarRing3 },
+    { id: 'add-node', label: 'Add Federated Node', icon: IconNetwork }
 ];
 
 function SiteAdmin() {
@@ -110,6 +116,10 @@ function SiteAdmin() {
                         emptyLabel="No site admins"
                     />
                 );
+            case 'nodes':
+                return <FederatedNodes onNavigate={setActiveSection} />;
+            case 'add-node':
+                return <AddFederatedServer onSuccess={() => setActiveSection('nodes')} />;
             default:
                 return null;
         }

--- a/src/views/siteCurator/siteCurator.jsx
+++ b/src/views/siteCurator/siteCurator.jsx
@@ -2,22 +2,10 @@ import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 // mui
-import {
-    Alert,
-    Box,
-    CircularProgress,
-    Divider,
-    List,
-    ListItemButton,
-    ListItemIcon,
-    ListItemText,
-    useMediaQuery
-} from '@mui/material';
 import { IconLibraryPlus, IconListDetails, IconShieldPlus, IconUserCog } from '@tabler/icons-react';
 
 // project imports
-import MainCard from '../../ui-component/cards/MainCard';
-import DefaultErrorBoundary from '../../ui-component/DefaultErrorBoundary';
+import DashboardShell from '../../ui-component/DashboardShell';
 import useSiteRoles from '../../hooks/useSiteRoles';
 import DacAuthorizationsTable from '../siteAdmin/DacAuthorizationsTable';
 import AddDacAuthorization from '../siteAdmin/AddDacAuthorization';
@@ -37,27 +25,10 @@ const SECTIONS = [
 ];
 
 function SiteCurator() {
-    const { loading, isSiteCurator } = useSiteRoles();
+    const { loading, error, isSiteCurator } = useSiteRoles();
     const [searchParams] = useSearchParams();
     const requestedSection = SECTIONS.find((section) => section.id === searchParams.get('section'));
     const [activeSection, setActiveSection] = useState(requestedSection ? requestedSection.id : SECTIONS[0].id);
-    const isSmall = useMediaQuery((theme) => theme.breakpoints.down('md'));
-
-    if (loading) {
-        return (
-            <Box display="flex" justifyContent="center" alignItems="center" sx={{ minHeight: 300 }}>
-                <CircularProgress />
-            </Box>
-        );
-    }
-
-    if (!isSiteCurator) {
-        return (
-            <MainCard title="Site Curator Dashboard">
-                <Alert severity="error">You must be a site curator to view this page.</Alert>
-            </MainCard>
-        );
-    }
 
     const renderSection = () => {
         switch (activeSection) {
@@ -74,35 +45,22 @@ function SiteCurator() {
         }
     };
 
+    const notice = error
+        ? { severity: 'error', message: `Could not verify your access. ${error}` }
+        : !isSiteCurator
+        ? { severity: 'error', message: 'You must be a site curator to view this page.' }
+        : null;
+
     return (
-        <MainCard title="Site Curator Dashboard">
-            <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2 }}>
-                <Box sx={{ width: { xs: '100%', md: 260 }, flexShrink: 0 }}>
-                    <List component="nav" sx={{ p: 0 }}>
-                        {SECTIONS.map((section) => {
-                            const SectionIcon = section.icon;
-                            return (
-                                <ListItemButton
-                                    key={section.id}
-                                    selected={activeSection === section.id}
-                                    onClick={() => setActiveSection(section.id)}
-                                    sx={{ borderRadius: 2, mb: 0.5 }}
-                                >
-                                    <ListItemIcon sx={{ minWidth: 36 }}>
-                                        <SectionIcon size="1.3rem" stroke={1.5} />
-                                    </ListItemIcon>
-                                    <ListItemText primary={section.label} />
-                                </ListItemButton>
-                            );
-                        })}
-                    </List>
-                </Box>
-                {isSmall ? <Divider /> : <Divider orientation="vertical" flexItem />}
-                <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-                    <DefaultErrorBoundary>{renderSection()}</DefaultErrorBoundary>
-                </Box>
-            </Box>
-        </MainCard>
+        <DashboardShell
+            title="Site Curator Dashboard"
+            loading={loading}
+            notice={notice}
+            sections={SECTIONS}
+            activeSection={activeSection}
+            onSelectSection={setActiveSection}
+            renderSection={renderSection}
+        />
     );
 }
 

--- a/src/views/siteCurator/siteCurator.jsx
+++ b/src/views/siteCurator/siteCurator.jsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+// mui
+import {
+    Alert,
+    Box,
+    CircularProgress,
+    Divider,
+    List,
+    ListItemButton,
+    ListItemIcon,
+    ListItemText,
+    useMediaQuery
+} from '@mui/material';
+import { IconLibraryPlus, IconListDetails, IconShieldPlus, IconUserCog } from '@tabler/icons-react';
+
+// project imports
+import MainCard from '../../ui-component/cards/MainCard';
+import DefaultErrorBoundary from '../../ui-component/DefaultErrorBoundary';
+import useSiteRoles from '../../hooks/useSiteRoles';
+import DacAuthorizationsTable from '../siteAdmin/DacAuthorizationsTable';
+import AddDacAuthorization from '../siteAdmin/AddDacAuthorization';
+import RegisterProgram from '../siteAdmin/RegisterProgram';
+import ManagePrograms from '../siteAdmin/ManagePrograms';
+
+// ===========================|| SITE CURATOR DASHBOARD ||=========================== //
+
+// A site curator can curate any program: view/add DAC authorizations and
+// register programs. User approval (pending/preapproved) is site-admin only and
+// is intentionally excluded.
+const SECTIONS = [
+    { id: 'dac', label: 'DAC Authorizations', icon: IconListDetails },
+    { id: 'add-dac', label: 'Add DAC Authorization', icon: IconShieldPlus },
+    { id: 'register', label: 'Register Program', icon: IconLibraryPlus },
+    { id: 'program', label: 'Manage Programs', icon: IconUserCog }
+];
+
+function SiteCurator() {
+    const { loading, isSiteCurator } = useSiteRoles();
+    const [searchParams] = useSearchParams();
+    const requestedSection = SECTIONS.find((section) => section.id === searchParams.get('section'));
+    const [activeSection, setActiveSection] = useState(requestedSection ? requestedSection.id : SECTIONS[0].id);
+    const isSmall = useMediaQuery((theme) => theme.breakpoints.down('md'));
+
+    if (loading) {
+        return (
+            <Box display="flex" justifyContent="center" alignItems="center" sx={{ minHeight: 300 }}>
+                <CircularProgress />
+            </Box>
+        );
+    }
+
+    if (!isSiteCurator) {
+        return (
+            <MainCard title="Site Curator Dashboard">
+                <Alert severity="error">You must be a site curator to view this page.</Alert>
+            </MainCard>
+        );
+    }
+
+    const renderSection = () => {
+        switch (activeSection) {
+            case 'dac':
+                return <DacAuthorizationsTable onNavigate={setActiveSection} />;
+            case 'add-dac':
+                return <AddDacAuthorization onSuccess={() => setActiveSection('dac')} />;
+            case 'register':
+                return <RegisterProgram onNavigate={setActiveSection} />;
+            case 'program':
+                return <ManagePrograms onNavigate={setActiveSection} />;
+            default:
+                return null;
+        }
+    };
+
+    return (
+        <MainCard title="Site Curator Dashboard">
+            <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2 }}>
+                <Box sx={{ width: { xs: '100%', md: 260 }, flexShrink: 0 }}>
+                    <List component="nav" sx={{ p: 0 }}>
+                        {SECTIONS.map((section) => {
+                            const SectionIcon = section.icon;
+                            return (
+                                <ListItemButton
+                                    key={section.id}
+                                    selected={activeSection === section.id}
+                                    onClick={() => setActiveSection(section.id)}
+                                    sx={{ borderRadius: 2, mb: 0.5 }}
+                                >
+                                    <ListItemIcon sx={{ minWidth: 36 }}>
+                                        <SectionIcon size="1.3rem" stroke={1.5} />
+                                    </ListItemIcon>
+                                    <ListItemText primary={section.label} />
+                                </ListItemButton>
+                            );
+                        })}
+                    </List>
+                </Box>
+                {isSmall ? <Divider /> : <Divider orientation="vertical" flexItem />}
+                <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                    <DefaultErrorBoundary>{renderSection()}</DefaultErrorBoundary>
+                </Box>
+            </Box>
+        </MainCard>
+    );
+}
+
+export default SiteCurator;

--- a/src/views/userDashboard/userDashboard.jsx
+++ b/src/views/userDashboard/userDashboard.jsx
@@ -1,0 +1,269 @@
+import { useEffect, useState } from 'react';
+
+// mui
+import {
+    Alert,
+    Box,
+    Chip,
+    CircularProgress,
+    Divider,
+    List,
+    ListItemButton,
+    ListItemIcon,
+    ListItemText,
+    Stack,
+    Typography,
+    useMediaQuery
+} from '@mui/material';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { IconId, IconShieldCheck, IconUserCog, IconUsers } from '@tabler/icons-react';
+
+// project imports
+import MainCard from '../../ui-component/cards/MainCard';
+import DefaultErrorBoundary from '../../ui-component/DefaultErrorBoundary';
+import ManagePrograms from '../siteAdmin/ManagePrograms';
+import { fetchCurrentUserAuthorization } from '../../store/api';
+
+// Friendly labels for the global site roles.
+const SITE_ROLE_LABELS = { admin: 'Site Admin', curator: 'Site Curator' };
+
+// Classify a DAC authorization by its date window relative to today.
+function dacStatus(dac) {
+    const today = new Date().toISOString().slice(0, 10);
+    if (dac.start_date && today < dac.start_date) {
+        return 'Upcoming';
+    }
+    if (dac.end_date && today > dac.end_date) {
+        return 'Expired';
+    }
+    return 'Active';
+}
+
+const STATUS_COLORS = { Active: 'success', Upcoming: 'info', Expired: 'default' };
+
+// ===========================|| USER DASHBOARD ||=========================== //
+
+/*
+ * A generic, read-only view of the current user's own authorizations: the
+ * programs they curate / are a team member of, and the DAC authorizations they
+ * hold. Program curators additionally get a "Manage Programs" section to add
+ * team members / curators to the programs they curate. Sourced from the ingest
+ * service's /user/me endpoint.
+ */
+function UserDashboard() {
+    const [state, setState] = useState({ loading: true, error: null, data: null });
+    const [activeSection, setActiveSection] = useState('access');
+    const isSmall = useMediaQuery((theme) => theme.breakpoints.down('md'));
+
+    useEffect(() => {
+        let active = true;
+        fetchCurrentUserAuthorization()
+            .then((data) => active && setState({ loading: false, error: null, data }))
+            .catch((error) => active && setState({ loading: false, error: `${error}`, data: null }));
+        return () => {
+            active = false;
+        };
+    }, []);
+
+    if (state.loading) {
+        return (
+            <Box display="flex" justifyContent="center" alignItems="center" sx={{ minHeight: 300 }}>
+                <CircularProgress />
+            </Box>
+        );
+    }
+
+    if (state.error) {
+        return (
+            <MainCard title="User Dashboard">
+                <Alert severity="error">Could not load your authorizations. {state.error}</Alert>
+            </MainCard>
+        );
+    }
+
+    const data = state.data || {};
+    const userName = data.userinfo?.user_name || 'Unknown user';
+    const siteRoles = data.site_roles || [];
+
+    // This dashboard is for standard users; site admins / curators have their own.
+    if (siteRoles.includes('admin') || siteRoles.includes('curator')) {
+        return (
+            <MainCard title="User Dashboard">
+                <Alert severity="info">
+                    This dashboard is for standard users. Use your Site Admin or Site Curator Dashboard to view and manage authorizations.
+                </Alert>
+            </MainCard>
+        );
+    }
+
+    const programAuth = data.program_authorizations || {};
+    const curatorPrograms = programAuth.program_curator || [];
+    const teamPrograms = programAuth.team_member || [];
+    // dac_authorizations is an object keyed by program id (empty array when none).
+    const dacObject = Array.isArray(programAuth.dac_authorizations) ? {} : programAuth.dac_authorizations || {};
+    const dacRows = Object.entries(dacObject).map(([programId, dac], index) => ({
+        id: index,
+        program_id: dac.program_id || programId,
+        dac_id: dac.dac_id || '',
+        start_date: dac.start_date || '',
+        end_date: dac.end_date || '',
+        status: dacStatus(dac)
+    }));
+
+    // Combine program-curator and team-member programs into one access table,
+    // aggregating both levels onto a single row per program.
+    const accessMap = {};
+    curatorPrograms.forEach((program) => {
+        (accessMap[program] = accessMap[program] || new Set()).add('Program Curator');
+    });
+    teamPrograms.forEach((program) => {
+        (accessMap[program] = accessMap[program] || new Set()).add('Team Member');
+    });
+    const accessRows = Object.entries(accessMap).map(([program, levels], index) => {
+        const levelList = [...levels];
+        return { id: index, program_id: program, levels: levelList, access_level: levelList.join(', ') };
+    });
+
+    const accessColumns = [
+        { field: 'program_id', headerName: 'Program', flex: 1, minWidth: 200 },
+        {
+            field: 'access_level',
+            headerName: 'Access Level',
+            flex: 1,
+            minWidth: 240,
+            renderCell: (params) => (
+                <Stack direction="row" spacing={1}>
+                    {params.row.levels.map((level) => (
+                        <Chip key={level} label={level} size="small" color={level === 'Program Curator' ? 'primary' : 'default'} />
+                    ))}
+                </Stack>
+            )
+        }
+    ];
+
+    const dacColumns = [
+        { field: 'program_id', headerName: 'Program', flex: 1, minWidth: 160 },
+        { field: 'dac_id', headerName: 'DAC ID', flex: 1, minWidth: 130 },
+        { field: 'start_date', headerName: 'Start Date', flex: 1, minWidth: 120 },
+        { field: 'end_date', headerName: 'End Date', flex: 1, minWidth: 120 },
+        {
+            field: 'status',
+            headerName: 'Status',
+            width: 120,
+            renderCell: (params) => <Chip label={params.value} size="small" color={STATUS_COLORS[params.value] || 'default'} />
+        }
+    ];
+
+    const isProgramCurator = curatorPrograms.length > 0;
+    const sections = [{ id: 'access', label: 'My Authorizations', icon: IconId }];
+    if (isProgramCurator) {
+        sections.push({ id: 'manage', label: 'Manage Programs', icon: IconUserCog });
+    }
+    // Guard against a stale selection if the user isn't a curator.
+    const currentSection = sections.some((section) => section.id === activeSection) ? activeSection : 'access';
+
+    const renderSection = () => {
+        if (currentSection === 'manage') {
+            return (
+                <>
+                    <Typography variant="h4" mb={1}>
+                        Manage Your Programs
+                    </Typography>
+                    <Typography variant="body2" color="textSecondary" mb={2}>
+                        As a program curator you can add team members and program curators to the programs you curate.
+                    </Typography>
+                    <ManagePrograms allowedPrograms={curatorPrograms} showHeading={false} />
+                </>
+            );
+        }
+        return (
+            <>
+                <Stack direction="row" alignItems="center" spacing={1} mb={1}>
+                    <IconUsers size="1.2rem" stroke={1.5} />
+                    <Typography variant="h5">Program Access</Typography>
+                    <Chip label={accessRows.length} size="small" />
+                </Stack>
+                <Typography variant="body2" color="textSecondary" mb={2}>
+                    Programs you can access as a program curator or team member.
+                </Typography>
+                <Box sx={{ height: 340, width: '100%' }}>
+                    <DataGrid
+                        rows={accessRows}
+                        columns={accessColumns}
+                        slots={{ toolbar: GridToolbar }}
+                        slotProps={{ toolbar: { showQuickFilter: true } }}
+                        pageSizeOptions={[10, 25, 50]}
+                        initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+                        localeText={{ noRowsLabel: 'You are not a curator or team member of any program' }}
+                        disableRowSelectionOnClick
+                    />
+                </Box>
+
+                <Divider sx={{ my: 3 }} />
+
+                <Stack direction="row" alignItems="center" spacing={1} mb={1}>
+                    <IconShieldCheck size="1.2rem" stroke={1.5} />
+                    <Typography variant="h5">DAC Authorizations</Typography>
+                    <Chip label={dacRows.length} size="small" />
+                </Stack>
+                <Typography variant="body2" color="textSecondary" mb={2}>
+                    Time-bounded program access granted to you by a Data Access Committee.
+                </Typography>
+                <Box sx={{ height: 400, width: '100%' }}>
+                    <DataGrid
+                        rows={dacRows}
+                        columns={dacColumns}
+                        slots={{ toolbar: GridToolbar }}
+                        slotProps={{ toolbar: { showQuickFilter: true } }}
+                        pageSizeOptions={[10, 25, 50]}
+                        initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+                        localeText={{ noRowsLabel: 'You have no DAC authorizations' }}
+                        disableRowSelectionOnClick
+                    />
+                </Box>
+            </>
+        );
+    };
+
+    return (
+        <MainCard title="User Dashboard">
+            <DefaultErrorBoundary>
+                <Stack direction="row" alignItems="center" spacing={1} mb={2} flexWrap="wrap" useFlexGap>
+                    <Typography variant="h4">{userName}</Typography>
+                    {siteRoles
+                        .filter((role) => SITE_ROLE_LABELS[role])
+                        .map((role) => (
+                            <Chip key={role} label={SITE_ROLE_LABELS[role]} color="primary" size="small" />
+                        ))}
+                </Stack>
+
+                <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2 }}>
+                    <Box sx={{ width: { xs: '100%', md: 260 }, flexShrink: 0 }}>
+                        <List component="nav" sx={{ p: 0 }}>
+                            {sections.map((section) => {
+                                const SectionIcon = section.icon;
+                                return (
+                                    <ListItemButton
+                                        key={section.id}
+                                        selected={currentSection === section.id}
+                                        onClick={() => setActiveSection(section.id)}
+                                        sx={{ borderRadius: 2, mb: 0.5 }}
+                                    >
+                                        <ListItemIcon sx={{ minWidth: 36 }}>
+                                            <SectionIcon size="1.3rem" stroke={1.5} />
+                                        </ListItemIcon>
+                                        <ListItemText primary={section.label} />
+                                    </ListItemButton>
+                                );
+                            })}
+                        </List>
+                    </Box>
+                    {isSmall ? <Divider /> : <Divider orientation="vertical" flexItem />}
+                    <Box sx={{ flexGrow: 1, minWidth: 0 }}>{renderSection()}</Box>
+                </Box>
+            </DefaultErrorBoundary>
+        </MainCard>
+    );
+}
+
+export default UserDashboard;

--- a/src/views/userDashboard/userDashboard.jsx
+++ b/src/views/userDashboard/userDashboard.jsx
@@ -1,31 +1,16 @@
 import { useEffect, useState } from 'react';
 
 // mui
-import {
-    Alert,
-    Box,
-    Chip,
-    CircularProgress,
-    Divider,
-    List,
-    ListItemButton,
-    ListItemIcon,
-    ListItemText,
-    Stack,
-    Typography,
-    useMediaQuery
-} from '@mui/material';
-import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { Box, Chip, Divider, Stack, Typography } from '@mui/material';
+import { DataGrid } from '@mui/x-data-grid';
 import { IconId, IconShieldCheck, IconUserCog, IconUsers } from '@tabler/icons-react';
 
 // project imports
-import MainCard from '../../ui-component/cards/MainCard';
-import DefaultErrorBoundary from '../../ui-component/DefaultErrorBoundary';
+import DashboardShell from '../../ui-component/DashboardShell';
 import ManagePrograms from '../siteAdmin/ManagePrograms';
 import { fetchCurrentUserAuthorization } from '../../store/api';
-
-// Friendly labels for the global site roles.
-const SITE_ROLE_LABELS = { admin: 'Site Admin', curator: 'Site Curator' };
+import { SITE_ROLES, SITE_ROLE_LABELS } from '../../store/constant';
+import { adminDataGridProps } from '../../utils/adminHelpers';
 
 // Classify a DAC authorization by its date window relative to today.
 function dacStatus(dac) {
@@ -48,12 +33,11 @@ const STATUS_COLORS = { Active: 'success', Upcoming: 'info', Expired: 'default' 
  * programs they curate / are a team member of, and the DAC authorizations they
  * hold. Program curators additionally get a "Manage Programs" section to add
  * team members / curators to the programs they curate. Sourced from the ingest
- * service's /user/me endpoint.
+ * service's /user/me endpoint (shared/cached via fetchCurrentUserAuthorization).
  */
 function UserDashboard() {
     const [state, setState] = useState({ loading: true, error: null, data: null });
     const [activeSection, setActiveSection] = useState('access');
-    const isSmall = useMediaQuery((theme) => theme.breakpoints.down('md'));
 
     useEffect(() => {
         let active = true;
@@ -65,36 +49,10 @@ function UserDashboard() {
         };
     }, []);
 
-    if (state.loading) {
-        return (
-            <Box display="flex" justifyContent="center" alignItems="center" sx={{ minHeight: 300 }}>
-                <CircularProgress />
-            </Box>
-        );
-    }
-
-    if (state.error) {
-        return (
-            <MainCard title="User Dashboard">
-                <Alert severity="error">Could not load your authorizations. {state.error}</Alert>
-            </MainCard>
-        );
-    }
-
     const data = state.data || {};
     const userName = data.userinfo?.user_name || 'Unknown user';
     const siteRoles = data.site_roles || [];
-
-    // This dashboard is for standard users; site admins / curators have their own.
-    if (siteRoles.includes('admin') || siteRoles.includes('curator')) {
-        return (
-            <MainCard title="User Dashboard">
-                <Alert severity="info">
-                    This dashboard is for standard users. Use your Site Admin or Site Curator Dashboard to view and manage authorizations.
-                </Alert>
-            </MainCard>
-        );
-    }
+    const isSiteStaff = siteRoles.includes(SITE_ROLES.ADMIN) || siteRoles.includes(SITE_ROLES.CURATOR);
 
     const programAuth = data.program_authorizations || {};
     const curatorPrograms = programAuth.program_curator || [];
@@ -190,12 +148,8 @@ function UserDashboard() {
                     <DataGrid
                         rows={accessRows}
                         columns={accessColumns}
-                        slots={{ toolbar: GridToolbar }}
-                        slotProps={{ toolbar: { showQuickFilter: true } }}
-                        pageSizeOptions={[10, 25, 50]}
-                        initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+                        {...adminDataGridProps}
                         localeText={{ noRowsLabel: 'You are not a curator or team member of any program' }}
-                        disableRowSelectionOnClick
                     />
                 </Box>
 
@@ -213,56 +167,46 @@ function UserDashboard() {
                     <DataGrid
                         rows={dacRows}
                         columns={dacColumns}
-                        slots={{ toolbar: GridToolbar }}
-                        slotProps={{ toolbar: { showQuickFilter: true } }}
-                        pageSizeOptions={[10, 25, 50]}
-                        initialState={{ pagination: { paginationModel: { pageSize: 10 } } }}
+                        {...adminDataGridProps}
                         localeText={{ noRowsLabel: 'You have no DAC authorizations' }}
-                        disableRowSelectionOnClick
                     />
                 </Box>
             </>
         );
     };
 
-    return (
-        <MainCard title="User Dashboard">
-            <DefaultErrorBoundary>
-                <Stack direction="row" alignItems="center" spacing={1} mb={2} flexWrap="wrap" useFlexGap>
-                    <Typography variant="h4">{userName}</Typography>
-                    {siteRoles
-                        .filter((role) => SITE_ROLE_LABELS[role])
-                        .map((role) => (
-                            <Chip key={role} label={SITE_ROLE_LABELS[role]} color="primary" size="small" />
-                        ))}
-                </Stack>
+    // This dashboard is for standard users; site admins / curators have their own.
+    const notice = state.error
+        ? { severity: 'error', message: `Could not load your authorizations. ${state.error}` }
+        : isSiteStaff
+        ? {
+              severity: 'info',
+              message: 'This dashboard is for standard users. Use your Site Admin or Site Curator Dashboard to view and manage authorizations.'
+          }
+        : null;
 
-                <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2 }}>
-                    <Box sx={{ width: { xs: '100%', md: 260 }, flexShrink: 0 }}>
-                        <List component="nav" sx={{ p: 0 }}>
-                            {sections.map((section) => {
-                                const SectionIcon = section.icon;
-                                return (
-                                    <ListItemButton
-                                        key={section.id}
-                                        selected={currentSection === section.id}
-                                        onClick={() => setActiveSection(section.id)}
-                                        sx={{ borderRadius: 2, mb: 0.5 }}
-                                    >
-                                        <ListItemIcon sx={{ minWidth: 36 }}>
-                                            <SectionIcon size="1.3rem" stroke={1.5} />
-                                        </ListItemIcon>
-                                        <ListItemText primary={section.label} />
-                                    </ListItemButton>
-                                );
-                            })}
-                        </List>
-                    </Box>
-                    {isSmall ? <Divider /> : <Divider orientation="vertical" flexItem />}
-                    <Box sx={{ flexGrow: 1, minWidth: 0 }}>{renderSection()}</Box>
-                </Box>
-            </DefaultErrorBoundary>
-        </MainCard>
+    const header = (
+        <Stack direction="row" alignItems="center" spacing={1} mb={2} flexWrap="wrap" useFlexGap>
+            <Typography variant="h4">{userName}</Typography>
+            {siteRoles
+                .filter((role) => SITE_ROLE_LABELS[role])
+                .map((role) => (
+                    <Chip key={role} label={SITE_ROLE_LABELS[role]} color="primary" size="small" />
+                ))}
+        </Stack>
+    );
+
+    return (
+        <DashboardShell
+            title="User Dashboard"
+            loading={state.loading}
+            notice={notice}
+            header={header}
+            sections={sections}
+            activeSection={currentSection}
+            onSelectSection={setActiveSection}
+            renderSection={renderSection}
+        />
     );
 }
 


### PR DESCRIPTION
## Summary

Adds three role-based dashboards to the data portal, reachable from the profile (user) menu in the header and gated by the user's site role (fetched from the ingest `/user/me` endpoint).

### Site Admin Dashboard (site admins only)
Left-sidebar layout with sections for:
- **Pending Users** — approve/reject individually, approve selected, or approve all
- **Preapproved Users** — view, add one/many, remove
- **DAC Authorizations** — filterable table, collapsed by program/DAC/date range with users listed together
- **Add DAC Authorization** — multiple users × multiple programs (multi-select), optional `dac_id`
- **Register Program** — rejects duplicates and redirects to Manage Programs
- **Manage Programs** — lookup + add/replace curators & team members, preserving existing DAC authorizations
- **Site Curators** / **Site Admins** — view/add/remove (last-admin protected)
- **Federated Nodes** — table of registered peer nodes (name, province, server id, URL) annotated with a live **Connected / Unreachable** status; select and unregister nodes behind a confirmation dialog
- **Add Federated Node** — register a peer either via a form or by pasting a `{ server, authentication }` JSON blob that populates the form for confirmation before submitting; province is a dropdown that auto-fills the `province-code`

### Site Curator Dashboard (site curators only)
DAC authorization view/add and program registration/management.

### User Dashboard (standard users only)
- **My Authorizations** — a Program Access table (Program / Access Level) plus a DAC authorizations table with Active / Upcoming / Expired status
- **Manage Programs** — appears only for program curators, restricted to the programs they curate

Also adds a one-time header notification for site admins when users are awaiting approval, shared `useSiteRoles`/`useSiteAdmin` hooks, and ingest admin API helpers in `store/api.jsx`.

## Notes / follow-ups
- Node status has no dedicated federation endpoint, so it is derived from an **unsafe** `/fanout` probe — this bypasses the heartbeat's live-server filter so unreachable nodes are still contacted (and reported) rather than silently skipped. Status is merged onto the registered-server list by location name.

## Testing
- Lint (`eslint`) and production build pass.
- Each dashboard/section exercised end-to-end against a local mock backend (approve/reject, add/remove, register + duplicate rejection, manage add/replace, multi-user/multi-program DAC add, role management, role-based visibility/guards, and the Federated Nodes list/status/add/unregister flows). Note: local testing of the Federated Nodes sections requires the `candig-mock-server` to implement the `/v1/servers` routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
