### PR TITLE
Improve node/program dropdown behaviour on clinical & genomic search

### DIFF
--- a/src/views/clinicalGenomic/search/SearchHandler.jsx
+++ b/src/views/clinicalGenomic/search/SearchHandler.jsx
@@ -150,7 +150,16 @@ function SearchHandler({ setLoading }) {
                         )
                         .flat(1);
                     // console.log('Genomic Data:', genomicData);
-                    writer((old) => ({ ...old, clinical: clinicalData, genomic: genomicData, loading: false }));
+                    // Record which nodes the user excluded from this search so the
+                    // results table can distinguish a user-excluded node from one that
+                    // is genuinely offline (both otherwise return no counts).
+                    writer((old) => ({
+                        ...old,
+                        clinical: clinicalData,
+                        genomic: genomicData,
+                        excludedNodes: reader.filter?.node || [],
+                        loading: false
+                    }));
                 })
                 .catch((error) => {
                     // Ignore abort errors

--- a/src/views/clinicalGenomic/widgets/patientCountSingle.jsx
+++ b/src/views/clinicalGenomic/widgets/patientCountSingle.jsx
@@ -7,6 +7,7 @@ import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
 import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
+import FilterAltOffOutlinedIcon from '@mui/icons-material/FilterAltOffOutlined';
 import PropTypes from 'prop-types';
 import { SITE } from '../../../store/constant';
 import siteLogo from '../../../assets/images/users/siteLogo.png';
@@ -22,7 +23,8 @@ const classes = {
     button: `${PREFIX}-button`,
     divider: `${PREFIX}-divider`,
     unhealthy: `${PREFIX}-unhealthy`,
-    warningIcon: `${PREFIX}-warningIcon`
+    warningIcon: `${PREFIX}-warningIcon`,
+    excludedIcon: `${PREFIX}-excludedIcon`
 };
 
 const StyledBox = styled(Box)(({ theme }) => ({
@@ -68,28 +70,42 @@ const StyledBox = styled(Box)(({ theme }) => ({
         marginLeft: '0.25em',
         fontSize: '1.25em',
         verticalAlign: 'text-bottom'
+    },
+    [`& .${classes.excludedIcon}`]: {
+        color: theme.palette.primary.main,
+        marginLeft: '0.25em',
+        fontSize: '1.25em',
+        verticalAlign: 'text-bottom'
     }
 }));
 
 function PatientCountSingle(props) {
-    const { site, counts } = props;
+    const { site, counts, excluded } = props;
     const theme = useTheme();
 
     const [expanded, setExpanded] = useState(false);
 
+    // Three states: healthy, excluded (user deselected the node in the sidebar), or
+    // offline (node returned no data). Excluded takes precedence, since an excluded
+    // node also returns no counts and would otherwise be misread as a connection error.
     const nodeStatus = useMemo(() => {
-        const map = {};
-        const isHealthy = Object.keys(counts.totals).length > 0 && Object.keys(counts.counts).length > 0;
-        if (!isHealthy) {
-            map[counts.location] = {
+        if (excluded) {
+            return {
                 healthy: false,
+                excluded: true,
+                reason: 'Excluded from your search — re-select this node in the sidebar to include it'
+            };
+        }
+        const hasData = Object.keys(counts.totals).length > 0 && Object.keys(counts.counts).length > 0;
+        if (!hasData) {
+            return {
+                healthy: false,
+                excluded: false,
                 reason: 'Connection Error: No data returned from node'
             };
-        } else {
-            map[counts.location] = { healthy: true };
         }
-        return map;
-    }, [counts]);
+        return { healthy: true, excluded: false };
+    }, [counts, excluded]);
 
     const SumCensoredTotals = (countsArray) =>
         countsArray.reduce(
@@ -121,11 +137,15 @@ function PatientCountSingle(props) {
                     <CardHeader
                         avatar={<Avatar src={SITE === site ? siteLogo : ''}>{SITE === site ? '' : site.slice(0, 1).toUpperCase()}</Avatar>}
                         title={
-                            <Typography component="span" className={!nodeStatus[site].healthy ? classes.unhealthy : ''}>
+                            <Typography component="span" className={!nodeStatus.healthy ? classes.unhealthy : ''}>
                                 <b>{site}</b>
-                                {!nodeStatus[site].healthy && (
-                                    <Tooltip title={nodeStatus[site].reason || 'Node connection issue'} placement="right">
-                                        <WarningAmberOutlinedIcon className={classes.warningIcon} />
+                                {!nodeStatus.healthy && (
+                                    <Tooltip title={nodeStatus.reason || 'Node connection issue'} placement="right">
+                                        {nodeStatus.excluded ? (
+                                            <FilterAltOffOutlinedIcon className={classes.excludedIcon} />
+                                        ) : (
+                                            <WarningAmberOutlinedIcon className={classes.warningIcon} />
+                                        )}
                                     </Tooltip>
                                 )}
                             </Typography>
@@ -237,7 +257,8 @@ function PatientCountSingle(props) {
 
 PatientCountSingle.propTypes = {
     site: PropTypes.string,
-    counts: PropTypes.object
+    counts: PropTypes.object,
+    excluded: PropTypes.bool
 };
 
 export default PatientCountSingle;

--- a/src/views/clinicalGenomic/widgets/patientCounts.jsx
+++ b/src/views/clinicalGenomic/widgets/patientCounts.jsx
@@ -29,6 +29,10 @@ function PatientCounts() {
     const programs = context?.programs;
     const discoveryCounts = context?.counts?.patients_per_program;
     const clinicalCounts = context?.clinical;
+    // Nodes the user deselected in the sidebar for the current search. Use the same
+    // `.includes` test SearchHandler uses so the two stay consistent (e.g. the
+    // post-reset nested-array shape resolves to "nothing excluded" here too).
+    const excludedNodes = context?.excludedNodes;
 
     // Generate the map of site->program->numbers
     let siteData = [];
@@ -92,7 +96,11 @@ function PatientCounts() {
             {/* Individual counts */}
             {siteData?.map((site) => (
                 <React.Fragment key={site.location}>
-                    <PatientCountSingle site={site.location} counts={site} />
+                    <PatientCountSingle
+                        site={site.location}
+                        counts={site}
+                        excluded={Array.isArray(excludedNodes) && excludedNodes.includes(site.location)}
+                    />
                     <Box className={`${PREFIX}-spacing`} />
                 </React.Fragment>
             ))}

--- a/src/views/clinicalGenomic/widgets/sidebar.jsx
+++ b/src/views/clinicalGenomic/widgets/sidebar.jsx
@@ -277,6 +277,26 @@ function StyledCheckboxList(props) {
     };
 
     const checkedList = Array.isArray(checked) ? checked : Object.keys(checked || {});
+
+    // Move disabled options (unhealthy nodes, or programs whose node has been
+    // deselected) to the bottom of the list while preserving the relative order of
+    // everything else. Array.prototype.sort is stable, so equal-priority items keep
+    // their original order.
+    const orderedOptions = Array.isArray(options)
+        ? [...options].sort((a, b) => {
+              const aDisabled = optionStatusMap?.[a]?.healthy === false ? 1 : 0;
+              const bDisabled = optionStatusMap?.[b]?.healthy === false ? 1 : 0;
+              return aDisabled - bDisabled;
+          })
+        : options;
+
+    // Disabled options that the user hasn't explicitly excluded — i.e. offline nodes.
+    // They are shown as deselected (unchecked) rather than selected-but-disabled, so
+    // they must also be left out of the "N of M selected" tally.
+    const disabledUnselected = (Array.isArray(options) ? options : []).filter(
+        (o) => optionStatusMap?.[o]?.healthy === false && !checkedList.includes(o)
+    ).length;
+
     let label = groupName;
     let renderTags = (tagValue, getTagProps) =>
         tagValue.map((option, index) => <Chip {...getTagProps({ index })} key={option} label={option} />);
@@ -287,10 +307,10 @@ function StyledCheckboxList(props) {
     // `options.length - checkedList.length` is the count still selected.
     let summaryText = null;
     if (groupName === 'exclude_programs') {
-        summaryText = `${options.length - checkedList.length} of ${options.length} programs selected`;
+        summaryText = `${options.length - checkedList.length - disabledUnselected} of ${options.length} programs selected`;
         label = 'Programs';
     } else if (groupName === 'node') {
-        summaryText = `${options.length - checkedList.length} of ${options.length} nodes selected`;
+        summaryText = `${options.length - checkedList.length - disabledUnselected} of ${options.length} nodes selected`;
         label = 'Nodes';
     }
     if (summaryText) {
@@ -308,62 +328,74 @@ function StyledCheckboxList(props) {
                 size="small"
                 multiple
                 id={`checkboxes-tags-${groupName}`}
-            options={options}
+            options={orderedOptions}
             disableCloseOnSelect
             renderOption={(props, option, { selected }) => {
                 const status = optionStatusMap?.[option];
                 const isHealthy = status?.healthy !== false;
 
-                return (
-                    <li {...props} key={option}>
-                        <div
+                const rowContent = (
+                    <div
+                        style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            width: '100%'
+                        }}
+                    >
+                        <Checkbox
+                            icon={icon}
+                            checkedIcon={checkedIcon}
+                            sx={{
+                                paddingTop: 0,
+                                paddingBottom: 0,
+                                marginRight: 1
+                            }}
+                            checked={isHealthy ? (isExclusion ? !selected : selected) : false}
+                            value={option}
+                            disabled={!isHealthy}
+                        />
+                        <span
                             style={{
-                                display: 'flex',
+                                display: 'inline-flex',
                                 alignItems: 'center',
-                                width: '100%'
+                                gap: '4px',
+                                lineHeight: 1.2
                             }}
                         >
-                            <Checkbox
-                                icon={icon}
-                                checkedIcon={checkedIcon}
-                                sx={{
-                                    paddingTop: 0,
-                                    paddingBottom: 0,
-                                    marginRight: 1
-                                }}
-                                checked={isExclusion ? !selected : selected}
-                                value={option}
-                                disabled={!isHealthy}
-                            />
-                            <span
-                                style={{
-                                    display: 'inline-flex',
-                                    alignItems: 'baseline',
-                                    gap: '4px',
-                                    lineHeight: 1.2
-                                }}
-                            >
-                                {option}
-                                {groupName === 'exclude_programs' && authorizedPrograms && !authorizedPrograms.includes(option) && (
-                                    <Tooltip title="Unauthorized Program" placement="right">
-                                        <LockOutlinedIcon
-                                            sx={{
-                                                color: 'primary.main',
-                                                fontSize: '1.1rem',
-                                                verticalAlign: 'text-bottom',
-                                                position: 'relative',
-                                                top: '3px'
-                                            }}
-                                        />
-                                    </Tooltip>
-                                )}
-                                {!isHealthy && (
-                                    <Tooltip title={status?.reason || 'Node connection issue'} placement="right">
-                                        <WarningAmberOutlinedIcon className={classes.warningIcon} />
-                                    </Tooltip>
-                                )}
-                            </span>
-                        </div>
+                            {option}
+                            {groupName === 'exclude_programs' && authorizedPrograms && !authorizedPrograms.includes(option) && (
+                                <Tooltip title="Unauthorized Program" placement="right">
+                                    <LockOutlinedIcon
+                                        sx={{
+                                            color: 'primary.main',
+                                            fontSize: '1.1rem',
+                                            verticalAlign: 'text-bottom',
+                                            position: 'relative',
+                                            top: '3px'
+                                        }}
+                                    />
+                                </Tooltip>
+                            )}
+                            {!isHealthy && groupName !== 'exclude_programs' && (
+                                <WarningAmberOutlinedIcon className={classes.warningIcon} />
+                            )}
+                        </span>
+                    </div>
+                );
+
+                // MUI sets `pointer-events: none` on disabled options, which would
+                // suppress the tooltip on hover — override it here so the reason is
+                // discoverable. Selection is still blocked by getOptionDisabled and
+                // the onChange safe-value filter below.
+                return (
+                    <li {...props} key={option} style={{ ...props.style, ...(isHealthy ? {} : { pointerEvents: 'auto' }) }}>
+                        {!isHealthy && status?.reason ? (
+                            <Tooltip title={status.reason} placement="right">
+                                {rowContent}
+                            </Tooltip>
+                        ) : (
+                            rowContent
+                        )}
                     </li>
                 );
             }}
@@ -371,7 +403,13 @@ function StyledCheckboxList(props) {
             // set width to match parent
             sx={{ width: '100%', paddingTop: '0.5em', paddingBottom: '0.5em' }}
             onChange={(_, value, reason) => {
-                const safeValue = value.filter((v) => optionStatusMap?.[v]?.healthy !== false);
+                // Disabled options (unhealthy nodes / programs on a deselected node) are
+                // immutable: the user can't toggle them. Take the user's healthy picks,
+                // then re-add any disabled option that was already in the current value so
+                // it keeps its state rather than being silently dropped by this change.
+                const userSelectable = value.filter((v) => optionStatusMap?.[v]?.healthy !== false);
+                const disabledUnchanged = checkedList.filter((v) => optionStatusMap?.[v]?.healthy === false);
+                const safeValue = Array.from(new Set([...userSelectable, ...disabledUnchanged]));
                 HandleChange(safeValue, reason === 'selectOption');
             }}
             renderInput={(params) => <TextField {...params} label={label} />}
@@ -380,14 +418,15 @@ function StyledCheckboxList(props) {
             />
         </>
     ) : (
-        options?.map((option) => {
+        orderedOptions?.map((option) => {
             const status = optionStatusMap?.[option];
             const isHealthy = status?.healthy !== false;
 
-            return (
+            const control = (
                 <FormControlLabel
                     key={option}
                     className={classes.checkboxLabel}
+                    sx={isHealthy ? {} : { opacity: 0.38 }}
                     label={
                         <div className={classes.lockContainer}>
                             {option}
@@ -404,17 +443,15 @@ function StyledCheckboxList(props) {
                                     />
                                 </Tooltip>
                             )}
-                            {!isHealthy && (
-                                <Tooltip title={status?.reason || 'Node connection issue'} placement="right">
-                                    <WarningAmberOutlinedIcon className={classes.warningIcon} />
-                                </Tooltip>
+                            {!isHealthy && groupName !== 'exclude_programs' && (
+                                <WarningAmberOutlinedIcon className={classes.warningIcon} />
                             )}
                         </div>
                     }
                     control={
                         <Checkbox
                             className={classes.checkbox}
-                            checked={isExclusion ? !(option in checked) : option in checked}
+                            checked={isHealthy ? (isExclusion ? !(option in checked) : option in checked) : false}
                             disabled={!isHealthy}
                             onChange={(event) => {
                                 const newList = Object.keys(checked).slice();
@@ -433,6 +470,14 @@ function StyledCheckboxList(props) {
                         />
                     }
                 />
+            );
+
+            return !isHealthy && status?.reason ? (
+                <Tooltip key={option} title={status.reason} placement="right">
+                    <span>{control}</span>
+                </Tooltip>
+            ) : (
+                control
             );
         })
     );
@@ -673,6 +718,29 @@ function Sidebar() {
         return map;
     })();
 
+    // Programs whose node has been deselected are excluded from the search by the
+    // Nodes filter, which takes precedence at the backend. Rather than letting a user
+    // individually re-select such a program — which silently has no effect — grey it
+    // out, move it to the bottom of the Programs dropdown, and explain via tooltip
+    // that the node must be re-selected. `selectedNodes` holds the set of *deselected*
+    // (excluded) node names.
+    const programStatusMap = (() => {
+        const map = {};
+        readerContext?.federation?.forEach((site) => {
+            const nodeName = site?.location?.name;
+            if (!nodeName || !(nodeName in selectedNodes)) return;
+            (site.results || []).forEach((program) => {
+                if (program?.program_id) {
+                    map[program.program_id] = {
+                        healthy: false,
+                        reason: `Re-select the "${nodeName}" node to search this program`
+                    };
+                }
+            });
+        });
+        return map;
+    })();
+
     // On our first load, remove all query parameters
     useEffect(() => {
         writerContext(() => ({ reqNum: 0 }));
@@ -884,6 +952,7 @@ function Sidebar() {
                         isExclusion
                         checked={selectedPrograms}
                         setChecked={setSelectedPrograms}
+                        optionStatusMap={programStatusMap}
                     />
                     <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
                         <Button className={classes.button} onClick={() => setPrograms(programs)}>


### PR DESCRIPTION
## Summary

Reworks how deselected nodes and their programs are presented in the clinical & genomic search sidebar, and how node status is reported in the results table at the top of the page.

## Sidebar (`sidebar.jsx`)

- **Deselected-node programs are no longer silently overridden.** Previously, deselecting a node cascaded to deselecting its programs, but the node filter takes precedence at the backend — so re-checking an individual program had no effect. Those programs are now **greyed out, sorted to the bottom** of the Programs dropdown, and given a **hover tooltip** explaining the node must be re-selected.
- **Disabled options are immutable** — the Autocomplete `onChange` preserves their state instead of dropping them when the user toggles other options.
- **Offline nodes now display as deselected (unchecked)** rather than selected-but-disabled, and are left out of the "N of M selected" tally. They stay disabled and sorted to the bottom.
- Removed the warning icon from greyed program options (kept for nodes), and vertically centred node option rows with their status icon.

## Results table (`patientCounts.jsx`, `patientCountSingle.jsx`, `SearchHandler.jsx`)

- Distinguishes a **user-excluded** node from a genuinely **offline** one — both otherwise return no counts and were previously both labelled "Connection Error":
  - **Offline** → amber ⚠️ warning + "Connection Error: No data returned from node"
  - **User-excluded** → filter-off icon + "Excluded from your search — re-select this node in the sidebar to include it"
- `SearchHandler` records the excluded-node list in the results context so the table can tell the two cases apart.

## Testing

- Verified locally against the mock server (multi-node + offline node).
- `eslint` clean on all four changed files (only pre-existing unrelated warnings remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1591" height="819" alt="Screenshot 2026-07-22 at 2 40 48 PM" src="https://github.com/user-attachments/assets/58c6c27f-af68-4555-9ae5-9a7bbdce1366" />
<img width="1581" height="1006" alt="Screenshot 2026-07-22 at 2 40 36 PM" src="https://github.com/user-attachments/assets/8dd1f7e8-a8d7-4571-93ff-acfccaa06db8" />
