### PR TITLE
Fix reset excluding the sole node on single-node deployments

### DIFF
--- a/src/views/clinicalGenomic/widgets/sidebar.jsx
+++ b/src/views/clinicalGenomic/widgets/sidebar.jsx
@@ -754,7 +754,9 @@ function Sidebar() {
                 ...old,
                 filter: {
                     ...old.filter,
-                    node: [readerContext?.programs?.map((loc) => loc.location.name) || []]
+                    // Empty exclusion list = include all nodes. Avoids the nested-array
+                    // sentinel that excluded the sole node on single-node deployments.
+                    node: []
                 },
                 reqNum: old.reqNum + 1
             }));
@@ -846,17 +848,21 @@ function Sidebar() {
         setSelectedPrimarySite({});
         setSelectedSystemicTherapy({});
 
-        // Set context writer to include only nodes and programs
-        writerContext({
-            // Set nodes and programs in the filter
+        // Clear every filter and re-run the search. Use an empty node exclusion list
+        // (exclude nothing) rather than the previous nested-array sentinel: SearchHandler
+        // builds exclude_servers via filter.node.join('|'), and on a single-node
+        // deployment the nested shape joined to that node's own name and excluded it,
+        // making the node look like a connection error until a page refresh. Merge onto
+        // the existing query state and bump reqNum so the re-query fires reliably.
+        writerContext((old) => ({
+            ...old,
             filter: {
-                node: [readerContext?.programs?.map((loc) => loc.location.name) || []],
-                exclude_programs: [
-                    readerContext?.programs?.map((loc) => loc?.results?.items?.map((program) => program.program_id)).flat(1) || []
-                ],
-                query: {}
-            }
-        });
+                ...old.filter,
+                node: []
+            },
+            query: {},
+            reqNum: 'reqNum' in old ? old.reqNum + 1 : 0
+        }));
     }
 
     // Set programs to the given list


### PR DESCRIPTION
## Problem
After running a search, clicking **Reset** left the portal believing its own node had a connection error ("Connection Error: No data returned from node"). Only a full page refresh recovered. This reproduced reliably on single-node deployments (e.g. a local stack).

## Root cause
`resetButton()` and the `clear === 'nodes'` handler set the node filter to a nested-array sentinel `[[...nodeNames]]`, intended to mean "exclude nothing". The client-side checks treat it that way (`Array.includes` never matches the inner array), but `SearchHandler` builds the backend param as:

```js
fullQuery.exclude_servers = reader.filter.node.join('|');
```

`Array.join` stringifies each element:
- **Multi-node:** `[["a","b"]].join('|')` → `"a,b"` → matches no server → excludes nothing (works by accident).
- **Single-node:** `[["local"]].join('|')` → `"local"` → matches the only node → **excludes it from the search.**

The re-query then returned no counts for the node, while `federation` (fetched once at mount) still held its totals, so `patientCountSingle` computed `hasData = totals>0 && counts>0` = false → rendered as a connection error. A refresh wiped the query context (clearing `filter.node`) and re-ran the mount fetch, which is why only refresh helped; subsequent searches merged the poisoned `filter.node` forward.

## Fix
- Use an empty exclusion list `node: []` (exclude nothing) instead of the nested-array sentinel, in both `resetButton` and the `clear === 'nodes'` handler.
- In `resetButton`, merge onto the existing query state and bump `reqNum` (instead of replacing the whole context and dropping `reqNum`), and clear the top-level `query` properly.

Multi-node behaviour is unchanged (`[]` is correct there too).

## Testing
Confirmed on a local single-node stack: search → reset now leaves the node healthy with counts, no refresh needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)