### PR TITLE
Recolour stacked program-by-node chart for scale and legibility

### DIFF
--- a/src/views/summary/CustomOfflineChart.jsx
+++ b/src/views/summary/CustomOfflineChart.jsx
@@ -28,12 +28,6 @@ export const VALID_CHART_TYPES = ['bar', 'line', 'column', 'scatter', 'pie'];
 // Defined here in order to prevent a circular dependancy
 export const VISUALIZATION_LOCAL_STORAGE_KEY = 'chartDefinitions';
 
-// Helper: find the index of the first non-zero value in an array, modded by the max number of colours we have (to prevent out of bounds errors)
-function findSiteIndexMod(value, max) {
-    const siteIndex = Math.max(0, value.findIndex((v) => v!== 0));
-    return siteIndex % max;
-}
-
 // Helper: convert hex to HSL
 function hexToHSL(hex) {
     const bigint = parseInt(hex.replace('#', ''), 16);
@@ -281,45 +275,48 @@ function CustomOfflineChart({
                     theme.palette.primary.main,
                     theme.palette.secondary.main,
                     theme.palette.tertiary.main,
-                    theme.palette.teal.main,
+                    // Muted amber, not theme.palette.teal.main: the chart renders each hue at
+                    // its own forced lightness (0.4-0.7), and teal's cyan hue turns neon at the
+                    // lighter shades and clashed with the rest of the set. This warm amber fills
+                    // the gap between the yellow and red hues and stays muted across all shades.
+                    // Hardcoded because the palette has no amber token (tertiary is yellow,
+                    // burntOrange is too red).
+                    '#E08A3C',
                     theme.palette.plum.main,
                     theme.palette.coral.main,
-                    theme.palette.burntOrange.main,
-                    theme.palette.sage.main
+                    // sage sits between coral and burntOrange on purpose: the two are both
+                    // warm reds and were hard to tell apart when adjacent. Keeping a green
+                    // between them separates them in the node order.
+                    theme.palette.sage.main,
+                    theme.palette.burntOrange.main
                 ];
                 const stackedTheme = grayscale ? grayscaleTheme : colouredTheme;
-                const maxes = new Array(bars).fill(0);
-                const mins = new Array(bars).fill(Infinity);
 
-                // Site based max and min
-                data?.forEach((value) => {
-                    value.forEach((v, i) => {
-                        maxes[i] = Math.max(maxes[i], v);
-                        mins[i] = Math.min(mins[i], v === 0 ? mins[i] : v);
-                    });
-                });
+                // Colour model: each node (x-axis category / bar) gets its own distinct hue
+                // from the theme. Within a bar we do NOT try to give every program a unique
+                // shade — nodes can stack up to ~65 programs, and that many lightness steps of
+                // one hue are impossible to tell apart. Instead we cycle through a small,
+                // fixed set of shades (dark / mid / light) of the node hue by stack position,
+                // so the boundary between adjacent segments always contrasts and segments stay
+                // countable no matter how many there are. Colour delineates segments; program
+                // identity comes from the tooltip, not the shade.
+                const SHADE_LIGHTNESS = [0.4, 0.55, 0.7];
 
+                let stackPos = 0;
                 data?.forEach((value, key) => {
-                    const baseIndex = findSiteIndexMod(value, stackedTheme.length);
-                    // Colour conversion and manipulation
-                    const baseHex = stackedTheme[baseIndex];
-                    const baseHSL = hexToHSL(baseHex);
+                    const l = SHADE_LIGHTNESS[stackPos % SHADE_LIGHTNESS.length];
+                    stackPos += 1;
 
                     const points = value.map((y, i) => {
-                        let ratio = maxes[i] === mins[i] ? 0.5 : (y - mins[i]) / (maxes[i] - mins[i]);
-
-                        let [h, s, l] = baseHSL;
-
-                        // Hue shift ±5° but scaled up for small value differences
-                        h = (h + (ratio - 0.5) * (20 / 360) + 1) % 1; 
-
-                        // Lightness shift ±30% for small differences
-                        l = Math.min(1, Math.max(0, l - 0.15 + ratio * 0.3));
-
-                        // Saturation shift ±10% for small differences
-                        s = Math.min(1, Math.max(0, s - 0.05 + ratio * 0.1));
-
-                        return { y, color: hslToCss([h, s, l]) };
+                        // Hue is taken from the node (category index), so every bar is a
+                        // different colour; lightness cycles so adjacent programs contrast.
+                        const [h, s] = hexToHSL(stackedTheme[i % stackedTheme.length]);
+                        // Every program is a series spanning all bars, so a program absent
+                        // from this node arrives as y=0. Render those as null (not 0): with
+                        // minPointLength set, a 0-value point would still be drawn at the
+                        // forced minimum height, stacking a "cap" of foreign 0-count programs
+                        // on top of every bar. null points are omitted entirely.
+                        return { y: y === 0 ? null : y, color: hslToCss([h, s, l]) };
                     });
 
                     stackSeries.push({ name: key, data: points });
@@ -343,7 +340,17 @@ function CustomOfflineChart({
                     yAxis: { title: { text: DataVisualizationChartInfo[chartData].yAxis }, allowDecimals: false },
                     plotOptions: {
                         series: {
-                            stacking: 'normal'
+                            stacking: 'normal',
+                            // Drop the 1px white segment border: on a bar of hundreds of
+                            // donors it visually erases small programs (2-5 donors), which end
+                            // up thinner than the border and read as an empty gap. Adjacent
+                            // segments already contrast by lightness shade, so no divider needed.
+                            borderWidth: 0,
+                            // Guarantee every non-zero program a few pixels of height so tiny
+                            // programs stay visible instead of collapsing to nothing. This
+                            // slightly over-represents them relative to their true share — an
+                            // acceptable trade for "present and clickable" over "invisible".
+                            minPointLength: 3
                         }
                     },
                     legend: { enabled: false },


### PR DESCRIPTION
## What & why

The stacked **Distribution of Programs by Node** chart didn't hold up at realistic scale (nodes with up to ~65 programs, program sizes from a few to a few hundred donors). It picked each program's base colour from the index of the first node it had data in, then shaded each segment by its value relative to other programs at that node — so on a single-node deployment every program collapsed to the same hue, and equal counts produced identical shades. Small programs also disappeared into the segment borders.

<img width="568" height="459" alt="Screenshot 2026-07-29 at 3 01 50 PM" src="https://github.com/user-attachments/assets/417d5180-b32a-4c3c-a088-1117c5561edd" />


## Changes (all in `CustomOfflineChart.jsx`)

- **Per-node hue, cycled shades.** Each node (bar) gets its own hue from the theme; programs stacked within a bar cycle through a small fixed set of lightness shades (`0.4 / 0.55 / 0.7`) so adjacent segments always contrast and stay countable no matter how many stack up. Program identity comes from the tooltip, not the shade.
- **Amber instead of neon teal.** The chart renders each hue at a forced lightness, where teal's cyan went neon and clashed; swapped for a muted amber that sits with the rest of the set.
- **Palette reorder.** Coral and burntOrange (two similar warm reds) are no longer adjacent in the node order — sage sits between them.
- **Small programs stay visible.** `borderWidth: 0` (the 1px white border was erasing 2–5 donor segments) + `minPointLength: 3` (guarantees a few px per non-zero program). Trade-off: tiny programs are slightly over-represented vs their true share — acceptable for "present and clickable" over "invisible", and the tooltip always shows the exact count.
- **No more zero-count "cap".** Absent-program points (`y=0`) render as `null` so `minPointLength` doesn't stack a cap of foreign zero-count programs on top of every bar.

Also removes the now-dead `findSiteIndexMod` helper and the per-bar max/min computation the old approach used.

## Testing

Reviewed locally against the `candig-mock-server` (seeded to ~155 programs across 6 nodes, program sizes 3–222) — the companion mock changes to exercise this are on `candig-mock-server` `main`. Verified: single-node no longer collapses to one colour, 65-program bars stay legible, small programs are visible, and the zero-cap artifact is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)